### PR TITLE
Add defaultIfEmpty and switchIfEmpty operator on Observable

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DefaultIfEmpty.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DefaultIfEmpty.kt
@@ -1,34 +1,4 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.disposable.DisposableWrapper
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-
 fun <T> Observable<T>.defaultIfEmpty(defaultValue: T): Observable<T> =
-    observableUnsafe { observer ->
-        val disposableWrapper = DisposableWrapper()
-        observer.onSubscribe(disposableWrapper)
-
-        subscribeSafe(
-            object : ObservableObserver<T>, ObservableCallbacks<T> by observer {
-                private val isEmpty = AtomicReference(true)
-
-                override fun onSubscribe(disposable: Disposable) {
-                    disposableWrapper.set(disposable)
-                }
-
-                override fun onNext(value: T) {
-                    isEmpty.value = false
-                    observer.onNext(value)
-                }
-
-                override fun onComplete() {
-                    if (isEmpty.value) {
-                        observer.onNext(defaultValue)
-                    }
-
-                    observer.onComplete()
-                }
-            }
-        )
-    }
+    switchIfEmpty(observableOf(defaultValue))

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DefaultIfEmpty.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DefaultIfEmpty.kt
@@ -1,0 +1,34 @@
+package com.badoo.reaktive.observable
+
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.DisposableWrapper
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
+
+fun <T> Observable<T>.defaultIfEmpty(defaultValue: T): Observable<T> =
+    observableUnsafe { observer ->
+        val disposableWrapper = DisposableWrapper()
+        observer.onSubscribe(disposableWrapper)
+
+        subscribeSafe(
+            object : ObservableObserver<T>, ObservableCallbacks<T> by observer {
+                private val isEmpty = AtomicReference(true)
+
+                override fun onSubscribe(disposable: Disposable) {
+                    disposableWrapper.set(disposable)
+                }
+
+                override fun onNext(value: T) {
+                    isEmpty.value = false
+                    observer.onNext(value)
+                }
+
+                override fun onComplete() {
+                    if (isEmpty.value) {
+                        observer.onNext(defaultValue)
+                    }
+
+                    observer.onComplete()
+                }
+            }
+        )
+    }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SwitchIfEmpty.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SwitchIfEmpty.kt
@@ -1,0 +1,34 @@
+package com.badoo.reaktive.observable
+
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.DisposableWrapper
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
+
+fun <T> Observable<T>.switchIfEmpty(otherObservable: Observable<T>): Observable<T> =
+    observableUnsafe { observer ->
+        val disposableWrapper = DisposableWrapper()
+        observer.onSubscribe(disposableWrapper)
+
+        subscribeSafe(
+            object : ObservableObserver<T>, ObservableCallbacks<T> by observer {
+                private val isEmpty = AtomicReference(true)
+
+                override fun onSubscribe(disposable: Disposable) {
+                    disposableWrapper.set(disposable)
+                }
+
+                override fun onNext(value: T) {
+                    isEmpty.value = false
+                    observer.onNext(value)
+                }
+
+                override fun onComplete() {
+                    if (isEmpty.value) {
+                        otherObservable.subscribe(this)
+                    } else {
+                        observer.onComplete()
+                    }
+                }
+            }
+        )
+    }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SwitchIfEmpty.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SwitchIfEmpty.kt
@@ -1,10 +1,14 @@
 package com.badoo.reaktive.observable
 
+import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.utils.atomicreference.AtomicReference
 
 fun <T> Observable<T>.switchIfEmpty(otherObservable: Observable<T>): Observable<T> =
+    switchIfEmpty { otherObservable }
+
+fun <T> Observable<T>.switchIfEmpty(otherObservable: () -> Observable<T>): Observable<T> =
     observableUnsafe { observer ->
         val disposableWrapper = DisposableWrapper()
         observer.onSubscribe(disposableWrapper)
@@ -24,7 +28,21 @@ fun <T> Observable<T>.switchIfEmpty(otherObservable: Observable<T>): Observable<
 
                 override fun onComplete() {
                     if (isEmpty.value) {
-                        otherObservable.subscribe(this)
+                        otherObservable().subscribeSafe(
+                            object : ObservableObserver<T>, ErrorCallback by this {
+                                override fun onSubscribe(disposable: Disposable) {
+                                    disposableWrapper.set(disposable)
+                                }
+
+                                override fun onNext(value: T) {
+                                    observer.onNext(value)
+                                }
+
+                                override fun onComplete() {
+                                    observer.onComplete()
+                                }
+                            }
+                        )
                     } else {
                         observer.onComplete()
                     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DefaultIfEmptyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DefaultIfEmptyTest.kt
@@ -1,0 +1,46 @@
+package com.badoo.reaktive.observable
+
+import com.badoo.reaktive.testutils.TestObservable
+import com.badoo.reaktive.testutils.test
+import com.badoo.reaktive.testutils.values
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DefaultIfEmptyTest: UpstreamDownstreamGenericTests by UpstreamDownstreamGenericTests<Int>({ defaultIfEmpty(10) }) {
+
+    @Test
+    fun should_return_default_value_when_source_is_empty() {
+        val source = TestObservable<Int>()
+        val observer = source.defaultIfEmpty(42).test()
+
+        source.onComplete()
+
+        assertEquals(2, observer.events.size)
+        assertEquals(listOf(42), observer.values)
+    }
+
+    @Test
+    fun should_not_return_default_value_when_source_isnot_empty() {
+        val source = TestObservable<Int>()
+        val observer = source.defaultIfEmpty(42).test()
+
+        source.onNext(1)
+        source.onComplete()
+
+        assertEquals(2, observer.events.size)
+        assertEquals(listOf(1), observer.values)
+    }
+
+    @Test
+    fun should_not_return_default_value_when_source_emits_null() {
+        val source = TestObservable<Int?>()
+        val observer = source.defaultIfEmpty(42).test()
+
+        source.onNext(null)
+        source.onComplete()
+
+        assertEquals(2, observer.events.size)
+        assertEquals(listOf(null), observer.values)
+    }
+
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SwitchIfEmptyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SwitchIfEmptyTest.kt
@@ -1,12 +1,15 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.testutils.TestObservable
+import com.badoo.reaktive.testutils.isOnCompleteEvent
 import com.badoo.reaktive.testutils.test
 import com.badoo.reaktive.testutils.values
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
-class SwitchIfEmptyTest: UpstreamDownstreamGenericTests by UpstreamDownstreamGenericTests<Int>({ switchIfEmpty(observableOf(10)) }) {
+class SwitchIfEmptyTest :
+    UpstreamDownstreamGenericTests by UpstreamDownstreamGenericTests<Int>({ switchIfEmpty(observableOf(10)) }) {
 
     @Test
     fun should_switch_streams_when_source_is_empty() {
@@ -43,4 +46,28 @@ class SwitchIfEmptyTest: UpstreamDownstreamGenericTests by UpstreamDownstreamGen
         assertEquals(listOf(null), observer.values)
     }
 
+    @Test
+    fun should_complete_when_both_sources_are_empty() {
+        val source = TestObservable<Int>()
+        val observer = source.switchIfEmpty(observableOfEmpty()).test()
+
+        source.onComplete()
+
+        assertEquals(1, observer.events.size)
+        assertTrue(observer.isOnCompleteEvent(0))
+        assertTrue(observer.values.isEmpty())
+    }
+
+    @Test
+    fun should_switch_streams_when_source_is_empty_using_lambda() {
+        val source = TestObservable<Int>()
+        val otherObservable = observableOf(42)
+
+        val observer = source.switchIfEmpty { otherObservable }.test()
+
+        source.onComplete()
+
+        assertEquals(2, observer.events.size)
+        assertEquals(listOf(42), observer.values)
+    }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SwitchIfEmptyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SwitchIfEmptyTest.kt
@@ -1,0 +1,46 @@
+package com.badoo.reaktive.observable
+
+import com.badoo.reaktive.testutils.TestObservable
+import com.badoo.reaktive.testutils.test
+import com.badoo.reaktive.testutils.values
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SwitchIfEmptyTest: UpstreamDownstreamGenericTests by UpstreamDownstreamGenericTests<Int>({ switchIfEmpty(observableOf(10)) }) {
+
+    @Test
+    fun should_switch_streams_when_source_is_empty() {
+        val source = TestObservable<Int>()
+        val observer = source.switchIfEmpty(observableOf(42)).test()
+
+        source.onComplete()
+
+        assertEquals(2, observer.events.size)
+        assertEquals(listOf(42), observer.values)
+    }
+
+    @Test
+    fun should_not_switch_streams_when_source_isnot_empty() {
+        val source = TestObservable<Int>()
+        val observer = source.switchIfEmpty(observableOf(42)).test()
+
+        source.onNext(1)
+        source.onComplete()
+
+        assertEquals(2, observer.events.size)
+        assertEquals(listOf(1), observer.values)
+    }
+
+    @Test
+    fun should_not_switch_streams_when_source_emits_null() {
+        val source = TestObservable<Int?>()
+        val observer = source.switchIfEmpty(observableOf(42)).test()
+
+        source.onNext(null)
+        source.onComplete()
+
+        assertEquals(2, observer.events.size)
+        assertEquals(listOf(null), observer.values)
+    }
+
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SwitchIfEmptyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SwitchIfEmptyTest.kt
@@ -1,9 +1,6 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.testutils.TestObservable
-import com.badoo.reaktive.testutils.isOnCompleteEvent
-import com.badoo.reaktive.testutils.test
-import com.badoo.reaktive.testutils.values
+import com.badoo.reaktive.testutils.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -69,5 +66,17 @@ class SwitchIfEmptyTest :
 
         assertEquals(2, observer.events.size)
         assertEquals(listOf(42), observer.values)
+    }
+
+    @Test
+    fun should_emit_error_when_lambda_throws() {
+        val error = RuntimeException()
+        val source = TestObservable<Int>()
+        val observer = source.switchIfEmpty { throw error }.test()
+
+        source.onComplete()
+
+        assertEquals(1, observer.events.size)
+        assertTrue(observer.isError(error))
     }
 }


### PR DESCRIPTION
This PR adds the operator `defaultIfEmpty`, which is also available on other [implementations of Rx](http://reactivex.io/documentation/operators/defaultifempty.html)

I will probably create another PR adding the `switchIfEmpty`, is that ok?
Both have the same behavior, but `switchIfEmpty` receives another Observable as parameter instead of a value.