### PR TITLE
Add Lift and Route operator

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Lift.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Lift.kt
@@ -1,0 +1,33 @@
+package com.badoo.reaktive.observable
+
+import com.badoo.reaktive.disposable.Disposable
+
+typealias Lift<T, R> = (proceed: ObservableObserver<R>) -> ObservableObserver<T>
+
+fun <T, R> Observable<T>.lift(lift: Lift<T, R>): Observable<R> =
+    observable { emitter ->
+        emitter
+            .toObserver()
+            .let(lift)
+            .let { subscribeSafe(it) }
+    }
+
+private fun <T> ObservableEmitter<T>.toObserver() = object : ObservableObserver<T> {
+
+    private val emitter = this@toObserver
+
+    override fun onSubscribe(disposable: Disposable) = emitter.setDisposable(disposable)
+
+    override fun onNext(value: T) {
+        try {
+            emitter.onNext(value)
+        } catch (error: Throwable) {
+            emitter.onError(error)
+        }
+    }
+
+    override fun onComplete() = emitter.onComplete()
+
+    override fun onError(error: Throwable) = emitter.onError(error)
+
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Route.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Route.kt
@@ -1,0 +1,23 @@
+package com.badoo.reaktive.observable
+
+import com.badoo.reaktive.disposable.Disposable
+
+typealias Route<T, R> = (proceed: (T) -> Unit) -> (R) -> Unit
+
+fun <T, R> Observable<T>.route(route: Route<R, T>): Observable<R> =
+    lift { observer: ObservableObserver<R> -> observer.compose(route) }
+
+private fun <T, R> ObservableObserver<T>.compose(route: Route<T, R>) = object : ObservableObserver<R> {
+
+    private val observer = this@compose
+    private val onNext = route(observer::onNext)
+
+    override fun onSubscribe(disposable: Disposable) = observer.onSubscribe(disposable)
+
+    override fun onNext(value: R) = onNext.invoke(value)
+
+    override fun onComplete() = observer.onComplete()
+
+    override fun onError(error: Throwable) = observer.onError(error)
+
+}


### PR DESCRIPTION
For creating the a custom operator in RxJava I sometimes use the `lift` operator, but it is not in your implementation. 

In addition I added a `route` operator which is the same as lift, but only requires the onNext method to be implemented. I couldn't called it `lift` since it gives overload problems when using it.