### PR TITLE
Deliver errors to downstreams

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsMaybe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsMaybe.kt
@@ -1,13 +1,20 @@
 package com.badoo.reaktive.completable
 
-import com.badoo.reaktive.base.Observer
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.maybe.Maybe
 import com.badoo.reaktive.maybe.maybeUnsafe
 
 fun <T> Completable.asMaybe(): Maybe<T> =
     maybeUnsafe { observer ->
+        val disposableWrapper = DisposableWrapper()
+        observer.onSubscribe(disposableWrapper)
+
         subscribeSafe(
-            object : CompletableObserver, Observer by observer, CompletableCallbacks by observer {
+            object : CompletableObserver, CompletableCallbacks by observer {
+                override fun onSubscribe(disposable: Disposable) {
+                    disposableWrapper.set(disposable)
+                }
             }
         )
     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsObservable.kt
@@ -1,13 +1,20 @@
 package com.badoo.reaktive.completable
 
-import com.badoo.reaktive.base.Observer
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.observable.observableUnsafe
 
 fun <T> Completable.asObservable(): Observable<T> =
     observableUnsafe { observer ->
+        val disposableWrapper = DisposableWrapper()
+        observer.onSubscribe(disposableWrapper)
+
         subscribeSafe(
-            object : CompletableObserver, Observer by observer, CompletableCallbacks by observer {
+            object : CompletableObserver, CompletableCallbacks by observer {
+                override fun onSubscribe(disposable: Disposable) {
+                    disposableWrapper.set(disposable)
+                }
             }
         )
     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Concat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Concat.kt
@@ -15,7 +15,7 @@ fun Iterable<Completable>.concat(): Completable =
         }
 
         val upstreamObserver =
-            object : CompletableObserver by observer {
+            object : CompletableObserver, CompletableCallbacks by observer {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/SubscribeSafe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/SubscribeSafe.kt
@@ -2,10 +2,10 @@ package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.utils.handleSourceError
 
-internal fun Completable.subscribeSafe(observer: CompletableObserver, onError: ((Throwable) -> Unit)? = null) {
+internal fun Completable.subscribeSafe(observer: CompletableObserver) {
     try {
         subscribe(observer)
     } catch (e: Throwable) {
-        handleSourceError(e, onError)
+        handleSourceError(e, observer::onError)
     }
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Susbcribe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Susbcribe.kt
@@ -12,12 +12,12 @@ fun Completable.subscribe(
     onComplete: (() -> Unit)? = null
 ): Disposable {
     val disposableWrapper = DisposableWrapper()
+    onSubscribe?.invoke(disposableWrapper)
 
     subscribeSafe(
         object : CompletableObserver {
             override fun onSubscribe(disposable: Disposable) {
                 disposableWrapper.set(disposable)
-                onSubscribe?.invoke(disposable)
             }
 
             override fun onComplete() {
@@ -35,8 +35,7 @@ fun Completable.subscribe(
                     disposableWrapper.dispose()
                 }
             }
-        },
-        onError
+        }
     )
 
     return disposableWrapper

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsCompletable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsCompletable.kt
@@ -1,14 +1,22 @@
 package com.badoo.reaktive.maybe
 
-import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.completable.completableUnsafe
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.DisposableWrapper
 
 fun Maybe<*>.asCompletable(): Completable =
     completableUnsafe { observer ->
+        val disposableWrapper = DisposableWrapper()
+        observer.onSubscribe(disposableWrapper)
+
         subscribeSafe(
-            object : MaybeObserver<Any?>, Observer by observer, CompletableCallbacks by observer {
+            object : MaybeObserver<Any?>, CompletableCallbacks by observer {
+                override fun onSubscribe(disposable: Disposable) {
+                    disposableWrapper.set(disposable)
+                }
+
                 override fun onSuccess(value: Any?) {
                     observer.onComplete()
                 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsObservable.kt
@@ -1,14 +1,22 @@
 package com.badoo.reaktive.maybe
 
-import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.completable.CompletableCallbacks
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.observable.observableUnsafe
 
 fun <T> Maybe<T>.asObservable(): Observable<T> =
     observableUnsafe { observer ->
+        val disposableWrapper = DisposableWrapper()
+        observer.onSubscribe(disposableWrapper)
+
         subscribeSafe(
-            object : MaybeObserver<T>, Observer by observer, CompletableCallbacks by observer {
+            object : MaybeObserver<T>, CompletableCallbacks by observer {
+                override fun onSubscribe(disposable: Disposable) {
+                    disposableWrapper.set(disposable)
+                }
+
                 override fun onSuccess(value: T) {
                     observer.onNext(value)
                     observer.onComplete()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsSingle.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsSingle.kt
@@ -1,6 +1,7 @@
 package com.badoo.reaktive.maybe
 
-import com.badoo.reaktive.base.Observer
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.single.Single
 import com.badoo.reaktive.single.SingleCallbacks
 import com.badoo.reaktive.single.SingleObserver
@@ -24,8 +25,15 @@ fun <T> Maybe<T>.asSingle(defaultValueSupplier: () -> T): Single<T> =
 
 internal inline fun <T> Maybe<T>.asSingleOrAction(crossinline onComplete: (observer: SingleObserver<T>) -> Unit): Single<T> =
     singleUnsafe { observer ->
+        val disposableWrapper = DisposableWrapper()
+        observer.onSubscribe(disposableWrapper)
+
         subscribeSafe(
-            object : MaybeObserver<T>, Observer by observer, SingleCallbacks<T> by observer {
+            object : MaybeObserver<T>, SingleCallbacks<T> by observer {
+                override fun onSubscribe(disposable: Disposable) {
+                    disposableWrapper.set(disposable)
+                }
+
                 override fun onComplete() {
                     onComplete(observer)
                 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/FlatMap.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/FlatMap.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.maybe
 
-import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
@@ -11,7 +10,7 @@ fun <T, R> Maybe<T>.flatMap(mapper: (T) -> Maybe<R>): Maybe<R> =
         observer.onSubscribe(disposableWrapper)
 
         subscribeSafe(
-            object : MaybeObserver<T>, Observer by observer, CompletableCallbacks by observer {
+            object : MaybeObserver<T>, CompletableCallbacks by observer {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/FlatMapObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/FlatMapObservable.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.maybe
 
-import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
@@ -15,7 +14,7 @@ fun <T, R> Maybe<T>.flatMapObservable(mapper: (T) -> Observable<R>): Observable<
         observer.onSubscribe(disposableWrapper)
 
         subscribeSafe(
-            object : MaybeObserver<T>, Observer by observer, CompletableCallbacks by observer {
+            object : MaybeObserver<T>, CompletableCallbacks by observer {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Flatten.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Flatten.kt
@@ -2,15 +2,19 @@ package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.observable.observable
 
 fun <T> Maybe<Iterable<T>>.flatten(): Observable<T> =
     observable { emitter ->
+        val disposableWrapper = DisposableWrapper()
+        emitter.setDisposable(disposableWrapper)
+
         subscribeSafe(
             object : MaybeObserver<Iterable<T>>, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {
-                    emitter.setDisposable(disposable)
+                    disposableWrapper.set(disposable)
                 }
 
                 override fun onSuccess(value: Iterable<T>) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/SubscribeOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/SubscribeOn.kt
@@ -13,7 +13,7 @@ fun <T> Maybe<T>.subscribeOn(scheduler: Scheduler): Maybe<T> =
 
         executor.submit {
             subscribeSafe(
-                object : MaybeObserver<T> by observer {
+                object : MaybeObserver<T>, MaybeCallbacks<T> by observer {
                     override fun onSubscribe(disposable: Disposable) {
                         disposables += disposable
                     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/SubscribeSafe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/SubscribeSafe.kt
@@ -2,10 +2,10 @@ package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.utils.handleSourceError
 
-internal fun <T> Maybe<T>.subscribeSafe(observer: MaybeObserver<T>, onError: ((Throwable) -> Unit)? = null) {
+internal fun <T> Maybe<T>.subscribeSafe(observer: MaybeObserver<T>) {
     try {
         subscribe(observer)
     } catch (e: Throwable) {
-        handleSourceError(e, onError)
+        handleSourceError(e, observer::onError)
     }
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Susbcribe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Susbcribe.kt
@@ -13,12 +13,12 @@ fun <T> Maybe<T>.subscribe(
     onSuccess: ((T) -> Unit)? = null
 ): Disposable {
     val disposableWrapper = DisposableWrapper()
+    onSubscribe?.invoke(disposableWrapper)
 
     subscribeSafe(
         object : MaybeObserver<T> {
             override fun onSubscribe(disposable: Disposable) {
                 disposableWrapper.set(disposable)
-                onSubscribe?.invoke(disposable)
             }
 
             override fun onSuccess(value: T) {
@@ -44,8 +44,7 @@ fun <T> Maybe<T>.subscribe(
                     disposableWrapper.dispose()
                 }
             }
-        },
-        onError
+        }
     )
 
     return disposableWrapper

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Transform.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Transform.kt
@@ -1,18 +1,22 @@
 package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.DisposableWrapper
 
 internal inline fun <T, R> Maybe<T>.transform(
     crossinline onSuccess: (value: T, onSuccess: (R) -> Unit, onComplete: () -> Unit) -> Unit
 ): Maybe<R> =
     maybe { emitter ->
+        val disposableWrapper = DisposableWrapper()
+        emitter.setDisposable(disposableWrapper)
+
         subscribeSafe(
             object : MaybeObserver<T> {
                 private val onSuccessFunction = emitter::onSuccess
                 private val onCompleteFunction = emitter::onComplete
 
                 override fun onSubscribe(disposable: Disposable) {
-                    emitter.setDisposable(disposable)
+                    disposableWrapper.set(disposable)
                 }
 
                 override fun onSuccess(value: T) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/AsCompletable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/AsCompletable.kt
@@ -1,14 +1,22 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.completable.completableUnsafe
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.DisposableWrapper
 
 fun Observable<*>.asCompletable(): Completable =
     completableUnsafe { observer ->
+        val disposableWrapper = DisposableWrapper()
+        observer.onSubscribe(disposableWrapper)
+
         subscribeSafe(
-            object : ObservableObserver<Any?>, Observer by observer, CompletableCallbacks by observer {
+            object : ObservableObserver<Any?>, CompletableCallbacks by observer {
+                override fun onSubscribe(disposable: Disposable) {
+                    disposableWrapper.set(disposable)
+                }
+
                 override fun onNext(value: Any?) {
                     // no-op
                 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Collect.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Collect.kt
@@ -1,14 +1,22 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.base.ErrorCallback
-import com.badoo.reaktive.base.Observer
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.single.Single
 import com.badoo.reaktive.single.singleUnsafe
 
 fun <T, C> Observable<T>.collect(collection: C, accumulator: (C, T) -> Unit): Single<C> =
     singleUnsafe { observer ->
+        val disposableWrapper = DisposableWrapper()
+        observer.onSubscribe(disposableWrapper)
+
         subscribeSafe(
-            object : ObservableObserver<T>, Observer by observer, ErrorCallback by observer {
+            object : ObservableObserver<T>, ErrorCallback by observer {
+                override fun onSubscribe(disposable: Disposable) {
+                    disposableWrapper.set(disposable)
+                }
+
                 override fun onNext(value: T) {
                     accumulator(collection, value)
                 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Concat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Concat.kt
@@ -15,7 +15,7 @@ fun <T> Iterable<Observable<T>>.concat(): Observable<T> =
         }
 
         val upstreamObserver =
-            object : ObservableObserver<T> by observer {
+            object : ObservableObserver<T>, ObservableCallbacks<T> by observer {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SubscribeSafe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SubscribeSafe.kt
@@ -2,10 +2,10 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.utils.handleSourceError
 
-internal fun <T> Observable<T>.subscribeSafe(observer: ObservableObserver<T>, onError: ((Throwable) -> Unit)? = null) {
+internal fun <T> Observable<T>.subscribeSafe(observer: ObservableObserver<T>) {
     try {
         subscribe(observer)
     } catch (e: Throwable) {
-        handleSourceError(e, onError)
+        handleSourceError(e, observer::onError)
     }
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Susbcribe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Susbcribe.kt
@@ -13,12 +13,12 @@ fun <T> Observable<T>.subscribe(
     onNext: ((T) -> Unit)? = null
 ): Disposable {
     val disposableWrapper = DisposableWrapper()
+    onSubscribe?.invoke(disposableWrapper)
 
     subscribeSafe(
         object : ObservableObserver<T> {
             override fun onSubscribe(disposable: Disposable) {
                 disposableWrapper.set(disposable)
-                onSubscribe?.invoke(disposable)
             }
 
             override fun onNext(value: T) {
@@ -40,8 +40,7 @@ fun <T> Observable<T>.subscribe(
                     disposableWrapper.dispose()
                 }
             }
-        },
-        onError
+        }
     )
 
     return disposableWrapper

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Throttle.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Throttle.kt
@@ -1,12 +1,21 @@
 package com.badoo.reaktive.observable
 
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.utils.uptimeMillis
 
 fun <T> Observable<T>.throttle(windowMillis: Long): Observable<T> =
     observableUnsafe { observer ->
+        val disposableWrapper = DisposableWrapper()
+        observer.onSubscribe(disposableWrapper)
+
         subscribeSafe(
-            object : ObservableObserver<T> by observer {
+            object : ObservableObserver<T>, ObservableCallbacks<T> by observer {
                 private var lastTime = 0L
+
+                override fun onSubscribe(disposable: Disposable) {
+                    disposableWrapper.set(disposable)
+                }
 
                 override fun onNext(value: T) {
                     val time = uptimeMillis

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ToCompletable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ToCompletable.kt
@@ -1,14 +1,22 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.completable.completableUnsafe
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.DisposableWrapper
 
 fun Observable<*>.toCompletable(): Completable =
     completableUnsafe { observer ->
+        val disposableWrapper = DisposableWrapper()
+        observer.onSubscribe(disposableWrapper)
+
         subscribeSafe(
-            object : ObservableObserver<Any?>, Observer by observer, CompletableCallbacks by observer {
+            object : ObservableObserver<Any?>, CompletableCallbacks by observer {
+                override fun onSubscribe(disposable: Disposable) {
+                    disposableWrapper.set(disposable)
+                }
+
                 override fun onNext(value: Any?) {
                     // no-op
                 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Transform.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Transform.kt
@@ -2,15 +2,19 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.DisposableWrapper
 
 internal inline fun <T, R> Observable<T>.transform(crossinline onNext: (value: T, onNext: (R) -> Unit) -> Unit): Observable<R> =
     observable { emitter ->
+        val disposableWrapper = DisposableWrapper()
+        emitter.setDisposable(disposableWrapper)
+
         subscribeSafe(
             object : ObservableObserver<T>, CompletableCallbacks by emitter {
                 private val onNextFunction = emitter::onNext
 
                 override fun onSubscribe(disposable: Disposable) {
-                    emitter.setDisposable(disposable)
+                    disposableWrapper.set(disposable)
                 }
 
                 override fun onNext(value: T) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/FlatMapMaybe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/FlatMapMaybe.kt
@@ -1,7 +1,6 @@
 package com.badoo.reaktive.single
 
 import com.badoo.reaktive.base.ErrorCallback
-import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.maybe.Maybe
@@ -15,7 +14,7 @@ fun <T, R> Single<T>.flatMapMaybe(mapper: (T) -> Maybe<R>): Maybe<R> =
         observer.onSubscribe(disposableWrapper)
 
         subscribeSafe(
-            object : SingleObserver<T>, Observer by observer, ErrorCallback by observer {
+            object : SingleObserver<T>, ErrorCallback by observer {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SubscribeSafe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SubscribeSafe.kt
@@ -2,10 +2,10 @@ package com.badoo.reaktive.single
 
 import com.badoo.reaktive.utils.handleSourceError
 
-internal fun <T> Single<T>.subscribeSafe(observer: SingleObserver<T>, onError: ((Throwable) -> Unit)? = null) {
+internal fun <T> Single<T>.subscribeSafe(observer: SingleObserver<T>) {
     try {
         subscribe(observer)
     } catch (e: Throwable) {
-        handleSourceError(e, onError)
+        handleSourceError(e)
     }
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Susbcribe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Susbcribe.kt
@@ -12,12 +12,12 @@ fun <T> Single<T>.subscribe(
     onSuccess: ((T) -> Unit)? = null
 ): Disposable {
     val disposableWrapper = DisposableWrapper()
+    onSubscribe?.invoke(disposableWrapper)
 
     subscribeSafe(
         object : SingleObserver<T> {
             override fun onSubscribe(disposable: Disposable) {
                 disposableWrapper.set(disposable)
-                onSubscribe?.invoke(disposable)
             }
 
             override fun onSuccess(value: T) {
@@ -35,8 +35,7 @@ fun <T> Single<T>.subscribe(
                     disposableWrapper.dispose()
                 }
             }
-        },
-        onError
+        }
     )
 
     return disposableWrapper


### PR DESCRIPTION
A while ago (commit hash 2943757) I was confused by implementation of RxJava2. When you subscribe to an upstream (by calling its `subscribe` method) it may throw an exception. In this case it's actually possible (looks like) to deliver exception via regular `onError` callback instead of `uncaughtErrorHandler`, because we are able to provide a `Disposable` to a downstream before subscribing to an upstream. In this PR I'm fixing the issue.