### PR TITLE
Merge our gitignore with the RxJava his gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .idea
 /build
 /classes
+/out
+.DS_Store*


### PR DESCRIPTION
When developing I found that `.DS_Store` and `out/` were able to commit. Now I merged the gitignore of RxJava, but an alternative could be to use [gitignore.io](https://gitignore.io/).