### PR TITLE
Better callbacks interface segregation

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/CompleteCallback.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/CompleteCallback.kt
@@ -1,0 +1,12 @@
+package com.badoo.reaktive.base
+
+/**
+ * A common callback for listening for completions
+ */
+interface CompleteCallback {
+
+    /**
+     * Notifies the host (typically an [Observer]) about completion
+     */
+    fun onComplete()
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/Consumer.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/Consumer.kt
@@ -1,0 +1,6 @@
+package com.badoo.reaktive.base
+
+/**
+ * See [ValueCallback]
+ */
+typealias Consumer<T> = ValueCallback<T>

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/SuccessCallback.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/SuccessCallback.kt
@@ -1,0 +1,12 @@
+package com.badoo.reaktive.base
+
+/**
+ * A common callback for listening for completions with a value
+ */
+interface SuccessCallback<in T> {
+
+    /**
+     * Notifies the host (typically an [Observer]) about completion with a value
+     */
+    fun onSuccess(value: T)
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/ValueCallback.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/ValueCallback.kt
@@ -1,0 +1,12 @@
+package com.badoo.reaktive.base
+
+/**
+ * A common callback for listening for values
+ */
+interface ValueCallback<in T> {
+
+    /**
+     * Delivers values to the host (typically an [Observer])
+     */
+    fun onNext(value: T)
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/CompletableCallbacks.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/CompletableCallbacks.kt
@@ -1,16 +1,10 @@
 package com.badoo.reaktive.completable
 
+import com.badoo.reaktive.base.CompleteCallback
 import com.badoo.reaktive.base.ErrorCallback
-import com.badoo.reaktive.base.Observer
 
 /**
  * Callbacks for [Completable] source.
- * See [Completable] and [ErrorCallback] for more information.
+ * See [Completable], [CompleteCallback] and [ErrorCallback] for more information.
  */
-interface CompletableCallbacks : ErrorCallback {
-
-    /**
-     * Notifies the host (typically an [Observer]) about completion
-     */
-    fun onComplete()
-}
+interface CompletableCallbacks : CompleteCallback, ErrorCallback

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/DoOnBefore.kt
@@ -1,5 +1,6 @@
 package com.badoo.reaktive.completable
 
+import com.badoo.reaktive.base.CompleteCallback
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
@@ -46,7 +47,7 @@ fun Completable.doOnBeforeError(consumer: (Throwable) -> Unit): Completable =
         observer.onSubscribe(disposableWrapper)
 
         subscribeSafe(
-            object : CompletableObserver, CompletableCallbacks by observer {
+            object : CompletableObserver, CompleteCallback by observer {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DoOnBefore.kt
@@ -1,10 +1,12 @@
 package com.badoo.reaktive.maybe
 
+import com.badoo.reaktive.base.CompleteCallback
+import com.badoo.reaktive.base.ErrorCallback
+import com.badoo.reaktive.base.SuccessCallback
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.wrap
-import com.badoo.reaktive.single.SingleCallbacks
 import com.badoo.reaktive.utils.atomicreference.AtomicReference
 
 fun <T> Maybe<T>.doOnBeforeSubscribe(action: (Disposable) -> Unit): Maybe<T> =
@@ -47,7 +49,7 @@ fun <T> Maybe<T>.doOnBeforeComplete(action: () -> Unit): Maybe<T> =
         observer.onSubscribe(disposableWrapper)
 
         subscribeSafe(
-            object : MaybeObserver<T>, SingleCallbacks<T> by observer {
+            object : MaybeObserver<T>, SuccessCallback<T> by observer, ErrorCallback by observer {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }
@@ -66,7 +68,7 @@ fun <T> Maybe<T>.doOnBeforeError(consumer: (Throwable) -> Unit): Maybe<T> =
         observer.onSubscribe(disposableWrapper)
 
         subscribeSafe(
-            object : MaybeObserver<T>, MaybeCallbacks<T> by observer {
+            object : MaybeObserver<T>, SuccessCallback<T> by observer, CompleteCallback by observer {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/MaybeCallbacks.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/MaybeCallbacks.kt
@@ -1,10 +1,10 @@
 package com.badoo.reaktive.maybe
 
+import com.badoo.reaktive.base.SuccessCallback
 import com.badoo.reaktive.completable.CompletableCallbacks
-import com.badoo.reaktive.single.SingleCallbacks
 
 /**
  * Callbacks for [Maybe] source
- * See [Maybe], [CompletableCallbacks] and [SingleCallbacks] for more information.
+ * See [Maybe], [SuccessCallback] and [CompletableCallbacks] for more information.
  */
-interface MaybeCallbacks<in T> : CompletableCallbacks, SingleCallbacks<T>
+interface MaybeCallbacks<in T> : SuccessCallback<T>, CompletableCallbacks

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Transform.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Transform.kt
@@ -1,5 +1,6 @@
 package com.badoo.reaktive.maybe
 
+import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 
 internal inline fun <T, R> Maybe<T>.transform(
@@ -7,7 +8,7 @@ internal inline fun <T, R> Maybe<T>.transform(
 ): Maybe<R> =
     maybe { emitter ->
         subscribeSafe(
-            object : MaybeObserver<T> {
+            object : MaybeObserver<T>, CompletableCallbacks by emitter {
                 private val onSuccessFunction = emitter::onSuccess
                 private val onCompleteFunction = emitter::onComplete
 
@@ -21,14 +22,6 @@ internal inline fun <T, R> Maybe<T>.transform(
                     } catch (e: Throwable) {
                         emitter.onError(e)
                     }
-                }
-
-                override fun onComplete() {
-                    emitter.onComplete()
-                }
-
-                override fun onError(error: Throwable) {
-                    emitter.onError(error)
                 }
             }
         )

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DoOnBefore.kt
@@ -1,5 +1,9 @@
 package com.badoo.reaktive.observable
 
+import com.badoo.reaktive.base.CompleteCallback
+import com.badoo.reaktive.base.ErrorCallback
+import com.badoo.reaktive.base.ValueCallback
+import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.wrap
@@ -26,7 +30,7 @@ fun <T> Observable<T>.doOnBeforeNext(consumer: (T) -> Unit): Observable<T> =
         observer.onSubscribe(disposableWrapper)
 
         subscribeSafe(
-            object : ObservableObserver<T>, ObservableCallbacks<T> by observer {
+            object : ObservableObserver<T>, CompletableCallbacks by observer {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }
@@ -45,7 +49,7 @@ fun <T> Observable<T>.doOnBeforeComplete(action: () -> Unit): Observable<T> =
         observer.onSubscribe(disposableWrapper)
 
         subscribeSafe(
-            object : ObservableObserver<T>, ObservableCallbacks<T> by observer {
+            object : ObservableObserver<T>, ValueCallback<T> by observer, ErrorCallback by observer {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }
@@ -64,7 +68,7 @@ fun <T> Observable<T>.doOnBeforeError(consumer: (Throwable) -> Unit): Observable
         observer.onSubscribe(disposableWrapper)
 
         subscribeSafe(
-            object : ObservableObserver<T>, ObservableCallbacks<T> by observer {
+            object : ObservableObserver<T>, ValueCallback<T> by observer, CompleteCallback by observer {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }
@@ -83,7 +87,7 @@ fun <T> Observable<T>.doOnBeforeTerminate(action: () -> Unit): Observable<T> =
         observer.onSubscribe(disposableWrapper)
 
         subscribeSafe(
-            object : ObservableObserver<T>, ObservableCallbacks<T> by observer {
+            object : ObservableObserver<T>, ValueCallback<T> by observer {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }
@@ -130,7 +134,7 @@ fun <T> Observable<T>.doOnBeforeFinally(action: () -> Unit): Observable<T> =
         observer.onSubscribe(disposableWrapper.wrap(onBeforeDispose = ::onFinally))
 
         subscribeSafe(
-            object : ObservableObserver<T>, ObservableCallbacks<T> by observer {
+            object : ObservableObserver<T>, ValueCallback<T> by observer {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMap.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMap.kt
@@ -2,6 +2,7 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.Observer
+import com.badoo.reaktive.base.ValueCallback
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
@@ -20,10 +21,7 @@ fun <T, R> Observable<T>.flatMap(mapper: (T) -> Observable<R>): Observable<R> =
                 private val activeSourceCount = AtomicReference(1)
 
                 private val mappedObserver =
-                    object : ObservableObserver<R>, Observer by this, CompletableCallbacks by this {
-                        override fun onNext(value: R) {
-                            serializedEmitter.onNext(value)
-                        }
+                    object : ObservableObserver<R>, Observer by this, CompletableCallbacks by this, ValueCallback<R> by serializedEmitter {
                     }
 
                 override fun onSubscribe(disposable: Disposable) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObservableCallbacks.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObservableCallbacks.kt
@@ -1,12 +1,10 @@
 package com.badoo.reaktive.observable
 
+import com.badoo.reaktive.base.ValueCallback
 import com.badoo.reaktive.completable.CompletableCallbacks
 
 /**
  * Callbacks for [Observable] source.
- * See [CompletableCallbacks] for more information.
+ * See [ValueCallback] and [CompletableCallbacks] for more information.
  */
-interface ObservableCallbacks<in T> : CompletableCallbacks {
-
-    fun onNext(value: T)
-}
+interface ObservableCallbacks<in T> : ValueCallback<T>, CompletableCallbacks

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/AsMaybe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/AsMaybe.kt
@@ -1,13 +1,15 @@
 package com.badoo.reaktive.single
 
+import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.Observer
+import com.badoo.reaktive.base.SuccessCallback
 import com.badoo.reaktive.maybe.Maybe
 import com.badoo.reaktive.maybe.maybeUnsafe
 
 fun <T> Single<T>.asMaybe(): Maybe<T> =
     maybeUnsafe { observer ->
         subscribeSafe(
-            object : SingleObserver<T>, Observer by observer, SingleCallbacks<T> by observer {
+            object : SingleObserver<T>, Observer by observer, SuccessCallback<T> by observer, ErrorCallback by observer {
             }
         )
     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/DoOnBefore.kt
@@ -1,5 +1,7 @@
 package com.badoo.reaktive.single
 
+import com.badoo.reaktive.base.ErrorCallback
+import com.badoo.reaktive.base.SuccessCallback
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.wrap
@@ -11,7 +13,7 @@ fun <T> Single<T>.doOnBeforeSubscribe(action: (Disposable) -> Unit): Single<T> =
         observer.onSubscribe(disposableWrapper)
 
         subscribeSafe(
-            object : SingleObserver<T> by observer {
+            object : SingleObserver<T>, SingleCallbacks<T> by observer {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                     action(disposable)
@@ -26,7 +28,7 @@ fun <T> Single<T>.doOnBeforeSuccess(consumer: (T) -> Unit): Single<T> =
         observer.onSubscribe(disposableWrapper)
 
         subscribeSafe(
-            object : SingleObserver<T> by observer {
+            object : SingleObserver<T>, ErrorCallback by observer {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }
@@ -45,7 +47,7 @@ fun <T> Single<T>.doOnBeforeError(consumer: (Throwable) -> Unit): Single<T> =
         observer.onSubscribe(disposableWrapper)
 
         subscribeSafe(
-            object : SingleObserver<T> by observer {
+            object : SingleObserver<T>, SuccessCallback<T> by observer {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }
@@ -64,7 +66,7 @@ fun <T> Single<T>.doOnBeforeTerminate(action: () -> Unit): Single<T> =
         observer.onSubscribe(disposableWrapper)
 
         subscribeSafe(
-            object : SingleObserver<T> by observer {
+            object : SingleObserver<T> {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }
@@ -88,7 +90,7 @@ fun <T> Single<T>.doOnBeforeDispose(action: () -> Unit): Single<T> =
         observer.onSubscribe(disposableWrapper.wrap(onBeforeDispose = action))
 
         subscribeSafe(
-            object : SingleObserver<T> by observer {
+            object : SingleObserver<T>, SingleCallbacks<T> by observer {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }
@@ -111,7 +113,7 @@ fun <T> Single<T>.doOnBeforeFinally(action: () -> Unit): Single<T> =
         observer.onSubscribe(disposableWrapper.wrap(onBeforeDispose = ::onFinally))
 
         subscribeSafe(
-            object : SingleObserver<T> by observer {
+            object : SingleObserver<T> {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SingleCallbacks.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SingleCallbacks.kt
@@ -1,12 +1,10 @@
 package com.badoo.reaktive.single
 
 import com.badoo.reaktive.base.ErrorCallback
+import com.badoo.reaktive.base.SuccessCallback
 
 /**
  * Callbacks for [Single] source.
- * See [Single], [SingleCallbacks] and [ErrorCallback] for more information.
+ * See [Single], [SuccessCallback] and [ErrorCallback] for more information.
  */
-interface SingleCallbacks<in T> : ErrorCallback {
-
-    fun onSuccess(value: T)
-}
+interface SingleCallbacks<in T> : SuccessCallback<T>, ErrorCallback


### PR DESCRIPTION
Extracted `onNext`, `onSuccess` and `onComplete` callbacks to a separate interfaces. Added `Consumer` typealias. Now we can depend only on what we really need, e,g, we can pass an `Observable` or a `Subject` to a function accepting just `Consumer` without any extra allocations. Will be useful if we will be migrating `MviCore` to `Reaktive`.