### PR TITLE
Use CValue instead of Arena

### DIFF
--- a/reaktive/build.gradle
+++ b/reaktive/build.gradle
@@ -83,7 +83,7 @@ if (target.isCommon() || target.isMeta()) {
 
             linuxCommonMain.dependsOn nativeCommonMain
             linuxCommonTest.dependsOn nativeCommonTest
-          
+
             linuxX64Main.dependsOn linuxCommonMain
             linuxX64Test.dependsOn linuxCommonTest
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/BlockingGet.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/BlockingGet.kt
@@ -53,6 +53,6 @@ fun <T> Single<T>.blockingGet(): T {
 }
 
 private sealed class BlockingGetResult<out T> {
-    class Success<T>(val value: T) : BlockingGetResult<T>()
+    class Success<out T>(val value: T) : BlockingGetResult<T>()
     class Error(val error: Throwable) : BlockingGetResult<Nothing>()
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/Condition.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/Condition.kt
@@ -5,6 +5,4 @@ internal interface Condition {
     fun await(timeoutNanos: Long = -1L)
 
     fun signal()
-
-    fun destroy()
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/Lock.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/Lock.kt
@@ -6,7 +6,5 @@ internal expect class Lock constructor() {
 
     fun release()
 
-    fun destroy()
-
     fun newCondition(): Condition
 }

--- a/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/Lock.kt
+++ b/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/Lock.kt
@@ -10,10 +10,6 @@ internal actual class Lock {
         // no-op
     }
 
-    actual fun destroy() {
-        // no-op
-    }
-
     actual fun newCondition(): Condition = condition
 
     private companion object {
@@ -24,10 +20,6 @@ internal actual class Lock {
                 }
 
                 override fun signal() {
-                    // no-op
-                }
-
-                override fun destroy() {
                     // no-op
                 }
             }

--- a/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/Lock.kt
+++ b/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/Lock.kt
@@ -14,10 +14,6 @@ internal actual class Lock {
         delegate.unlock()
     }
 
-    actual fun destroy() {
-        // no-op
-    }
-
     actual fun newCondition(): Condition = ConditionImpl(this@Lock.delegate.newCondition())
 
     private class ConditionImpl(
@@ -33,10 +29,6 @@ internal actual class Lock {
 
         override fun signal() {
             delegate.signalAll()
-        }
-
-        override fun destroy() {
-            // no-op
         }
     }
 }

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/looperthread/LooperThread.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/looperthread/LooperThread.kt
@@ -27,7 +27,7 @@ internal class LooperThread {
 
     fun destroy() {
         isDestroyed.value = 1
-        queue.destroy()
+        queue.clear()
         worker.requestTermination(processScheduledJobs = false)
     }
 

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/looperthread/MessageQueue.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/looperthread/MessageQueue.kt
@@ -67,12 +67,6 @@ internal class MessageQueue {
         }
     }
 
-    fun destroy() {
-        clear()
-        condition.destroy()
-        lock.destroy()
-    }
-
     private class Entry(
         val token: Any,
         val startTimeNanos: Long,

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/Lock.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/Lock.kt
@@ -1,99 +1,79 @@
 package com.badoo.reaktive.utils
 
-import kotlin.system.getTimeNanos
-import kotlinx.cinterop.Arena
-import kotlinx.cinterop.CPointer
-import kotlinx.cinterop.alloc
+import kotlinx.cinterop.CValue
+import kotlinx.cinterop.cValue
 import kotlinx.cinterop.convert
-import kotlinx.cinterop.ptr
+import kotlinx.cinterop.useContents
 import platform.posix.PTHREAD_MUTEX_RECURSIVE
-import platform.posix.pthread_cond_destroy
 import platform.posix.pthread_cond_init
 import platform.posix.pthread_cond_signal
 import platform.posix.pthread_cond_t
 import platform.posix.pthread_cond_timedwait
 import platform.posix.pthread_cond_wait
-import platform.posix.pthread_mutex_destroy
 import platform.posix.pthread_mutex_init
 import platform.posix.pthread_mutex_lock
 import platform.posix.pthread_mutex_t
 import platform.posix.pthread_mutex_unlock
-import platform.posix.pthread_mutexattr_destroy
 import platform.posix.pthread_mutexattr_init
 import platform.posix.pthread_mutexattr_settype
 import platform.posix.pthread_mutexattr_t
 import platform.posix.timespec
+import kotlin.system.getTimeNanos
 
 internal actual class Lock {
 
-    private val arena = Arena()
-    private val attr: pthread_mutexattr_t = arena.alloc()
-    private val mutex: pthread_mutex_t = arena.alloc()
+    private val attr = cValue<pthread_mutexattr_t>()
+    private val mutex = cValue<pthread_mutex_t>()
 
     init {
-        pthread_mutexattr_init(attr.ptr)
-        pthread_mutexattr_settype(attr.ptr, PTHREAD_MUTEX_RECURSIVE.toInt())
-        pthread_mutex_init(mutex.ptr, attr.ptr)
+        pthread_mutexattr_init(attr)
+        pthread_mutexattr_settype(attr, PTHREAD_MUTEX_RECURSIVE.toInt())
+        pthread_mutex_init(mutex, attr)
     }
 
     actual fun acquire() {
-        pthread_mutex_lock(mutex.ptr)
+        pthread_mutex_lock(mutex)
     }
 
     actual fun release() {
-        pthread_mutex_unlock(mutex.ptr)
+        pthread_mutex_unlock(mutex)
     }
 
-    actual fun destroy() {
-        pthread_mutex_destroy(mutex.ptr)
-        pthread_mutexattr_destroy(attr.ptr)
-        arena.clear()
-    }
-
-    actual fun newCondition(): Condition = ConditionImpl(mutex.ptr)
+    actual fun newCondition(): Condition = ConditionImpl(mutex)
 
     internal class ConditionImpl(
-        private val lockPtr: CPointer<pthread_mutex_t>
+        private val lockPtr: CValue<pthread_mutex_t>
     ) : Condition {
 
-        private val arena = Arena()
-        private val cond: pthread_cond_t = arena.alloc()
+        private val cond = cValue<pthread_cond_t>()
 
         init {
-            pthread_cond_init(cond.ptr, null)
+            pthread_cond_init(cond, null)
         }
 
         override fun await(timeoutNanos: Long) {
             if (timeoutNanos >= 0L) {
-                val a = Arena()
-                try {
-                    val t: timespec = a.alloc()
-                    (getTimeNanos() + timeoutNanos).toTimespec(t)
-                    pthread_cond_timedwait(cond.ptr, lockPtr, t.ptr)
-                } finally {
-                    a.clear()
-                }
+                val t = cValue<timespec>()
+                (getTimeNanos() + timeoutNanos).toTimespec(t)
+                pthread_cond_timedwait(cond, lockPtr, t)
             } else {
-                pthread_cond_wait(cond.ptr, lockPtr)
+                pthread_cond_wait(cond, lockPtr)
             }
         }
 
         override fun signal() {
-            pthread_cond_signal(cond.ptr)
-        }
-
-        override fun destroy() {
-            pthread_cond_destroy(cond.ptr)
-            arena.clear()
+            pthread_cond_signal(cond)
         }
 
         private companion object {
             private const val SECOND_IN_NANOS = 1000000000L
 
-            private fun Long.toTimespec(time: timespec) {
+            private fun Long.toTimespec(time: CValue<timespec>) {
                 val secs = this / SECOND_IN_NANOS
-                time.tv_sec = secs.convert()
-                time.tv_nsec = (this - (secs * SECOND_IN_NANOS)).convert()
+                time.useContents {
+                    tv_sec = secs.convert()
+                    tv_nsec = (this@toTimespec - (secs * SECOND_IN_NANOS)).convert()
+                }
             }
         }
     }


### PR DESCRIPTION
We can use CValue instead of manual alloc with Arena. In this case we don't have to manually dispose the allocated memory. This approach is used by `ktor`. Checked with `valgrind`, all good.