### PR TITLE
Make AtomicReference public

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomicreference/AtomicReference.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomicreference/AtomicReference.kt
@@ -1,6 +1,6 @@
 package com.badoo.reaktive.utils.atomicreference
 
-internal expect class AtomicReference<T>(
+expect class AtomicReference<T>(
     initialValue: T,
     autoFreeze: Boolean = false
 ) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomicreference/AtomicReferenceExt.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomicreference/AtomicReferenceExt.kt
@@ -1,24 +1,24 @@
 package com.badoo.reaktive.utils.atomicreference
 
-internal inline fun <T> AtomicReference<T>.getAndUpdate(update: (T) -> T): T {
-    var var2: T
+inline fun <T> AtomicReference<T>.getAndUpdate(update: (T) -> T): T {
+    var prev: T
     do {
-        var2 = value
-    } while (!compareAndSet(var2, update(var2)))
+        prev = value
+    } while (!compareAndSet(prev, update(prev)))
 
-    return var2
+    return prev
 }
 
-internal inline fun <T> AtomicReference<T>.updateAndGet(update: (T) -> T): T {
-    var var3: T
+inline fun <T> AtomicReference<T>.updateAndGet(update: (T) -> T): T {
+    var next: T
     do {
-        val var2 = value
-        var3 = update(var2)
-    } while (!compareAndSet(var2, var3))
+        val prev = value
+        next = update(prev)
+    } while (!compareAndSet(prev, next))
 
-    return var3
+    return next
 }
 
-internal inline fun <T> AtomicReference<T>.update(update: (T) -> T) {
+inline fun <T> AtomicReference<T>.update(update: (T) -> T) {
     getAndUpdate(update)
 }

--- a/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/atomicreference/AtomicReference.kt
+++ b/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/atomicreference/AtomicReference.kt
@@ -1,6 +1,6 @@
 package com.badoo.reaktive.utils.atomicreference
 
-internal actual class AtomicReference<T> actual constructor(
+actual class AtomicReference<T> actual constructor(
     initialValue: T,
     autoFreeze: Boolean
 ) {

--- a/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/atomicreference/AtomicReference.kt
+++ b/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/atomicreference/AtomicReference.kt
@@ -1,6 +1,6 @@
 package com.badoo.reaktive.utils.atomicreference
 
-internal actual class AtomicReference<T> actual constructor(
+actual class AtomicReference<T> actual constructor(
     initialValue: T,
     autoFreeze: Boolean
 ) {

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/atomicreference/AtomicReference.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/atomicreference/AtomicReference.kt
@@ -2,7 +2,7 @@ package com.badoo.reaktive.utils.atomicreference
 
 import com.badoo.reaktive.utils.freeze
 
-internal actual class AtomicReference<T> actual constructor(
+actual class AtomicReference<T> actual constructor(
     initialValue: T,
     private val autoFreeze: Boolean
 ) {


### PR DESCRIPTION
Tried to use Reaktive in a multiplatform project and immediately noticed that AtomicReference is needed. Could not find any good existing library, [AtomicFU](https://github.com/Kotlin/kotlinx.atomicfu) is not thread safe in Native.