### PR TITLE
Configuration for jitpack and iOS target is enabled explicitly only

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk: openjdk8
+install: ./gradlew reaktive:publishToMavenLocal rxjava2-interop:publishToMavenLocal

--- a/reaktive/build.gradle
+++ b/reaktive/build.gradle
@@ -83,7 +83,8 @@ if (target.isCommon() || target.isMeta()) {
     }
 }
 
-if (target.isIos() || target.isMeta()) {
+// target.isIos() || target.isMeta() when iOS is ready for publishing
+if (target.isIos()) {
     kotlin {
         targets {
             fromPreset(presets.iosArm32, 'ios32') {
@@ -112,8 +113,6 @@ if (target.isIos() || target.isMeta()) {
         }
     }
 
-    // Uncomment when ios is ready
-    /*
     task iosTest(dependsOn: 'linkTestDebugExecutableIosSim') {
         group 'verification'
         doLast {
@@ -124,7 +123,6 @@ if (target.isIos() || target.isMeta()) {
         }
     }
     tasks.check.dependsOn iosTest
-    */
 }
 
 apply from: '../publication.gradle'

--- a/target.gradle
+++ b/target.gradle
@@ -6,7 +6,10 @@ enum MpBuildTarget {
 
     boolean isCommon() { return this == ALL || this == COMMON }
 
-    boolean isIos() { return this == ALL || this == IOS }
+    boolean isIos() {
+        // return this == ALL || this == IOS when iOS is ready for publishing
+        return this == IOS 
+    }
 
     boolean isMeta() { return this == ALL || this == META }
 }


### PR DESCRIPTION
Now jitpack will build only reaktive and RxJava2 interoperability lib without launching tests, it's CI's job.
iOS support now can be enabled only explicitly to avoid iOS metadata publication. 