### PR TITLE
Introduce JsPlugin for configuration and run tests on NodeJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /out
 .DS_Store*
 */build
+*/node_modules
+*/package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
           - android-28
       env: MP_TARGET=COMMON
       install: true
-      script: ./gradlew reaktive:check reaktive:runMocha rxjava2-interop:check -DMP_TARGET=$MP_TARGET
+      script: ./gradlew reaktive:check rxjava2-interop:check -DMP_TARGET=$MP_TARGET
     - os: osx
       osx_image: xcode10.2
       language: java

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
           - android-28
       env: MP_TARGET=COMMON
       install: true
-      script: ./gradlew reaktive:check rxjava2-interop:check -DMP_TARGET=$MP_TARGET
+      script: ./gradlew reaktive:check reaktive:runMocha rxjava2-interop:check -DMP_TARGET=$MP_TARGET
     - os: osx
       osx_image: xcode10.2
       language: java

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 buildscript {
-    ext.kotlin_version = '1.3.31'
     ext.reaktive_version = '1.0.0-alpha3'
     ext.reaktive_group_id = 'com.github.badoo.reaktive'
 
@@ -10,7 +9,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
         classpath 'org.jetbrains.kotlin:kotlin-frontend-plugin:0.0.45'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.30'
+    ext.kotlin_version = '1.3.31'
     ext.reaktive_version = '1.0.0-alpha3'
     ext.reaktive_group_id = 'com.github.badoo.reaktive'
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    google()
+    jcenter()
+}
+
+dependencies {
+    implementation("com.moowork.gradle:gradle-node-plugin:1.3.1")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.31")
+    implementation("com.android.tools.build:gradle:3.3.2")
+}

--- a/buildSrc/src/main/kotlin/JsPlugin.kt
+++ b/buildSrc/src/main/kotlin/JsPlugin.kt
@@ -1,8 +1,10 @@
+import com.moowork.gradle.node.NodeExtension
 import com.moowork.gradle.node.NodePlugin
 import com.moowork.gradle.node.npm.NpmTask
 import com.moowork.gradle.node.task.NodeTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.api.internal.AbstractTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.InputFile
@@ -40,7 +42,20 @@ abstract class JsPlugin : Plugin<Project> {
     }
 
     private fun configureJsTest(target: Project) {
+        // workaround for https://github.com/srs/gradle-node-plugin/issues/301
+        target.repositories.whenObjectAdded {
+            if (this is IvyArtifactRepository) {
+                metadataSources {
+                    artifact()
+                }
+            }
+        }
+
         target.pluginManager.apply(NodePlugin::class.java)
+        target.extensions.configure(NodeExtension::class.java) {
+            download = true
+            version = "12.2.0"
+        }
 
         val dependenciesTaskProvider = target.tasks.register("installJsTestDependencies", NpmTask::class.java) {
             setArgs(listOf("install", "kotlin", "kotlin-test", "mocha"))

--- a/buildSrc/src/main/kotlin/JsPlugin.kt
+++ b/buildSrc/src/main/kotlin/JsPlugin.kt
@@ -73,11 +73,15 @@ abstract class JsPlugin : Plugin<Project> {
 
         val compileTestJsTask = target.tasks.named("compileTestKotlinJs", Kotlin2JsCompile::class.java)
 
-        target.tasks.register("runMocha", NodeTask::class.java) {
+        val runMochaTask = target.tasks.register("runMocha", NodeTask::class.java) {
             dependsOn(dependenciesTask, compileTestJsTask, nodeModuleTask)
             setScript(project.file("node_modules/mocha/bin/mocha"))
             // NodeTask does not support lazy configuration through properties
             setArgs(listOf(compileTestJsTask.get().outputFile.relativeTo(project.projectDir)))
+        }
+
+        target.tasks.named("check") {
+            dependsOn(runMochaTask)
         }
     }
 

--- a/buildSrc/src/main/kotlin/JsPlugin.kt
+++ b/buildSrc/src/main/kotlin/JsPlugin.kt
@@ -58,7 +58,7 @@ abstract class JsPlugin : Plugin<Project> {
         }
 
         val dependenciesTaskProvider = target.tasks.register("installJsTestDependencies", NpmTask::class.java) {
-            setArgs(listOf("install", "kotlin", "kotlin-test", "mocha"))
+            setArgs(listOf("install", "kotlin@1.3.31", "kotlin-test@1.3.31", "mocha@6.1.4"))
         }
 
         val nodeModuleTaskProvider = target.tasks.register("populateNodeModule", PopulateNodeModuleTask::class.java) {

--- a/buildSrc/src/main/kotlin/JsPlugin.kt
+++ b/buildSrc/src/main/kotlin/JsPlugin.kt
@@ -4,7 +4,6 @@ import com.moowork.gradle.node.task.NodeTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.internal.AbstractTask
-import org.gradle.api.internal.provider.Providers
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
@@ -48,9 +47,7 @@ abstract class JsPlugin : Plugin<Project> {
         }
 
         val nodeModuleTaskProvider = target.tasks.register("populateNodeModule", PopulateNodeModuleTask::class.java) {
-            val compileJsTasks = target.tasks.named("compileKotlinJs", Kotlin2JsCompile::class.java)
-            input.set(compileJsTasks.flatMap { Providers.of(it.outputFile) })
-            output.set(compileJsTasks.flatMap { Providers.of(it.project.file("node_modules/${it.outputFile.name}")) })
+            input.set(target.tasks.named("compileKotlinJs", Kotlin2JsCompile::class.java).map { it.outputFile })
         }
 
         val compileTestJsTask = target.tasks.named("compileTestKotlinJs", Kotlin2JsCompile::class.java)
@@ -78,6 +75,10 @@ abstract class JsPlugin : Plugin<Project> {
 
         @get:OutputFile
         abstract val output: Property<File>
+
+        init {
+            output.set(input.map { project.file("node_modules/${it.name}") })
+        }
 
         @TaskAction
         open fun populate() {

--- a/buildSrc/src/main/kotlin/JsPlugin.kt
+++ b/buildSrc/src/main/kotlin/JsPlugin.kt
@@ -21,11 +21,17 @@ abstract class JsPlugin : Plugin<Project> {
     private fun configureJsCompilation(target: Project) {
         target.extensions.configure(KotlinMultiplatformExtension::class.java) {
             targetFromPreset(presets.getByName("js"), "js")
-            sourceSets.getByName("jsMain").dependencies {
-                implementation(kotlin("stdlib-js"))
+            sourceSets.getByName("jsMain") {
+                dependsOn(sourceSets.getByName("jvmJsCommonMain"))
+                dependencies {
+                    implementation(kotlin("stdlib-js"))
+                }
             }
-            sourceSets.getByName("jsTest").dependencies {
-                implementation(kotlin("test-js"))
+            sourceSets.getByName("jsTest") {
+                dependsOn(sourceSets.getByName("jvmJsCommonTest"))
+                dependencies {
+                    implementation(kotlin("test-js"))
+                }
             }
         }
         target.tasks.named("compileKotlinJs", Kotlin2JsCompile::class.java) {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,0 +1,7 @@
+object Versions {
+
+    const val kotlin = "1.3.31"
+    const val mocha = "6.1.4"
+    const val node = "12.2.0"
+
+}

--- a/reaktive/build.gradle
+++ b/reaktive/build.gradle
@@ -63,9 +63,9 @@ if (target.isCommon() || target.isMeta()) {
             }
 
             jvmMain.dependsOn jvmCommonMain
-            androidMain.dependsOn jvmCommonMain
-
             jvmTest.dependsOn jvmCommonTest
+
+            androidMain.dependsOn jvmCommonMain
             androidTest.dependsOn jvmCommonTest
 
             nativeCommonMain.dependsOn commonMain

--- a/reaktive/build.gradle
+++ b/reaktive/build.gradle
@@ -16,7 +16,6 @@ kotlin {
         commonTest {
             dependencies {
                 implementation 'org.jetbrains.kotlin:kotlin-test'
-                implementation 'org.jetbrains.kotlin:kotlin-test-junit'
                 implementation 'org.jetbrains.kotlin:kotlin-test-common'
                 implementation 'org.jetbrains.kotlin:kotlin-test-annotations-common'
             }
@@ -44,7 +43,6 @@ if (target.isCommon() || target.isMeta()) {
             // fromPreset(presets.jvm, 'jvmCommon')
             fromPreset(presets.jvm, 'jvm')
             fromPreset(presets.android, 'android')
-            fromPreset(presets.js, 'js')
             // fromPreset(presets.linuxX64, 'nativeCommon')
             fromPreset(presets.linuxX64, 'linuxX64')
             fromPreset(presets.linuxArm32Hfp, 'linuxArm32Hfp')
@@ -56,29 +54,19 @@ if (target.isCommon() || target.isMeta()) {
                     implementation 'org.jetbrains.kotlin:kotlin-stdlib'
                 }
             }
+            
+            jvmCommonTest {
+                dependsOn commonTest
+                dependencies {
+                    implementation 'org.jetbrains.kotlin:kotlin-test-junit'
+                }
+            }
 
             jvmMain.dependsOn jvmCommonMain
             androidMain.dependsOn jvmCommonMain
 
-            jsMain {
-                dependencies {
-                    implementation 'org.jetbrains.kotlin:kotlin-stdlib-js'
-                }
-
-                compileKotlinJs {
-                    kotlinOptions.metaInfo = true
-                    kotlinOptions.sourceMap = true
-                    kotlinOptions.verbose = true
-                    kotlinOptions.main = 'call'
-                    kotlinOptions.moduleKind = 'umd'
-                }
-            }
-
-            jsTest {
-                dependencies {
-                    implementation 'org.jetbrains.kotlin:kotlin-test-js'
-                }
-            }
+            jvmTest.dependsOn jvmCommonTest
+            androidTest.dependsOn jvmCommonTest
 
             nativeCommonMain.dependsOn commonMain
             nativeCommonTest.dependsOn commonTest
@@ -97,6 +85,8 @@ if (target.isCommon() || target.isMeta()) {
             publishLibraryVariants('release', 'debug')
         }
     }
+
+    apply plugin: JsPlugin
 }
 
 if (target.isIos() || target.isMeta()) {

--- a/reaktive/build.gradle
+++ b/reaktive/build.gradle
@@ -10,14 +10,14 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-common'
+                implementation kotlin('stdlib-common')
             }
         }
         commonTest {
             dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-test'
-                implementation 'org.jetbrains.kotlin:kotlin-test-common'
-                implementation 'org.jetbrains.kotlin:kotlin-test-annotations-common'
+                implementation kotlin('test')
+                implementation kotlin('test-common')
+                implementation kotlin('test-annotations-common')
             }
         }
     }
@@ -51,14 +51,14 @@ if (target.isCommon() || target.isMeta()) {
         sourceSets {
             jvmCommonMain {
                 dependencies {
-                    implementation 'org.jetbrains.kotlin:kotlin-stdlib'
+                    implementation kotlin('stdlib')
                 }
             }
             
             jvmCommonTest {
                 dependsOn commonTest
                 dependencies {
-                    implementation 'org.jetbrains.kotlin:kotlin-test-junit'
+                    implementation kotlin('test-junit')
                 }
             }
 

--- a/sample-js-browser-app/build.gradle
+++ b/sample-js-browser-app/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-js:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-js:${Versions.kotlin}"
     compile project(':reaktive')
 }
 
@@ -12,21 +12,21 @@ compileKotlin2Js {
     kotlinOptions.metaInfo = true
     kotlinOptions.sourceMap = true
     kotlinOptions.verbose = true
-    kotlinOptions.main = "call"
-    kotlinOptions.moduleKind = "umd"
+    kotlinOptions.main = 'call'
+    kotlinOptions.moduleKind = 'umd'
 }
 
 kotlinFrontend {
-    downloadNodeJsVersion = "latest"
+    downloadNodeJsVersion = 'latest'
 
     webpackBundle {
-        bundleName = "main"
+        bundleName = 'main'
         sourceMapEnabled = true
         contentPath = file('src/main/web')
-        publicPath = "/"
+        publicPath = '/'
         port = 8088
-        proxyUrl = ""
-        stats = "errors-only"
+        proxyUrl = ''
+        stats = 'errors-only'
     }
 }
 


### PR DESCRIPTION
`jsTest` task does not run tests.

To run test we need to install `mocha` (probably any JS test engine is fine) and launch it manually through `node mocha reaktive-test.js` call. 

Fixes https://github.com/badoo/Reaktive/issues/53