### PR TITLE
Fixed broken Native Lock and Condition

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/BlockingGet.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/BlockingGet.kt
@@ -1,56 +1,60 @@
 package com.badoo.reaktive.single
 
 import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.utils.Lock
 import com.badoo.reaktive.utils.atomicreference.AtomicReference
 import com.badoo.reaktive.utils.synchronized
+import com.badoo.reaktive.utils.useCondition
+import com.badoo.reaktive.utils.useLock
 
-fun <T> Single<T>.blockingGet(): T {
-    val lock = Lock()
-    val condition = lock.newCondition()
-    val result = AtomicReference<BlockingGetResult<T>?>(null, true)
-    val upstreamDisposable = AtomicReference<Disposable?>(null, true)
+fun <T> Single<T>.blockingGet(): T =
+    useLock { lock ->
+        lock.useCondition { condition ->
+            val result = AtomicReference<BlockingGetResult<T>?>(null, true)
+            val upstreamDisposable = AtomicReference<Disposable?>(null, true)
 
-    subscribe(
-        object : SingleObserver<T> {
-            override fun onSubscribe(disposable: Disposable) {
-                upstreamDisposable.value = disposable
-            }
+            subscribe(
+                object : SingleObserver<T> {
+                    override fun onSubscribe(disposable: Disposable) {
+                        upstreamDisposable.value = disposable
+                    }
 
-            override fun onSuccess(value: T) {
-                lock.synchronized {
-                    result.value = BlockingGetResult.Success(value)
-                    condition.signal()
+                    override fun onSuccess(value: T) {
+                        lock.synchronized {
+                            result.value = BlockingGetResult.Success(value)
+                            condition.signal()
+                        }
+                    }
+
+                    override fun onError(error: Throwable) {
+                        lock.synchronized {
+                            result.value = BlockingGetResult.Error(error)
+                            condition.signal()
+                        }
+                    }
+                }
+            )
+
+            lock.synchronized {
+                while (result.value == null) {
+                    try {
+                        condition.await()
+                    } catch (e: Throwable) {
+                        upstreamDisposable.value?.dispose()
+                        throw e
+                    }
                 }
             }
 
-            override fun onError(error: Throwable) {
-                lock.synchronized {
-                    result.value = BlockingGetResult.Error(error)
-                    condition.signal()
+            result
+                .value!!
+                .let {
+                    when (it) {
+                        is BlockingGetResult.Success -> it.value
+                        is BlockingGetResult.Error -> throw it.error
+                    }
                 }
-            }
-        }
-    )
-
-    lock.synchronized {
-        while (result.value == null) {
-            try {
-                condition.await()
-            } catch (e: Throwable) {
-                upstreamDisposable.value?.dispose()
-                throw e
-            }
         }
     }
-
-    result.value!!.also {
-        when (it) {
-            is BlockingGetResult.Success -> return it.value
-            is BlockingGetResult.Error -> throw it.error
-        }
-    }
-}
 
 private sealed class BlockingGetResult<out T> {
     class Success<out T>(val value: T) : BlockingGetResult<T>()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/Condition.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/Condition.kt
@@ -5,4 +5,6 @@ internal interface Condition {
     fun await(timeoutNanos: Long = -1L)
 
     fun signal()
+
+    fun destroy()
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/ConditionExt.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/ConditionExt.kt
@@ -1,0 +1,8 @@
+package com.badoo.reaktive.utils
+
+internal inline fun <T> Condition.use(block: (Condition) -> T): T =
+    try {
+        block(this)
+    } finally {
+        destroy()
+    }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/Lock.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/Lock.kt
@@ -6,5 +6,7 @@ internal expect class Lock constructor() {
 
     fun release()
 
+    fun destroy()
+
     fun newCondition(): Condition
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/LockExt.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/LockExt.kt
@@ -8,3 +8,14 @@ internal inline fun Lock.synchronized(block: () -> Unit) {
         release()
     }
 }
+
+internal inline fun <T> Lock.use(block: (Lock) -> T): T =
+    try {
+        block(this)
+    } finally {
+        destroy()
+    }
+
+internal inline fun <T> useLock(block: (Lock) -> T): T = Lock().use(block)
+
+internal inline fun <T> Lock.useCondition(block: (Condition) -> T): T = newCondition().use(block)

--- a/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/Lock.kt
+++ b/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/Lock.kt
@@ -10,6 +10,10 @@ internal actual class Lock {
         // no-op
     }
 
+    actual fun destroy() {
+        // no-op
+    }
+
     actual fun newCondition(): Condition = condition
 
     private companion object {
@@ -20,6 +24,10 @@ internal actual class Lock {
                 }
 
                 override fun signal() {
+                    // no-op
+                }
+
+                override fun destroy() {
                     // no-op
                 }
             }

--- a/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/Lock.kt
+++ b/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/Lock.kt
@@ -14,6 +14,10 @@ internal actual class Lock {
         delegate.unlock()
     }
 
+    actual fun destroy() {
+        // no-op
+    }
+
     actual fun newCondition(): Condition = ConditionImpl(this@Lock.delegate.newCondition())
 
     private class ConditionImpl(
@@ -29,6 +33,10 @@ internal actual class Lock {
 
         override fun signal() {
             delegate.signalAll()
+        }
+
+        override fun destroy() {
+            // no-op
         }
     }
 }

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/looperthread/LooperThread.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/looperthread/LooperThread.kt
@@ -27,7 +27,7 @@ internal class LooperThread {
 
     fun destroy() {
         isDestroyed.value = 1
-        queue.clear()
+        queue.destroy()
         worker.requestTermination(processScheduledJobs = false)
     }
 

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/looperthread/MessageQueue.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/looperthread/MessageQueue.kt
@@ -67,6 +67,12 @@ internal class MessageQueue {
         }
     }
 
+    fun destroy() {
+        clear()
+        condition.destroy()
+        lock.destroy()
+    }
+
     private class Entry(
         val token: Any,
         val startTimeNanos: Long,


### PR DESCRIPTION
Well, after further investigations it appears to be impossible to avoid manual memory freeing when using `cinterop` from Kotlin. The [implementation](https://github.com/ktorio/ktor/blob/master/ktor-utils/posix/src/io/ktor/util/LockNative.kt) from `ktor` does not work either. I have raised an [issue](https://github.com/ktorio/ktor/issues/1135) for them. Reverted the commit fafa90e1ec82b896148eb30748235d54d89123ec and updated the code a bit.
Fixes https://github.com/badoo/Reaktive/issues/62