### PR TITLE
Rename some factory methods

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsMaybe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsMaybe.kt
@@ -2,10 +2,10 @@ package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.maybe.Maybe
-import com.badoo.reaktive.maybe.maybe
+import com.badoo.reaktive.maybe.maybeUnsafe
 
 fun <T> Completable.asMaybe(): Maybe<T> =
-    maybe { observer ->
+    maybeUnsafe { observer ->
         subscribeSafe(
             object : CompletableObserver, Observer by observer, CompletableCallbacks by observer {
             }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsObservable.kt
@@ -2,10 +2,10 @@ package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.observable.Observable
-import com.badoo.reaktive.observable.observable
+import com.badoo.reaktive.observable.observableUnsafe
 
 fun <T> Completable.asObservable(): Observable<T> =
-    observable { observer ->
+    observableUnsafe { observer ->
         subscribeSafe(
             object : CompletableObserver, Observer by observer, CompletableCallbacks by observer {
             }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsSingle.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsSingle.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.single.Single
 import com.badoo.reaktive.single.SingleObserver
-import com.badoo.reaktive.single.single
+import com.badoo.reaktive.single.singleUnsafe
 
 fun <T> Completable.asSingle(defaultValue: T): Single<T> =
     asSingleOrAction { observer ->
@@ -23,7 +23,7 @@ fun <T> Completable.asSingle(defaultValueSupplier: () -> T): Single<T> =
     }
 
 private inline fun <T> Completable.asSingleOrAction(crossinline onComplete: (observer: SingleObserver<T>) -> Unit): Single<T> =
-    single { observer ->
+    singleUnsafe { observer ->
         subscribeSafe(
             object : CompletableObserver, Observer by observer, ErrorCallback by observer {
                 override fun onComplete() {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/CompletableByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/CompletableByEmitter.kt
@@ -3,8 +3,8 @@ package com.badoo.reaktive.completable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 
-inline fun completableByEmitter(crossinline onSubscribe: (emitter: CompletableEmitter) -> Unit): Completable =
-    completable { observer ->
+fun completable(onSubscribe: (emitter: CompletableEmitter) -> Unit): Completable =
+    completableUnsafe { observer ->
         val disposableWrapper = DisposableWrapper()
         observer.onSubscribe(disposableWrapper)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Concat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Concat.kt
@@ -4,14 +4,14 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 
 fun Iterable<Completable>.concat(): Completable =
-    completable { observer ->
+    completableUnsafe { observer ->
         val disposableWrapper = DisposableWrapper()
         observer.onSubscribe(disposableWrapper)
 
         val iterator = iterator()
         if (!iterator.hasNext()) {
             observer.onComplete()
-            return@completable
+            return@completableUnsafe
         }
 
         val upstreamObserver =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/DoOnBefore.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.utils.lock.newLock
 import com.badoo.reaktive.utils.lock.synchronized
 
 fun Completable.doOnBeforeSubscribe(action: (Disposable) -> Unit): Completable =
-    completable { observer ->
+    completableUnsafe { observer ->
         subscribeSafe(
             object : CompletableObserver by observer {
                 override fun onSubscribe(disposable: Disposable) {
@@ -18,7 +18,7 @@ fun Completable.doOnBeforeSubscribe(action: (Disposable) -> Unit): Completable =
     }
 
 fun Completable.doOnBeforeComplete(action: () -> Unit): Completable =
-    completable { observer ->
+    completableUnsafe { observer ->
         subscribeSafe(
             object : CompletableObserver by observer {
                 override fun onComplete() {
@@ -30,7 +30,7 @@ fun Completable.doOnBeforeComplete(action: () -> Unit): Completable =
     }
 
 fun Completable.doOnBeforeError(consumer: (Throwable) -> Unit): Completable =
-    completable { observer ->
+    completableUnsafe { observer ->
         subscribeSafe(
             object : CompletableObserver by observer {
                 override fun onError(error: Throwable) {
@@ -42,7 +42,7 @@ fun Completable.doOnBeforeError(consumer: (Throwable) -> Unit): Completable =
     }
 
 fun Completable.doOnBeforeTerminate(action: () -> Unit): Completable =
-    completable { observer ->
+    completableUnsafe { observer ->
         subscribeSafe(
             object : CompletableObserver by observer {
                 override fun onComplete() {
@@ -59,7 +59,7 @@ fun Completable.doOnBeforeTerminate(action: () -> Unit): Completable =
     }
 
 fun Completable.doOnBeforeDispose(action: () -> Unit): Completable =
-    completable { observer ->
+    completableUnsafe { observer ->
         subscribeSafe(
             object : CompletableObserver by observer {
                 override fun onSubscribe(disposable: Disposable) {
@@ -70,7 +70,7 @@ fun Completable.doOnBeforeDispose(action: () -> Unit): Completable =
     }
 
 fun Completable.doOnBeforeFinally(action: () -> Unit): Completable =
-    completable { observer ->
+    completableUnsafe { observer ->
         subscribeSafe(
             object : CompletableObserver by observer {
                 private val lock = newLock()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/ObserveOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/ObserveOn.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
 
 fun Completable.observeOn(scheduler: Scheduler): Completable =
-    completableByEmitter { emitter ->
+    completable { emitter ->
         val disposables = CompositeDisposable()
         emitter.setDisposable(disposables)
         val executor = scheduler.newExecutor()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/SubscribeOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/SubscribeOn.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
 
 fun Completable.subscribeOn(scheduler: Scheduler): Completable =
-    completable { observer ->
+    completableUnsafe { observer ->
         val disposables = CompositeDisposable()
         observer.onSubscribe(disposables)
         val executor = scheduler.newExecutor()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Vairous.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Vairous.kt
@@ -1,23 +1,23 @@
 package com.badoo.reaktive.completable
 
-inline fun completable(crossinline onSubscribe: (observer: CompletableObserver) -> Unit): Completable =
+inline fun completableUnsafe(crossinline onSubscribe: (observer: CompletableObserver) -> Unit): Completable =
     object : Completable {
         override fun subscribe(observer: CompletableObserver) {
             onSubscribe(observer)
         }
     }
 
-fun errorCompletable(e: Throwable): Completable =
-    completableByEmitter { emitter ->
-        emitter.onError(e)
+fun completableOfError(error: Throwable): Completable =
+    completable { emitter ->
+        emitter.onError(error)
     }
 
-fun Throwable.toErrorCompletable(): Completable = errorCompletable(this)
+fun Throwable.toCompletableOfError(): Completable = completableOfError(this)
 
-fun emptyCompletable(): Completable = completableByEmitter(CompletableEmitter::onComplete)
+fun completableOfEmpty(): Completable = completable(CompletableEmitter::onComplete)
 
 fun completableFromFunction(func: () -> Unit): Completable =
-    completableByEmitter { emitter ->
+    completable { emitter ->
         func()
         emitter.onComplete()
     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsCompletable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsCompletable.kt
@@ -3,10 +3,10 @@ package com.badoo.reaktive.maybe
 import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.completable.CompletableCallbacks
-import com.badoo.reaktive.completable.completable
+import com.badoo.reaktive.completable.completableUnsafe
 
 fun Maybe<*>.asCompletable(): Completable =
-    completable { observer ->
+    completableUnsafe { observer ->
         subscribeSafe(
             object : MaybeObserver<Any?>, Observer by observer, CompletableCallbacks by observer {
                 override fun onSuccess(value: Any?) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsObservable.kt
@@ -3,10 +3,10 @@ package com.badoo.reaktive.maybe
 import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.observable.Observable
-import com.badoo.reaktive.observable.observable
+import com.badoo.reaktive.observable.observableUnsafe
 
 fun <T> Maybe<T>.asObservable(): Observable<T> =
-    observable { observer ->
+    observableUnsafe { observer ->
         subscribeSafe(
             object : MaybeObserver<T>, Observer by observer, CompletableCallbacks by observer {
                 override fun onSuccess(value: T) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsSingle.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsSingle.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.single.Single
 import com.badoo.reaktive.single.SingleCallbacks
 import com.badoo.reaktive.single.SingleObserver
-import com.badoo.reaktive.single.single
+import com.badoo.reaktive.single.singleUnsafe
 
 fun <T> Maybe<T>.asSingle(defaultValue: T): Single<T> =
     asSingleOrAction { observer ->
@@ -23,7 +23,7 @@ fun <T> Maybe<T>.asSingle(defaultValueSupplier: () -> T): Single<T> =
     }
 
 internal inline fun <T> Maybe<T>.asSingleOrAction(crossinline onComplete: (observer: SingleObserver<T>) -> Unit): Single<T> =
-    single { observer ->
+    singleUnsafe { observer ->
         subscribeSafe(
             object : MaybeObserver<T>, Observer by observer, SingleCallbacks<T> by observer {
                 override fun onComplete() {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DoOnBefore.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.utils.lock.newLock
 import com.badoo.reaktive.utils.lock.synchronized
 
 fun <T> Maybe<T>.doOnBeforeSubscribe(action: (Disposable) -> Unit): Maybe<T> =
-    maybe { observer ->
+    maybeUnsafe { observer ->
         subscribeSafe(
             object : MaybeObserver<T> by observer {
                 override fun onSubscribe(disposable: Disposable) {
@@ -18,7 +18,7 @@ fun <T> Maybe<T>.doOnBeforeSubscribe(action: (Disposable) -> Unit): Maybe<T> =
     }
 
 fun <T> Maybe<T>.doOnBeforeSuccess(consumer: (T) -> Unit): Maybe<T> =
-    maybe { observer ->
+    maybeUnsafe { observer ->
         subscribeSafe(
             object : MaybeObserver<T> by observer {
                 override fun onSuccess(value: T) {
@@ -30,7 +30,7 @@ fun <T> Maybe<T>.doOnBeforeSuccess(consumer: (T) -> Unit): Maybe<T> =
     }
 
 fun <T> Maybe<T>.doOnBeforeComplete(action: () -> Unit): Maybe<T> =
-    maybe { observer ->
+    maybeUnsafe { observer ->
         subscribeSafe(
             object : MaybeObserver<T> by observer {
                 override fun onComplete() {
@@ -42,7 +42,7 @@ fun <T> Maybe<T>.doOnBeforeComplete(action: () -> Unit): Maybe<T> =
     }
 
 fun <T> Maybe<T>.doOnBeforeError(consumer: (Throwable) -> Unit): Maybe<T> =
-    maybe { observer ->
+    maybeUnsafe { observer ->
         subscribeSafe(
             object : MaybeObserver<T> by observer {
                 override fun onError(error: Throwable) {
@@ -54,7 +54,7 @@ fun <T> Maybe<T>.doOnBeforeError(consumer: (Throwable) -> Unit): Maybe<T> =
     }
 
 fun <T> Maybe<T>.doOnBeforeTerminate(action: () -> Unit): Maybe<T> =
-    maybe { observer ->
+    maybeUnsafe { observer ->
         subscribeSafe(
             object : MaybeObserver<T> by observer {
                 override fun onSuccess(value: T) {
@@ -76,7 +76,7 @@ fun <T> Maybe<T>.doOnBeforeTerminate(action: () -> Unit): Maybe<T> =
     }
 
 fun <T> Maybe<T>.doOnBeforeDispose(action: () -> Unit): Maybe<T> =
-    maybe { observer ->
+    maybeUnsafe { observer ->
         subscribeSafe(
             object : MaybeObserver<T> by observer {
                 override fun onSubscribe(disposable: Disposable) {
@@ -87,7 +87,7 @@ fun <T> Maybe<T>.doOnBeforeDispose(action: () -> Unit): Maybe<T> =
     }
 
 fun <T> Maybe<T>.doOnBeforeFinally(action: () -> Unit): Maybe<T> =
-    maybe { observer ->
+    maybeUnsafe { observer ->
         subscribeSafe(
             object : MaybeObserver<T> by observer {
                 private val lock = newLock()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/FlatMap.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/FlatMap.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 
 fun <T, R> Maybe<T>.flatMap(mapper: (T) -> Maybe<R>): Maybe<R> =
-    maybe { observer ->
+    maybeUnsafe { observer ->
         val disposableWrapper = DisposableWrapper()
         observer.onSubscribe(disposableWrapper)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/FlatMapObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/FlatMapObservable.kt
@@ -6,11 +6,11 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.observable.ObservableObserver
-import com.badoo.reaktive.observable.observable
+import com.badoo.reaktive.observable.observableUnsafe
 import com.badoo.reaktive.observable.subscribeSafe
 
 fun <T, R> Maybe<T>.flatMapObservable(mapper: (T) -> Observable<R>): Observable<R> =
-    observable { observer ->
+    observableUnsafe { observer ->
         val disposableWrapper = DisposableWrapper()
         observer.onSubscribe(disposableWrapper)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Flatten.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Flatten.kt
@@ -3,10 +3,10 @@ package com.badoo.reaktive.maybe
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.observable.Observable
-import com.badoo.reaktive.observable.observableByEmitter
+import com.badoo.reaktive.observable.observable
 
 fun <T> Maybe<Iterable<T>>.flatten(): Observable<T> =
-    observableByEmitter { emitter ->
+    observable { emitter ->
         subscribeSafe(
             object : MaybeObserver<Iterable<T>>, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/MaybeByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/MaybeByEmitter.kt
@@ -3,8 +3,8 @@ package com.badoo.reaktive.maybe
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 
-inline fun <T> maybeByEmitter(crossinline onSubscribe: (emitter: MaybeEmitter<T>) -> Unit): Maybe<T> =
-    maybe { observer ->
+fun <T> maybe(onSubscribe: (emitter: MaybeEmitter<T>) -> Unit): Maybe<T> =
+    maybeUnsafe { observer ->
         val disposableWrapper = DisposableWrapper()
         observer.onSubscribe(disposableWrapper)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/ObserveOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/ObserveOn.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
 
 fun <T> Maybe<T>.observeOn(scheduler: Scheduler): Maybe<T> =
-    maybeByEmitter { emitter ->
+    maybe { emitter ->
         val disposables = CompositeDisposable()
         emitter.setDisposable(disposables)
         val executor = scheduler.newExecutor()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/SubscribeOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/SubscribeOn.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
 
 fun <T> Maybe<T>.subscribeOn(scheduler: Scheduler): Maybe<T> =
-    maybe { observer ->
+    maybeUnsafe { observer ->
         val disposables = CompositeDisposable()
         observer.onSubscribe(disposables)
         val executor = scheduler.newExecutor()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Transform.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Transform.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.disposable.Disposable
 internal inline fun <T, R> Maybe<T>.transform(
     crossinline onSuccess: (value: T, onSuccess: (R) -> Unit, onComplete: () -> Unit) -> Unit
 ): Maybe<R> =
-    maybeByEmitter { emitter ->
+    maybe { emitter ->
         subscribeSafe(
             object : MaybeObserver<T> {
                 private val onSuccessFunction = emitter::onSuccess

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Vairous.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Vairous.kt
@@ -1,6 +1,6 @@
 package com.badoo.reaktive.maybe
 
-inline fun <T> maybe(crossinline onSubscribe: (observer: MaybeObserver<T>) -> Unit): Maybe<T> =
+inline fun <T> maybeUnsafe(crossinline onSubscribe: (observer: MaybeObserver<T>) -> Unit): Maybe<T> =
     object : Maybe<T> {
         override fun subscribe(observer: MaybeObserver<T>) {
             onSubscribe(observer)
@@ -8,23 +8,23 @@ inline fun <T> maybe(crossinline onSubscribe: (observer: MaybeObserver<T>) -> Un
     }
 
 fun <T> maybeOf(value: T): Maybe<T> =
-    maybeByEmitter { emitter ->
+    maybe { emitter ->
         emitter.onSuccess(value)
     }
 
 fun <T> T.toMaybe(): Maybe<T> = maybeOf(this)
 
-fun <T> errorMaybe(e: Throwable): Maybe<T> =
-    maybeByEmitter { emitter ->
-        emitter.onError(e)
+fun <T> maybeOfError(error: Throwable): Maybe<T> =
+    maybe { emitter ->
+        emitter.onError(error)
     }
 
-fun <T> Throwable.toErrorMaybe(): Maybe<T> = errorMaybe(this)
+fun <T> Throwable.toMaybeOfError(): Maybe<T> = maybeOfError(this)
 
-fun <T> emptyMaybe(): Maybe<T> =
-    maybeByEmitter(MaybeEmitter<*>::onComplete)
+fun <T> maybeOfEmpty(): Maybe<T> =
+    maybe(MaybeEmitter<*>::onComplete)
 
 fun <T> maybeFromFunction(func: () -> T): Maybe<T> =
-    maybeByEmitter { emitter ->
+    maybe { emitter ->
         emitter.onSuccess(func())
     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/AsCompletable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/AsCompletable.kt
@@ -3,10 +3,10 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.completable.CompletableCallbacks
-import com.badoo.reaktive.completable.completable
+import com.badoo.reaktive.completable.completableUnsafe
 
 fun Observable<*>.asCompletable(): Completable =
-    completable { observer ->
+    completableUnsafe { observer ->
         subscribeSafe(
             object : ObservableObserver<Any?>, Observer by observer, CompletableCallbacks by observer {
                 override fun onNext(value: Any?) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Collect.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Collect.kt
@@ -3,10 +3,10 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.single.Single
-import com.badoo.reaktive.single.single
+import com.badoo.reaktive.single.singleUnsafe
 
 fun <T, C> Observable<T>.collect(collection: C, accumulator: (C, T) -> Unit): Single<C> =
-    single { observer ->
+    singleUnsafe { observer ->
         subscribeSafe(
             object : ObservableObserver<T>, Observer by observer, ErrorCallback by observer {
                 override fun onNext(value: T) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/CombineLatest.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/CombineLatest.kt
@@ -7,7 +7,7 @@ import com.badoo.reaktive.utils.serializer.serializer
 private val dummyValue = Any()
 
 fun <T, R> Collection<Observable<T>>.combineLatest(mapper: (List<T>) -> R): Observable<R> =
-    observableByEmitter { emitter ->
+    observable { emitter ->
         val disposables = CompositeDisposable()
         emitter.setDisposable(disposables)
         val values = MutableList<Any?>(size) { dummyValue }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Concat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Concat.kt
@@ -4,14 +4,14 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 
 fun <T> Iterable<Observable<T>>.concat(): Observable<T> =
-    observable { observer ->
+    observableUnsafe { observer ->
         val disposableWrapper = DisposableWrapper()
         observer.onSubscribe(disposableWrapper)
 
         val iterator = iterator()
         if (!iterator.hasNext()) {
             observer.onComplete()
-            return@observable
+            return@observableUnsafe
         }
 
         val upstreamObserver =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ConcatMap.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ConcatMap.kt
@@ -11,7 +11,7 @@ import com.badoo.reaktive.utils.lock.newLock
 import com.badoo.reaktive.utils.lock.synchronized
 
 fun <T, R> Observable<T>.concatMap(mapper: (T) -> Observable<R>): Observable<R> =
-    observableByEmitter { emitter ->
+    observable { emitter ->
         val disposables = CompositeDisposable()
         emitter.setDisposable(disposables)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Debounce.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Debounce.kt
@@ -7,7 +7,7 @@ import com.badoo.reaktive.utils.lock.newLock
 import com.badoo.reaktive.utils.lock.synchronized
 
 fun <T> Observable<T>.debounce(timeoutMillis: Long, scheduler: Scheduler): Observable<T> =
-    observableByEmitter { emitter ->
+    observable { emitter ->
         val disposableWrapper = CompositeDisposable()
         emitter.setDisposable(disposableWrapper)
         val executor = scheduler.newExecutor()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DoOnBefore.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.utils.lock.newLock
 import com.badoo.reaktive.utils.lock.synchronized
 
 fun <T> Observable<T>.doOnBeforeSubscribe(action: (Disposable) -> Unit): Observable<T> =
-    observable { observer ->
+    observableUnsafe { observer ->
         subscribeSafe(
             object : ObservableObserver<T> by observer {
                 override fun onSubscribe(disposable: Disposable) {
@@ -18,7 +18,7 @@ fun <T> Observable<T>.doOnBeforeSubscribe(action: (Disposable) -> Unit): Observa
     }
 
 fun <T> Observable<T>.doOnBeforeNext(consumer: (T) -> Unit): Observable<T> =
-    observable { observer ->
+    observableUnsafe { observer ->
         subscribeSafe(
             object : ObservableObserver<T> by observer {
                 override fun onNext(value: T) {
@@ -30,7 +30,7 @@ fun <T> Observable<T>.doOnBeforeNext(consumer: (T) -> Unit): Observable<T> =
     }
 
 fun <T> Observable<T>.doOnBeforeComplete(action: () -> Unit): Observable<T> =
-    observable { observer ->
+    observableUnsafe { observer ->
         subscribeSafe(
             object : ObservableObserver<T> by observer {
                 override fun onComplete() {
@@ -42,7 +42,7 @@ fun <T> Observable<T>.doOnBeforeComplete(action: () -> Unit): Observable<T> =
     }
 
 fun <T> Observable<T>.doOnBeforeError(consumer: (Throwable) -> Unit): Observable<T> =
-    observable { observer ->
+    observableUnsafe { observer ->
         subscribeSafe(
             object : ObservableObserver<T> by observer {
                 override fun onError(error: Throwable) {
@@ -54,7 +54,7 @@ fun <T> Observable<T>.doOnBeforeError(consumer: (Throwable) -> Unit): Observable
     }
 
 fun <T> Observable<T>.doOnBeforeTerminate(action: () -> Unit): Observable<T> =
-    observable { observer ->
+    observableUnsafe { observer ->
         subscribeSafe(
             object : ObservableObserver<T> by observer {
                 override fun onComplete() {
@@ -71,7 +71,7 @@ fun <T> Observable<T>.doOnBeforeTerminate(action: () -> Unit): Observable<T> =
     }
 
 fun <T> Observable<T>.doOnBeforeDispose(action: () -> Unit): Observable<T> =
-    observable { observer ->
+    observableUnsafe { observer ->
         subscribeSafe(
             object : ObservableObserver<T> by observer {
                 override fun onSubscribe(disposable: Disposable) {
@@ -82,7 +82,7 @@ fun <T> Observable<T>.doOnBeforeDispose(action: () -> Unit): Observable<T> =
     }
 
 fun <T> Observable<T>.doOnBeforeFinally(action: () -> Unit): Observable<T> =
-    observable { observer ->
+    observableUnsafe { observer ->
         subscribeSafe(
             object : ObservableObserver<T> by observer {
                 private val lock = newLock()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FirstOrComplete.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FirstOrComplete.kt
@@ -1,12 +1,12 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.maybe.Maybe
-import com.badoo.reaktive.maybe.maybeByEmitter
+import com.badoo.reaktive.maybe.maybe
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 
 fun <T> Observable<T>.firstOrComplete(): Maybe<T> =
-    maybeByEmitter { emitter ->
+    maybe { emitter ->
         val disposableWrapper = DisposableWrapper()
         emitter.setDisposable(disposableWrapper)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FirstOrDefault.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FirstOrDefault.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.single.Single
 import com.badoo.reaktive.single.SingleEmitter
-import com.badoo.reaktive.single.singleByEmitter
+import com.badoo.reaktive.single.single
 
 fun <T> Observable<T>.firstOrDefault(defaultValue: T): Single<T> =
     firstOrAction { emitter ->
@@ -23,7 +23,7 @@ fun <T> Observable<T>.firstOrDefault(defaultValueSupplier: () -> T): Single<T> =
     }
 
 internal inline fun <T> Observable<T>.firstOrAction(crossinline onComplete: (emitter: SingleEmitter<T>) -> Unit): Single<T> =
-    singleByEmitter { emitter ->
+    single { emitter ->
         val disposableWrapper = DisposableWrapper()
         emitter.setDisposable(disposableWrapper)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMap.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMap.kt
@@ -9,7 +9,7 @@ import com.badoo.reaktive.utils.lock.synchronized
 import com.badoo.reaktive.utils.serializer.serializer
 
 fun <T, R> Observable<T>.flatMap(mapper: (T) -> Observable<R>): Observable<R> =
-    observableByEmitter { emitter ->
+    observable { emitter ->
         val disposables = CompositeDisposable()
         emitter.setDisposable(disposables)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObservableByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObservableByEmitter.kt
@@ -3,8 +3,8 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 
-fun <T> observableByEmitter(onSubscribe: (emitter: ObservableEmitter<T>) -> Unit): Observable<T> =
-    observable { observer ->
+fun <T> observable(onSubscribe: (emitter: ObservableEmitter<T>) -> Unit): Observable<T> =
+    observableUnsafe { observer ->
         val disposableWrapper = DisposableWrapper()
         observer.onSubscribe(disposableWrapper)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObserveOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObserveOn.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.scheduler.BufferedExecutor
 import com.badoo.reaktive.scheduler.Scheduler
 
 fun <T> Observable<T>.observeOn(scheduler: Scheduler): Observable<T> =
-    observableByEmitter { emitter ->
+    observable { emitter ->
         val disposables = CompositeDisposable()
         emitter.setDisposable(disposables)
         val executor = scheduler.newExecutor()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Sample.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Sample.kt
@@ -7,7 +7,7 @@ import com.badoo.reaktive.utils.lock.newLock
 import com.badoo.reaktive.utils.lock.synchronized
 
 fun <T> Observable<T>.sample(windowMillis: Long, scheduler: Scheduler): Observable<T> =
-    observableByEmitter { emitter ->
+    observable { emitter ->
         val disposableWrapper = CompositeDisposable()
         emitter.setDisposable(disposableWrapper)
         val executor = scheduler.newExecutor()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SubscribeOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SubscribeOn.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
 
 fun <T> Observable<T>.subscribeOn(scheduler: Scheduler): Observable<T> =
-    observable { observer ->
+    observableUnsafe { observer ->
         val disposables = CompositeDisposable()
         observer.onSubscribe(disposables)
         val executor = scheduler.newExecutor()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Throttle.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Throttle.kt
@@ -3,7 +3,7 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.utils.uptimeMillis
 
 fun <T> Observable<T>.throttle(windowMillis: Long): Observable<T> =
-    observable { observer ->
+    observableUnsafe { observer ->
         subscribeSafe(
             object : ObservableObserver<T> by observer {
                 private var lastTime = 0L

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ToCompletable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ToCompletable.kt
@@ -3,10 +3,10 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.completable.CompletableCallbacks
-import com.badoo.reaktive.completable.completable
+import com.badoo.reaktive.completable.completableUnsafe
 
 fun Observable<*>.toCompletable(): Completable =
-    completable { observer ->
+    completableUnsafe { observer ->
         subscribeSafe(
             object : ObservableObserver<Any?>, Observer by observer, CompletableCallbacks by observer {
                 override fun onNext(value: Any?) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Transform.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Transform.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 
 internal inline fun <T, R> Observable<T>.transform(crossinline onNext: (value: T, onNext: (R) -> Unit) -> Unit): Observable<R> =
-    observableByEmitter { emitter ->
+    observable { emitter ->
         subscribeSafe(
             object : ObservableObserver<T>, CompletableCallbacks by emitter {
                 private val onNextFunction = emitter::onNext

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Various.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Various.kt
@@ -1,6 +1,6 @@
 package com.badoo.reaktive.observable
 
-inline fun <T> observable(crossinline onSubscribe: (observer: ObservableObserver<T>) -> Unit): Observable<T> =
+inline fun <T> observableUnsafe(crossinline onSubscribe: (observer: ObservableObserver<T>) -> Unit): Observable<T> =
     object : Observable<T> {
         override fun subscribe(observer: ObservableObserver<T>) {
             onSubscribe(observer)
@@ -8,7 +8,7 @@ inline fun <T> observable(crossinline onSubscribe: (observer: ObservableObserver
     }
 
 fun <T> observableOf(value: T): Observable<T> =
-    observableByEmitter { emitter ->
+    observable { emitter ->
         emitter.onNext(value)
         emitter.onComplete()
     }
@@ -16,26 +16,26 @@ fun <T> observableOf(value: T): Observable<T> =
 fun <T> T.toObservable(): Observable<T> = observableOf(this)
 
 fun <T> Iterable<T>.asObservable(): Observable<T> =
-    observableByEmitter { emitter ->
+    observable { emitter ->
         forEach(emitter::onNext)
         emitter.onComplete()
     }
 
 fun <T> observableOf(vararg values: T): Observable<T> =
-    observableByEmitter { emitter ->
+    observable { emitter ->
         values.forEach(emitter::onNext)
         emitter.onComplete()
     }
 
-fun <T> errorObservable(error: Throwable): Observable<T> =
-    observableByEmitter { emitter -> emitter.onError(error) }
+fun <T> observableOfError(error: Throwable): Observable<T> =
+    observable { emitter -> emitter.onError(error) }
 
-fun <T> Throwable.toErrorObservable(): Observable<T> = errorObservable(this)
+fun <T> Throwable.toObservableOfError(): Observable<T> = observableOfError(this)
 
-fun <T> emptyObservable(): Observable<T> = observableByEmitter(ObservableEmitter<*>::onComplete)
+fun <T> observableOfEmpty(): Observable<T> = observable(ObservableEmitter<*>::onComplete)
 
 fun <T> observableFromFunction(func: () -> T): Observable<T> =
-    observableByEmitter { emitter ->
+    observable { emitter ->
         emitter.onNext(func())
         emitter.onComplete()
     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Zip.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Zip.kt
@@ -9,7 +9,7 @@ import com.badoo.reaktive.utils.queue.take
 import com.badoo.reaktive.utils.serializer.serializer
 
 fun <T, R> Collection<Observable<T>>.zip(mapper: (List<T>) -> R): Observable<R> =
-    observableByEmitter { emitter ->
+    observable { emitter ->
         val disposables = CompositeDisposable()
         emitter.setDisposable(disposables)
         val values = List<ArrayQueue<T>>(size) { ArrayQueue() }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/AsCompletable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/AsCompletable.kt
@@ -3,10 +3,10 @@ package com.badoo.reaktive.single
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.completable.Completable
-import com.badoo.reaktive.completable.completable
+import com.badoo.reaktive.completable.completableUnsafe
 
 fun Single<*>.asCompletable(): Completable =
-    completable { observer ->
+    completableUnsafe { observer ->
         subscribeSafe(
             object : SingleObserver<Any?>, Observer by observer, ErrorCallback by observer {
                 override fun onSuccess(value: Any?) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/AsMaybe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/AsMaybe.kt
@@ -2,10 +2,10 @@ package com.badoo.reaktive.single
 
 import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.maybe.Maybe
-import com.badoo.reaktive.maybe.maybe
+import com.badoo.reaktive.maybe.maybeUnsafe
 
 fun <T> Single<T>.asMaybe(): Maybe<T> =
-    maybe { observer ->
+    maybeUnsafe { observer ->
         subscribeSafe(
             object : SingleObserver<T>, Observer by observer, SingleCallbacks<T> by observer {
             }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/AsObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/AsObservable.kt
@@ -3,10 +3,10 @@ package com.badoo.reaktive.single
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.observable.Observable
-import com.badoo.reaktive.observable.observable
+import com.badoo.reaktive.observable.observableUnsafe
 
 fun <T> Single<T>.asObservable(): Observable<T> =
-    observable { observer ->
+    observableUnsafe { observer ->
         subscribeSafe(
             object : SingleObserver<T>, Observer by observer, ErrorCallback by observer {
                 override fun onSuccess(value: T) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/DoOnBefore.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.utils.lock.newLock
 import com.badoo.reaktive.utils.lock.synchronized
 
 fun <T> Single<T>.doOnBeforeSubscribe(action: (Disposable) -> Unit): Single<T> =
-    single { observer ->
+    singleUnsafe { observer ->
         subscribeSafe(
             object : SingleObserver<T> by observer {
                 override fun onSubscribe(disposable: Disposable) {
@@ -18,7 +18,7 @@ fun <T> Single<T>.doOnBeforeSubscribe(action: (Disposable) -> Unit): Single<T> =
     }
 
 fun <T> Single<T>.doOnBeforeSuccess(consumer: (T) -> Unit): Single<T> =
-    single { observer ->
+    singleUnsafe { observer ->
         subscribeSafe(
             object : SingleObserver<T> by observer {
                 override fun onSuccess(value: T) {
@@ -30,7 +30,7 @@ fun <T> Single<T>.doOnBeforeSuccess(consumer: (T) -> Unit): Single<T> =
     }
 
 fun <T> Single<T>.doOnBeforeError(consumer: (Throwable) -> Unit): Single<T> =
-    single { observer ->
+    singleUnsafe { observer ->
         subscribeSafe(
             object : SingleObserver<T> by observer {
                 override fun onError(error: Throwable) {
@@ -42,7 +42,7 @@ fun <T> Single<T>.doOnBeforeError(consumer: (Throwable) -> Unit): Single<T> =
     }
 
 fun <T> Single<T>.doOnBeforeTerminate(action: () -> Unit): Single<T> =
-    single { observer ->
+    singleUnsafe { observer ->
         subscribeSafe(
             object : SingleObserver<T> by observer {
                 override fun onSuccess(value: T) {
@@ -59,7 +59,7 @@ fun <T> Single<T>.doOnBeforeTerminate(action: () -> Unit): Single<T> =
     }
 
 fun <T> Single<T>.doOnBeforeDispose(action: () -> Unit): Single<T> =
-    single { observer ->
+    singleUnsafe { observer ->
         subscribeSafe(
             object : SingleObserver<T> by observer {
                 override fun onSubscribe(disposable: Disposable) {
@@ -70,7 +70,7 @@ fun <T> Single<T>.doOnBeforeDispose(action: () -> Unit): Single<T> =
     }
 
 fun <T> Single<T>.doOnBeforeFinally(action: () -> Unit): Single<T> =
-    single { observer ->
+    singleUnsafe { observer ->
         subscribeSafe(
             object : SingleObserver<T> by observer {
                 private val lock = newLock()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/FlatMap.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/FlatMap.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 
 fun <T, R> Single<T>.flatMap(mapper: (T) -> Single<R>): Single<R> =
-    single { observer ->
+    singleUnsafe { observer ->
         val disposableWrapper = DisposableWrapper()
         observer.onSubscribe(disposableWrapper)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/FlatMapMaybe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/FlatMapMaybe.kt
@@ -6,11 +6,11 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.maybe.Maybe
 import com.badoo.reaktive.maybe.MaybeObserver
-import com.badoo.reaktive.maybe.maybe
+import com.badoo.reaktive.maybe.maybeUnsafe
 import com.badoo.reaktive.maybe.subscribeSafe
 
 fun <T, R> Single<T>.flatMapMaybe(mapper: (T) -> Maybe<R>): Maybe<R> =
-    maybe { observer ->
+    maybeUnsafe { observer ->
         val disposableWrapper = DisposableWrapper()
         observer.onSubscribe(disposableWrapper)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/FlatMapObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/FlatMapObservable.kt
@@ -6,11 +6,11 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.observable.ObservableObserver
-import com.badoo.reaktive.observable.observable
+import com.badoo.reaktive.observable.observableUnsafe
 import com.badoo.reaktive.observable.subscribeSafe
 
 fun <T, R> Single<T>.flatMapObservable(mapper: (T) -> Observable<R>): Observable<R> =
-    observable { observer ->
+    observableUnsafe { observer ->
         val disposableWrapper = DisposableWrapper()
         observer.onSubscribe(disposableWrapper)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Flatten.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Flatten.kt
@@ -3,10 +3,10 @@ package com.badoo.reaktive.single
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.observable.Observable
-import com.badoo.reaktive.observable.observableByEmitter
+import com.badoo.reaktive.observable.observable
 
 fun <T> Single<Iterable<T>>.flatten(): Observable<T> =
-    observableByEmitter { emitter ->
+    observable { emitter ->
         subscribeSafe(
             object : SingleObserver<Iterable<T>>, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/ObserveOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/ObserveOn.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
 
 fun <T> Single<T>.observeOn(scheduler: Scheduler): Single<T> =
-    singleByEmitter { emitter ->
+    single { emitter ->
         val disposables = CompositeDisposable()
         emitter.setDisposable(disposables)
         val executor = scheduler.newExecutor()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SingleByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SingleByEmitter.kt
@@ -3,8 +3,8 @@ package com.badoo.reaktive.single
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 
-inline fun <T> singleByEmitter(crossinline onSubscribe: (emitter: SingleEmitter<T>) -> Unit): Single<T> =
-    single { observer ->
+fun <T> single(onSubscribe: (emitter: SingleEmitter<T>) -> Unit): Single<T> =
+    singleUnsafe { observer ->
         val disposableWrapper = DisposableWrapper()
         observer.onSubscribe(disposableWrapper)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SubscribeOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SubscribeOn.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
 
 fun <T> Single<T>.subscribeOn(scheduler: Scheduler): Single<T> =
-    single { observer ->
+    singleUnsafe { observer ->
         val disposables = CompositeDisposable()
         observer.onSubscribe(disposables)
         val executor = scheduler.newExecutor()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Transform.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Transform.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.disposable.Disposable
 internal inline fun <T, R> Single<T>.transform(
     crossinline onSuccess: (value: T, onSuccess: (R) -> Unit) -> Unit
 ): Single<R> =
-    singleByEmitter { emitter ->
+    single { emitter ->
         subscribeSafe(
             object : SingleObserver<T> {
                 override fun onSubscribe(disposable: Disposable) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Vairous.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Vairous.kt
@@ -1,6 +1,6 @@
 package com.badoo.reaktive.single
 
-inline fun <T> single(crossinline onSubscribe: (observer: SingleObserver<T>) -> Unit): Single<T> =
+inline fun <T> singleUnsafe(crossinline onSubscribe: (observer: SingleObserver<T>) -> Unit): Single<T> =
     object : Single<T> {
         override fun subscribe(observer: SingleObserver<T>) {
             onSubscribe(observer)
@@ -8,20 +8,20 @@ inline fun <T> single(crossinline onSubscribe: (observer: SingleObserver<T>) -> 
     }
 
 fun <T> singleOf(value: T): Single<T> =
-    singleByEmitter { emitter ->
+    single { emitter ->
         emitter.onSuccess(value)
     }
 
 fun <T> T.toSingle(): Single<T> = singleOf(this)
 
-fun <T> errorSingle(error: Throwable): Single<T> =
-    singleByEmitter { emitter ->
+fun <T> singleOfError(error: Throwable): Single<T> =
+    single { emitter ->
         emitter.onError(error)
     }
 
-fun <T> Throwable.toErrorSingle(): Single<T> = errorSingle(this)
+fun <T> Throwable.toSingleOfError(): Single<T> = singleOfError(this)
 
 fun <T> singleFromFunction(func: () -> T): Single<T> =
-    singleByEmitter { emitter ->
+    single { emitter ->
         emitter.onSuccess(func())
     }

--- a/reaktive/src/jsMain/kotlin/com/badoo/reaktive/promise/PromiseToReaktive.kt
+++ b/reaktive/src/jsMain/kotlin/com/badoo/reaktive/promise/PromiseToReaktive.kt
@@ -1,10 +1,10 @@
 package com.badoo.reaktive.promise
 
 import com.badoo.reaktive.single.Single
-import com.badoo.reaktive.single.singleByEmitter
+import com.badoo.reaktive.single.single
 import kotlin.js.Promise
 
 fun <T> Promise<T>.asSingle(): Single<T> =
-    singleByEmitter { emitter ->
+    single { emitter ->
         then(onFulfilled = emitter::onSuccess, onRejected = emitter::onError)
     }

--- a/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Completable.kt
+++ b/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Completable.kt
@@ -2,7 +2,7 @@ package com.badoo.reaktive.rxjavainterop
 
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.completable.CompletableObserver
-import com.badoo.reaktive.completable.completable
+import com.badoo.reaktive.completable.completableUnsafe
 import com.badoo.reaktive.disposable.Disposable
 
 fun Completable.toRxJava2Source(): io.reactivex.CompletableSource =
@@ -18,7 +18,7 @@ fun Completable.toRxJava2(): io.reactivex.Completable =
     }
 
 fun <T> io.reactivex.CompletableSource.toReaktive(): Completable =
-    completable { observer ->
+    completableUnsafe { observer ->
         subscribe(observer.toRxJava2())
     }
 

--- a/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Maybe.kt
+++ b/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Maybe.kt
@@ -3,7 +3,7 @@ package com.badoo.reaktive.rxjavainterop
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.maybe.Maybe
 import com.badoo.reaktive.maybe.MaybeObserver
-import com.badoo.reaktive.maybe.maybe
+import com.badoo.reaktive.maybe.maybeUnsafe
 
 fun <T> Maybe<T>.toRxJava2Source(): io.reactivex.MaybeSource<T> =
     io.reactivex.MaybeSource { observer ->
@@ -18,7 +18,7 @@ fun <T> Maybe<T>.toRxJava2(): io.reactivex.Maybe<T> =
     }
 
 fun <T> io.reactivex.MaybeSource<out T>.toReaktive(): Maybe<T> =
-    maybe { observer ->
+    maybeUnsafe { observer ->
         subscribe(observer.toRxJava2())
     }
 

--- a/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Observable.kt
+++ b/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Observable.kt
@@ -3,7 +3,7 @@ package com.badoo.reaktive.rxjavainterop
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.observable.ObservableObserver
-import com.badoo.reaktive.observable.observable
+import com.badoo.reaktive.observable.observableUnsafe
 
 fun <T> Observable<T>.toRxJava2Source(): io.reactivex.ObservableSource<T> =
     io.reactivex.ObservableSource { observer ->
@@ -18,7 +18,7 @@ fun <T> Observable<T>.toRxJava2(): io.reactivex.Observable<T> =
     }
 
 fun <T> io.reactivex.ObservableSource<out T>.toReaktive(): Observable<T> =
-    observable { observer ->
+    observableUnsafe { observer ->
         subscribe(observer.toRxJava2())
     }
 

--- a/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Single.kt
+++ b/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Single.kt
@@ -3,7 +3,7 @@ package com.badoo.reaktive.rxjavainterop
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.single.Single
 import com.badoo.reaktive.single.SingleObserver
-import com.badoo.reaktive.single.single
+import com.badoo.reaktive.single.singleUnsafe
 
 fun <T> Single<T>.toRxJava2Source(): io.reactivex.SingleSource<T> =
     io.reactivex.SingleSource { observer ->
@@ -18,7 +18,7 @@ fun <T> Single<T>.toRxJava2(): io.reactivex.Single<T> =
     }
 
 fun <T> io.reactivex.SingleSource<out T>.toReaktive(): Single<T> =
-    single { observer ->
+    singleUnsafe { observer ->
         subscribe(observer.toRxJava2())
     }
 

--- a/sample-android-app/src/main/java/com/badoo/reaktive/sample/android/MainActivity.kt
+++ b/sample-android-app/src/main/java/com/badoo/reaktive/sample/android/MainActivity.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.widget.Button
 import android.widget.TextView
-import com.badoo.reaktive.observable.observableByEmitter
+import com.badoo.reaktive.observable.observable
 import com.badoo.reaktive.observable.observeOn
 import com.badoo.reaktive.observable.subscribe
 import com.badoo.reaktive.observable.subscribeOn
@@ -23,7 +23,7 @@ class MainActivity : AppCompatActivity() {
         val textView = findViewById<TextView>(R.id.text)
 
         findViewById<Button>(R.id.button).setOnClickListener {
-            observableByEmitter<String> { emitter ->
+            observable<String> { emitter ->
                 emitter.onNext("Loading...")
                 Thread.sleep(1000L)
                 emitter.onNext(SimpleDateFormat.getDateTimeInstance().format(Date()))


### PR DESCRIPTION
It would be nice to rename some of our source factory methods so they will be more like in RxJava. E.g.:
`observableByEmitter{}` -> `observable{}`
`observable{}` -> `observableUnsafe{}`
etc.