### PR TITLE
Tests for doOnBeforeXxx

### DIFF
--- a/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/completable/DefaultCompletableObserver.kt
+++ b/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/completable/DefaultCompletableObserver.kt
@@ -1,0 +1,16 @@
+package com.badoo.reaktive.test.completable
+
+import com.badoo.reaktive.completable.CompletableObserver
+import com.badoo.reaktive.disposable.Disposable
+
+interface DefaultCompletableObserver : CompletableObserver {
+
+    override fun onSubscribe(disposable: Disposable) {
+    }
+
+    override fun onComplete() {
+    }
+
+    override fun onError(error: Throwable) {
+    }
+}

--- a/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/completable/TestCompletableObserverExt.kt
+++ b/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/completable/TestCompletableObserverExt.kt
@@ -3,7 +3,7 @@ package com.badoo.reaktive.test.completable
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.test.completable.TestCompletableObserver.Event
 
-val TestCompletableObserver.isCompleted: Boolean
+val TestCompletableObserver.isComplete: Boolean
     get() = (events.count { it is Event.OnComplete } == 1) && events.none { it is Event.OnError }
 
 val TestCompletableObserver.isError: Boolean

--- a/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/maybe/DefaultMaybeObserver.kt
+++ b/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/maybe/DefaultMaybeObserver.kt
@@ -1,0 +1,19 @@
+package com.badoo.reaktive.test.maybe
+
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.maybe.MaybeObserver
+
+interface DefaultMaybeObserver<T> : MaybeObserver<T> {
+
+    override fun onSubscribe(disposable: Disposable) {
+    }
+
+    override fun onSuccess(value: T) {
+    }
+
+    override fun onComplete() {
+    }
+
+    override fun onError(error: Throwable) {
+    }
+}

--- a/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/observable/DefaultObservableObserver.kt
+++ b/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/observable/DefaultObservableObserver.kt
@@ -1,0 +1,19 @@
+package com.badoo.reaktive.test.observable
+
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.observable.ObservableObserver
+
+interface DefaultObservableObserver<T> : ObservableObserver<T> {
+
+    override fun onSubscribe(disposable: Disposable) {
+    }
+
+    override fun onNext(value: T) {
+    }
+
+    override fun onComplete() {
+    }
+
+    override fun onError(error: Throwable) {
+    }
+}

--- a/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/observable/TestObservableObserverExt.kt
+++ b/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/observable/TestObservableObserverExt.kt
@@ -18,7 +18,7 @@ fun TestObservableObserver<*>.getOnErrorEvent(index: Int): Event.OnError =
 fun TestObservableObserver<*>.getOnErrorValue(index: Int): Throwable =
     getOnErrorEvent(index).error
 
-val TestObservableObserver<*>.isCompleted: Boolean
+val TestObservableObserver<*>.isComplete: Boolean
     get() = (events.count { it is Event.OnComplete } == 1) && events.none { it is Event.OnError }
 
 val TestObservableObserver<*>.isError: Boolean

--- a/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/single/DefaultSingleObserver.kt
+++ b/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/single/DefaultSingleObserver.kt
@@ -1,0 +1,16 @@
+package com.badoo.reaktive.test.single
+
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.single.SingleObserver
+
+interface DefaultSingleObserver<T> : SingleObserver<T> {
+
+    override fun onSubscribe(disposable: Disposable) {
+    }
+
+    override fun onSuccess(value: T) {
+    }
+
+    override fun onError(error: Throwable) {
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AndThenTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AndThenTest.kt
@@ -2,14 +2,14 @@ package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.completable.TestCompletable
-import com.badoo.reaktive.test.completable.isCompleted
+import com.badoo.reaktive.test.completable.isComplete
 import com.badoo.reaktive.test.completable.isError
 import com.badoo.reaktive.test.completable.test
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class AndThenTest : UpstreamDownstreamGenericTests by UpstreamDownstreamGenericTests({ andThen(TestCompletable()) }) {
+class AndThenTest : CompletableToCompletableTests by CompletableToCompletableTests({ andThen(TestCompletable()) }) {
 
     private val upstream = TestCompletable()
     private val inner = TestCompletable()
@@ -37,7 +37,7 @@ class AndThenTest : UpstreamDownstreamGenericTests by UpstreamDownstreamGenericT
         upstream.onComplete()
         inner.onComplete()
 
-        assertTrue(observer.isCompleted)
+        assertTrue(observer.isComplete)
     }
 
     @Test
@@ -58,7 +58,7 @@ class AndThenTest : UpstreamDownstreamGenericTests by UpstreamDownstreamGenericT
 
         inner.onComplete()
 
-        assertFalse(observer.isCompleted)
+        assertFalse(observer.isComplete)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToCompletableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToCompletableTests.kt
@@ -7,7 +7,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-interface UpstreamDownstreamGenericTests {
+interface CompletableToCompletableTests {
 
     @Test
     fun calls_onSubscribe_only_once_WHEN_subscribed()
@@ -19,8 +19,8 @@ interface UpstreamDownstreamGenericTests {
     fun disposes_upstream_WHEN_disposed()
 
     companion object {
-        operator fun invoke(transform: Completable.() -> Completable): UpstreamDownstreamGenericTests =
-            object : UpstreamDownstreamGenericTests {
+        operator fun invoke(transform: Completable.() -> Completable): CompletableToCompletableTests =
+            object : CompletableToCompletableTests {
                 private val upstream = TestCompletable()
                 private val observer = upstream.transform().test()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeCompleteTest.kt
@@ -2,16 +2,20 @@ package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.test.completable.DefaultCompletableObserver
 import com.badoo.reaktive.test.completable.TestCompletable
+import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class DoOnBeforeCompleteTest
     : CompletableToCompletableTests by CompletableToCompletableTests({ doOnBeforeComplete {} }) {
 
+    private val upstream = TestCompletable()
+
     @Test
     fun calls_action_before_completion() {
-        val upstream = TestCompletable()
         val callOrder = SafeMutableList<String>()
 
         upstream
@@ -29,5 +33,20 @@ class DoOnBeforeCompleteTest
         upstream.onComplete()
 
         assertEquals(listOf("action", "onComplete"), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_produced_error() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeComplete {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onError(Throwable())
+
+        assertFalse(isCalled.value)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeCompleteTest.kt
@@ -1,0 +1,33 @@
+package com.badoo.reaktive.completable
+
+import com.badoo.reaktive.test.completable.DefaultCompletableObserver
+import com.badoo.reaktive.test.completable.TestCompletable
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeCompleteTest
+    : CompletableToCompletableTests by CompletableToCompletableTests({ doOnBeforeComplete {} }) {
+
+    @Test
+    fun calls_action_before_completion() {
+        val upstream = TestCompletable()
+        val callOrder = SafeMutableList<String>()
+
+        upstream
+            .doOnBeforeComplete {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultCompletableObserver {
+                    override fun onComplete() {
+                        callOrder += "onComplete"
+                    }
+                }
+            )
+
+        upstream.onComplete()
+
+        assertEquals(listOf("action", "onComplete"), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeDisposeTest.kt
@@ -1,0 +1,31 @@
+package com.badoo.reaktive.completable
+
+import com.badoo.reaktive.disposable.disposable
+import com.badoo.reaktive.test.completable.test
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeDisposeTest
+    : CompletableToCompletableTests by CompletableToCompletableTests({ doOnBeforeDispose {} }) {
+
+    @Test
+    fun calls_action_before_disposing_upstream() {
+        val callOrder = SafeMutableList<String>()
+
+        completableUnsafe { observer ->
+            observer.onSubscribe(
+                disposable {
+                    callOrder += "dispose"
+                }
+            )
+        }
+            .doOnBeforeDispose {
+                callOrder += "action"
+            }
+            .test()
+            .dispose()
+
+        assertEquals(listOf("action", "dispose"), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeDisposeTest.kt
@@ -1,13 +1,18 @@
 package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.disposable.disposable
+import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class DoOnBeforeDisposeTest
     : CompletableToCompletableTests by CompletableToCompletableTests({ doOnBeforeDispose {} }) {
+
+    private val upstream = TestCompletable()
 
     @Test
     fun calls_action_before_disposing_upstream() {
@@ -27,5 +32,35 @@ class DoOnBeforeDisposeTest
             .dispose()
 
         assertEquals(listOf("action", "dispose"), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_completed() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeDispose {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onComplete()
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_produced_error() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeDispose {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onError(Throwable())
+
+        assertFalse(isCalled.value)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeErrorTest.kt
@@ -2,16 +2,20 @@ package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.test.completable.DefaultCompletableObserver
 import com.badoo.reaktive.test.completable.TestCompletable
+import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class DoOnBeforeErrorTest
     : CompletableToCompletableTests by CompletableToCompletableTests({ doOnBeforeError {} }) {
 
+    private val upstream = TestCompletable()
+
     @Test
     fun calls_action_before_failing() {
-        val upstream = TestCompletable()
         val callOrder = SafeMutableList<Pair<String, Throwable>>()
         val exception = Exception()
 
@@ -30,5 +34,20 @@ class DoOnBeforeErrorTest
         upstream.onError(exception)
 
         assertEquals(listOf("action" to exception, "onError" to exception), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_completed() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeError {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onComplete()
+
+        assertFalse(isCalled.value)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeErrorTest.kt
@@ -1,0 +1,34 @@
+package com.badoo.reaktive.completable
+
+import com.badoo.reaktive.test.completable.DefaultCompletableObserver
+import com.badoo.reaktive.test.completable.TestCompletable
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeErrorTest
+    : CompletableToCompletableTests by CompletableToCompletableTests({ doOnBeforeError {} }) {
+
+    @Test
+    fun calls_action_before_failing() {
+        val upstream = TestCompletable()
+        val callOrder = SafeMutableList<Pair<String, Throwable>>()
+        val exception = Exception()
+
+        upstream
+            .doOnBeforeError { error ->
+                callOrder += "action" to error
+            }
+            .subscribe(
+                object : DefaultCompletableObserver {
+                    override fun onError(error: Throwable) {
+                        callOrder += "onError" to error
+                    }
+                }
+            )
+
+        upstream.onError(exception)
+
+        assertEquals(listOf("action" to exception, "onError" to exception), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeFinallyTest.kt
@@ -1,0 +1,146 @@
+package com.badoo.reaktive.completable
+
+import com.badoo.reaktive.disposable.disposable
+import com.badoo.reaktive.test.completable.DefaultCompletableObserver
+import com.badoo.reaktive.test.completable.TestCompletable
+import com.badoo.reaktive.test.completable.test
+import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomicreference.update
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeFinallyTest
+    : CompletableToCompletableTests by CompletableToCompletableTests({ doOnBeforeFinally {} }) {
+
+    private val upstream = TestCompletable()
+
+    @Test
+    fun calls_action_before_completion() {
+        val callOrder = SafeMutableList<String>()
+
+        upstream
+            .doOnBeforeFinally {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultCompletableObserver {
+                    override fun onComplete() {
+                        callOrder += "onComplete"
+                    }
+                }
+            )
+
+        upstream.onComplete()
+
+        assertEquals(listOf("action", "onComplete"), callOrder.items)
+    }
+
+    @Test
+    fun calls_action_before_failing() {
+        val callOrder = SafeMutableList<String>()
+        val exception = Exception()
+
+        upstream
+            .doOnBeforeFinally {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultCompletableObserver {
+                    override fun onError(error: Throwable) {
+                        callOrder += "onError"
+                    }
+                }
+            )
+
+        upstream.onError(exception)
+
+        assertEquals(listOf("action", "onError"), callOrder.items)
+    }
+
+    @Test
+    fun calls_action_before_disposing_upstream() {
+        val callOrder = SafeMutableList<String>()
+
+        completableUnsafe { observer ->
+            observer.onSubscribe(
+                disposable {
+                    callOrder += "dispose"
+                }
+            )
+        }
+            .doOnBeforeFinally {
+                callOrder += "action"
+            }
+            .test()
+            .dispose()
+
+        assertEquals(listOf("action", "dispose"), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_second_time_WHEN_downstream_disposed_and_upstream_completed() {
+        val count = AtomicReference(0)
+
+        upstream
+            .doOnBeforeFinally {
+                count.update(Int::inc)
+            }
+            .test()
+            .dispose()
+
+        upstream.onComplete()
+
+        assertEquals(1, count.value)
+    }
+
+    @Test
+    fun does_not_call_action_second_time_WHEN_downstream_disposed_and_upstream_produced_error() {
+        val count = AtomicReference(0)
+
+        upstream
+            .doOnBeforeFinally {
+                count.update(Int::inc)
+            }
+            .test()
+            .dispose()
+
+        upstream.onError(Throwable())
+
+        assertEquals(1, count.value)
+    }
+
+    @Test
+    fun does_not_call_action_second_time_WHEN_upstream_completed_and_downstream_disposed() {
+        val count = AtomicReference(0)
+
+        val observer =
+            upstream
+                .doOnBeforeFinally {
+                    count.update(Int::inc)
+                }
+                .test()
+
+        upstream.onComplete()
+        observer.dispose()
+
+        assertEquals(1, count.value)
+    }
+
+    @Test
+    fun does_not_call_action_second_time_WHEN_upstream_produced_error_and_downstream_disposed() {
+        val count = AtomicReference(0)
+
+        val observer =
+            upstream
+                .doOnBeforeFinally {
+                    count.update(Int::inc)
+                }
+                .test()
+
+        upstream.onError(Throwable())
+        observer.dispose()
+
+        assertEquals(1, count.value)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeSubscribeTest.kt
@@ -3,6 +3,7 @@ package com.badoo.reaktive.completable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.disposable
 import com.badoo.reaktive.test.completable.DefaultCompletableObserver
+import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
 import com.badoo.reaktive.utils.atomicreference.AtomicReference
@@ -68,6 +69,41 @@ class DoOnBeforeSubscribeTest
                 isCalled.value = true
             }
             .test()
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_completed() {
+        val isCalled = AtomicReference(false)
+        val upstream = TestCompletable()
+
+        upstream
+            .doOnBeforeSubscribe {
+                isCalled.value = true
+            }
+            .test()
+
+        isCalled.value = false
+        upstream.onComplete()
+
+        assertFalse(isCalled.value)
+    }
+
+
+    @Test
+    fun does_not_call_action_WHEN_produced_error() {
+        val isCalled = AtomicReference(false)
+        val upstream = TestCompletable()
+
+        upstream
+            .doOnBeforeSubscribe {
+                isCalled.value = true
+            }
+            .test()
+
+        isCalled.value = false
+        upstream.onError(Throwable())
 
         assertFalse(isCalled.value)
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeSubscribeTest.kt
@@ -1,0 +1,74 @@
+package com.badoo.reaktive.completable
+
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.disposable
+import com.badoo.reaktive.test.completable.DefaultCompletableObserver
+import com.badoo.reaktive.test.completable.test
+import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class DoOnBeforeSubscribeTest
+    : CompletableToCompletableTests by CompletableToCompletableTests({ doOnBeforeSubscribe {} }) {
+
+    @Test
+    fun calls_action_before_downstream_onSubscribe_WHEN_action_does_not_throw_exception() {
+        val callOrder = SafeMutableList<String>()
+
+        completableUnsafe {}
+            .doOnBeforeSubscribe {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultCompletableObserver {
+                    override fun onSubscribe(disposable: Disposable) {
+                        callOrder += "onSubscribe"
+                    }
+                }
+            )
+
+        assertEquals(listOf("action", "onSubscribe"), callOrder.items)
+    }
+
+    @Test
+    fun delegates_error_to_downstream_after_downstream_onSubscribe_WHEN_action_throws_exception() {
+        val callOrder = SafeMutableList<Any>()
+        val exception = Exception()
+
+        completableUnsafe {}
+            .doOnBeforeSubscribe {
+                throw exception
+            }
+            .subscribe(
+                object : DefaultCompletableObserver {
+                    override fun onSubscribe(disposable: Disposable) {
+                        callOrder += "onSubscribe"
+                    }
+
+                    override fun onError(error: Throwable) {
+                        callOrder += error
+                    }
+                }
+            )
+
+        assertEquals(listOf("onSubscribe", exception), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_onSubscribe_received_from_upstream() {
+        val isCalled = AtomicReference(false)
+
+        completableUnsafe { observer ->
+            isCalled.value = false
+            observer.onSubscribe(disposable())
+        }
+            .doOnBeforeSubscribe {
+                isCalled.value = true
+            }
+            .test()
+
+        assertFalse(isCalled.value)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeTerminateTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeTerminateTest.kt
@@ -1,0 +1,56 @@
+package com.badoo.reaktive.completable
+
+import com.badoo.reaktive.test.completable.DefaultCompletableObserver
+import com.badoo.reaktive.test.completable.TestCompletable
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeTerminateTest
+    : CompletableToCompletableTests by CompletableToCompletableTests({ doOnBeforeTerminate {} }) {
+
+    private val upstream = TestCompletable()
+    private val callOrder = SafeMutableList<String>()
+
+    @Test
+    fun calls_action_before_completion() {
+
+        upstream
+            .doOnBeforeTerminate {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultCompletableObserver {
+                    override fun onComplete() {
+                        callOrder += "onComplete"
+                    }
+                }
+            )
+
+        upstream.onComplete()
+
+        assertEquals(listOf("action", "onComplete"), callOrder.items)
+    }
+
+    @Test
+    fun calls_action_before_failing() {
+        val callOrder = SafeMutableList<String>()
+        val exception = Exception()
+
+        upstream
+            .doOnBeforeTerminate {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultCompletableObserver {
+                    override fun onError(error: Throwable) {
+                        callOrder += "onError"
+                    }
+                }
+            )
+
+        upstream.onError(exception)
+
+        assertEquals(listOf("action", "onError"), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeCompleteTest.kt
@@ -2,16 +2,20 @@ package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
 import com.badoo.reaktive.test.maybe.TestMaybe
+import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class DoOnBeforeCompleteTest
     : MaybeToMaybeTests by MaybeToMaybeTests<Unit>({ doOnBeforeComplete {} }) {
 
+    private val upstream = TestMaybe<Int>()
+
     @Test
     fun calls_action_before_completion() {
-        val upstream = TestMaybe<Nothing>()
         val callOrder = SafeMutableList<String>()
 
         upstream
@@ -19,7 +23,7 @@ class DoOnBeforeCompleteTest
                 callOrder += "action"
             }
             .subscribe(
-                object : DefaultMaybeObserver<Nothing> {
+                object : DefaultMaybeObserver<Int> {
                     override fun onComplete() {
                         callOrder += "onComplete"
                     }
@@ -29,5 +33,35 @@ class DoOnBeforeCompleteTest
         upstream.onComplete()
 
         assertEquals(listOf("action", "onComplete"), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_succeeded() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeComplete {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onSuccess(0)
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_produced_error() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeComplete {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onError(Throwable())
+
+        assertFalse(isCalled.value)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeCompleteTest.kt
@@ -1,0 +1,33 @@
+package com.badoo.reaktive.maybe
+
+import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
+import com.badoo.reaktive.test.maybe.TestMaybe
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeCompleteTest
+    : MaybeToMaybeTests by MaybeToMaybeTests<Unit>({ doOnBeforeComplete {} }) {
+
+    @Test
+    fun calls_action_before_completion() {
+        val upstream = TestMaybe<Nothing>()
+        val callOrder = SafeMutableList<String>()
+
+        upstream
+            .doOnBeforeComplete {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultMaybeObserver<Nothing> {
+                    override fun onComplete() {
+                        callOrder += "onComplete"
+                    }
+                }
+            )
+
+        upstream.onComplete()
+
+        assertEquals(listOf("action", "onComplete"), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeDisposeTest.kt
@@ -1,0 +1,31 @@
+package com.badoo.reaktive.maybe
+
+import com.badoo.reaktive.disposable.disposable
+import com.badoo.reaktive.test.maybe.test
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeDisposeTest
+    : MaybeToMaybeTests by MaybeToMaybeTests<Unit>({ doOnBeforeDispose {} }) {
+
+    @Test
+    fun calls_action_before_disposing_upstream() {
+        val callOrder = SafeMutableList<String>()
+
+        maybeUnsafe<Nothing> { observer ->
+            observer.onSubscribe(
+                disposable {
+                    callOrder += "dispose"
+                }
+            )
+        }
+            .doOnBeforeDispose {
+                callOrder += "action"
+            }
+            .test()
+            .dispose()
+
+        assertEquals(listOf("action", "dispose"), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeDisposeTest.kt
@@ -1,13 +1,18 @@
 package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.disposable.disposable
+import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class DoOnBeforeDisposeTest
     : MaybeToMaybeTests by MaybeToMaybeTests<Unit>({ doOnBeforeDispose {} }) {
+
+    private val upstream = TestMaybe<Int>()
 
     @Test
     fun calls_action_before_disposing_upstream() {
@@ -27,5 +32,50 @@ class DoOnBeforeDisposeTest
             .dispose()
 
         assertEquals(listOf("action", "dispose"), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_succeeded() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeDispose {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onSuccess(0)
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_completed() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeDispose {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onComplete()
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_produced_error() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeDispose {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onError(Throwable())
+
+        assertFalse(isCalled.value)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeErrorTest.kt
@@ -2,16 +2,20 @@ package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
 import com.badoo.reaktive.test.maybe.TestMaybe
+import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class DoOnBeforeErrorTest
     : MaybeToMaybeTests by MaybeToMaybeTests<Unit>({ doOnBeforeError {} }) {
 
+    private val upstream = TestMaybe<Int>()
+
     @Test
     fun calls_action_before_failing() {
-        val upstream = TestMaybe<Nothing>()
         val callOrder = SafeMutableList<Pair<String, Throwable>>()
         val exception = Exception()
 
@@ -20,7 +24,7 @@ class DoOnBeforeErrorTest
                 callOrder += "action" to error
             }
             .subscribe(
-                object : DefaultMaybeObserver<Nothing> {
+                object : DefaultMaybeObserver<Int> {
                     override fun onError(error: Throwable) {
                         callOrder += "onError" to error
                     }
@@ -30,5 +34,35 @@ class DoOnBeforeErrorTest
         upstream.onError(exception)
 
         assertEquals(listOf("action" to exception, "onError" to exception), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_succeeded_value() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeError {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onSuccess(0)
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_completed() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeError {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onComplete()
+
+        assertFalse(isCalled.value)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeErrorTest.kt
@@ -1,0 +1,34 @@
+package com.badoo.reaktive.maybe
+
+import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
+import com.badoo.reaktive.test.maybe.TestMaybe
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeErrorTest
+    : MaybeToMaybeTests by MaybeToMaybeTests<Unit>({ doOnBeforeError {} }) {
+
+    @Test
+    fun calls_action_before_failing() {
+        val upstream = TestMaybe<Nothing>()
+        val callOrder = SafeMutableList<Pair<String, Throwable>>()
+        val exception = Exception()
+
+        upstream
+            .doOnBeforeError { error ->
+                callOrder += "action" to error
+            }
+            .subscribe(
+                object : DefaultMaybeObserver<Nothing> {
+                    override fun onError(error: Throwable) {
+                        callOrder += "onError" to error
+                    }
+                }
+            )
+
+        upstream.onError(exception)
+
+        assertEquals(listOf("action" to exception, "onError" to exception), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeFinallyTest.kt
@@ -1,0 +1,146 @@
+package com.badoo.reaktive.maybe
+
+import com.badoo.reaktive.disposable.disposable
+import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
+import com.badoo.reaktive.test.maybe.TestMaybe
+import com.badoo.reaktive.test.maybe.test
+import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomicreference.update
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeFinallyTest
+    : MaybeToMaybeTests by MaybeToMaybeTests<Unit>({ doOnBeforeFinally {} }) {
+
+    private val upstream = TestMaybe<Nothing>()
+
+    @Test
+    fun calls_action_before_completion() {
+        val callOrder = SafeMutableList<String>()
+
+        upstream
+            .doOnBeforeFinally {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultMaybeObserver<Nothing> {
+                    override fun onComplete() {
+                        callOrder += "onComplete"
+                    }
+                }
+            )
+
+        upstream.onComplete()
+
+        assertEquals(listOf("action", "onComplete"), callOrder.items)
+    }
+
+    @Test
+    fun calls_action_before_failing() {
+        val callOrder = SafeMutableList<String>()
+        val exception = Exception()
+
+        upstream
+            .doOnBeforeFinally {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultMaybeObserver<Nothing> {
+                    override fun onError(error: Throwable) {
+                        callOrder += "onError"
+                    }
+                }
+            )
+
+        upstream.onError(exception)
+
+        assertEquals(listOf("action", "onError"), callOrder.items)
+    }
+
+    @Test
+    fun calls_action_before_disposing_upstream() {
+        val callOrder = SafeMutableList<String>()
+
+        maybeUnsafe<Unit> { observer ->
+            observer.onSubscribe(
+                disposable {
+                    callOrder += "dispose"
+                }
+            )
+        }
+            .doOnBeforeFinally {
+                callOrder += "action"
+            }
+            .test()
+            .dispose()
+
+        assertEquals(listOf("action", "dispose"), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_second_time_WHEN_downstream_disposed_and_upstream_completed() {
+        val count = AtomicReference(0)
+
+        upstream
+            .doOnBeforeFinally {
+                count.update(Int::inc)
+            }
+            .test()
+            .dispose()
+
+        upstream.onComplete()
+
+        assertEquals(1, count.value)
+    }
+
+    @Test
+    fun does_not_call_action_second_time_WHEN_downstream_disposed_and_upstream_produced_error() {
+        val count = AtomicReference(0)
+
+        upstream
+            .doOnBeforeFinally {
+                count.update(Int::inc)
+            }
+            .test()
+            .dispose()
+
+        upstream.onError(Throwable())
+
+        assertEquals(1, count.value)
+    }
+
+    @Test
+    fun does_not_call_action_second_time_WHEN_upstream_completed_and_downstream_disposed() {
+        val count = AtomicReference(0)
+
+        val observer =
+            upstream
+                .doOnBeforeFinally {
+                    count.update(Int::inc)
+                }
+                .test()
+
+        upstream.onComplete()
+        observer.dispose()
+
+        assertEquals(1, count.value)
+    }
+
+    @Test
+    fun does_not_call_action_second_time_WHEN_upstream_produced_error_and_downstream_disposed() {
+        val count = AtomicReference(0)
+
+        val observer =
+            upstream
+                .doOnBeforeFinally {
+                    count.update(Int::inc)
+                }
+                .test()
+
+        upstream.onError(Throwable())
+        observer.dispose()
+
+        assertEquals(1, count.value)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSubscribeTest.kt
@@ -1,0 +1,74 @@
+package com.badoo.reaktive.maybe
+
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.disposable
+import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
+import com.badoo.reaktive.test.maybe.test
+import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class DoOnBeforeSubscribeTest
+    : MaybeToMaybeTests by MaybeToMaybeTests<Unit>({ doOnBeforeSubscribe {} }) {
+
+    @Test
+    fun calls_action_before_downstream_onSubscribe_WHEN_action_does_not_throw_exception() {
+        val callOrder = SafeMutableList<String>()
+
+        maybeUnsafe<Nothing> {}
+            .doOnBeforeSubscribe {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultMaybeObserver<Nothing> {
+                    override fun onSubscribe(disposable: Disposable) {
+                        callOrder += "onSubscribe"
+                    }
+                }
+            )
+
+        assertEquals(listOf("action", "onSubscribe"), callOrder.items)
+    }
+
+    @Test
+    fun delegates_error_to_downstream_after_downstream_onSubscribe_WHEN_action_throws_exception() {
+        val callOrder = SafeMutableList<Any>()
+        val exception = Exception()
+
+        maybeUnsafe<Nothing> {}
+            .doOnBeforeSubscribe {
+                throw exception
+            }
+            .subscribe(
+                object : DefaultMaybeObserver<Nothing> {
+                    override fun onSubscribe(disposable: Disposable) {
+                        callOrder += "onSubscribe"
+                    }
+
+                    override fun onError(error: Throwable) {
+                        callOrder += error
+                    }
+                }
+            )
+
+        assertEquals(listOf("onSubscribe", exception), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_onSubscribe_received_from_upstream() {
+        val isCalled = AtomicReference(false)
+
+        maybeUnsafe<Nothing> { observer ->
+            isCalled.value = false
+            observer.onSubscribe(disposable())
+        }
+            .doOnBeforeSubscribe {
+                isCalled.value = true
+            }
+            .test()
+
+        assertFalse(isCalled.value)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSubscribeTest.kt
@@ -3,6 +3,7 @@ package com.badoo.reaktive.maybe
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.disposable
 import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
+import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.utils.SafeMutableList
 import com.badoo.reaktive.utils.atomicreference.AtomicReference
@@ -68,6 +69,58 @@ class DoOnBeforeSubscribeTest
                 isCalled.value = true
             }
             .test()
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_succeeded() {
+        val isCalled = AtomicReference(false)
+        val upstream = TestMaybe<Int>()
+
+        upstream
+            .doOnBeforeSubscribe {
+                isCalled.value = true
+            }
+            .test()
+
+        isCalled.value = false
+        upstream.onSuccess(0)
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_completed() {
+        val isCalled = AtomicReference(false)
+        val upstream = TestMaybe<Nothing>()
+
+        upstream
+            .doOnBeforeSubscribe {
+                isCalled.value = true
+            }
+            .test()
+
+        isCalled.value = false
+        upstream.onComplete()
+
+        assertFalse(isCalled.value)
+    }
+
+
+    @Test
+    fun does_not_call_action_WHEN_produced_error() {
+        val isCalled = AtomicReference(false)
+        val upstream = TestMaybe<Nothing>()
+
+        upstream
+            .doOnBeforeSubscribe {
+                isCalled.value = true
+            }
+            .test()
+
+        isCalled.value = false
+        upstream.onError(Throwable())
 
         assertFalse(isCalled.value)
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSuccessTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSuccessTest.kt
@@ -2,16 +2,20 @@ package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
 import com.badoo.reaktive.test.maybe.TestMaybe
+import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class DoOnBeforeSuccessTest
     : MaybeToMaybeTests by MaybeToMaybeTests<Unit>({ doOnBeforeSuccess {} }) {
 
+    private val upstream = TestMaybe<Int>()
+
     @Test
     fun calls_action_before_emitting() {
-        val upstream = TestMaybe<Int>()
         val callOrder = SafeMutableList<String>()
 
         upstream
@@ -29,5 +33,35 @@ class DoOnBeforeSuccessTest
         upstream.onSuccess(0)
 
         assertEquals(listOf("action 0", "onNext 0"), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_completed() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeSuccess {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onComplete()
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_produced_error() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeSuccess {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onError(Throwable())
+
+        assertFalse(isCalled.value)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSuccessTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSuccessTest.kt
@@ -1,0 +1,33 @@
+package com.badoo.reaktive.maybe
+
+import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
+import com.badoo.reaktive.test.maybe.TestMaybe
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeSuccessTest
+    : MaybeToMaybeTests by MaybeToMaybeTests<Unit>({ doOnBeforeSuccess {} }) {
+
+    @Test
+    fun calls_action_before_emitting() {
+        val upstream = TestMaybe<Int>()
+        val callOrder = SafeMutableList<String>()
+
+        upstream
+            .doOnBeforeSuccess { value ->
+                callOrder += "action $value"
+            }
+            .subscribe(
+                object : DefaultMaybeObserver<Int> {
+                    override fun onSuccess(value: Int) {
+                        callOrder += "onNext $value"
+                    }
+                }
+            )
+
+        upstream.onSuccess(0)
+
+        assertEquals(listOf("action 0", "onNext 0"), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeTerminateTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeTerminateTest.kt
@@ -1,0 +1,56 @@
+package com.badoo.reaktive.maybe
+
+import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
+import com.badoo.reaktive.test.maybe.TestMaybe
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeTerminateTest
+    : MaybeToMaybeTests by MaybeToMaybeTests<Unit>({ doOnBeforeTerminate {} }) {
+
+    private val upstream = TestMaybe<Nothing>()
+    private val callOrder = SafeMutableList<String>()
+
+    @Test
+    fun calls_action_before_completion() {
+
+        upstream
+            .doOnBeforeTerminate {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultMaybeObserver<Nothing> {
+                    override fun onComplete() {
+                        callOrder += "onComplete"
+                    }
+                }
+            )
+
+        upstream.onComplete()
+
+        assertEquals(listOf("action", "onComplete"), callOrder.items)
+    }
+
+    @Test
+    fun calls_action_before_failing() {
+        val callOrder = SafeMutableList<String>()
+        val exception = Exception()
+
+        upstream
+            .doOnBeforeTerminate {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultMaybeObserver<Nothing> {
+                    override fun onError(error: Throwable) {
+                        callOrder += "onError"
+                    }
+                }
+            )
+
+        upstream.onError(exception)
+
+        assertEquals(listOf("action", "onError"), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToMaybeTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToMaybeTests.kt
@@ -1,0 +1,54 @@
+package com.badoo.reaktive.maybe
+
+import com.badoo.reaktive.test.maybe.TestMaybe
+import com.badoo.reaktive.test.maybe.isComplete
+import com.badoo.reaktive.test.maybe.isError
+import com.badoo.reaktive.test.maybe.test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+interface MaybeToMaybeTests {
+
+    @Test
+    fun calls_onSubscribe_only_once_WHEN_subscribed()
+
+    @Test
+    fun completes_WHEN_upstream_is_completed()
+
+    @Test
+    fun produces_error_WHEN_upstream_produced_error()
+
+    @Test
+    fun disposes_upstream_WHEN_disposed()
+
+    companion object {
+        operator fun <T> invoke(transform: Maybe<T>.() -> Maybe<*>): MaybeToMaybeTests =
+            object : MaybeToMaybeTests {
+                private val upstream = TestMaybe<T>()
+                private val observer = upstream.transform().test()
+
+                override fun calls_onSubscribe_only_once_WHEN_subscribed() {
+                    assertEquals(1, observer.disposables.size)
+                }
+
+                override fun completes_WHEN_upstream_is_completed() {
+                    upstream.onComplete()
+
+                    assertTrue(observer.isComplete)
+                }
+
+                override fun produces_error_WHEN_upstream_produced_error() {
+                    upstream.onError(Throwable())
+
+                    assertTrue(observer.isError)
+                }
+
+                override fun disposes_upstream_WHEN_disposed() {
+                    observer.dispose()
+
+                    assertTrue(upstream.isDisposed)
+                }
+            }
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/CombineLatestTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/CombineLatestTest.kt
@@ -2,7 +2,7 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.test.observable.getOnNextValue
 import com.badoo.reaktive.test.observable.hasOnNext
-import com.badoo.reaktive.test.observable.isCompleted
+import com.badoo.reaktive.test.observable.isComplete
 import com.badoo.reaktive.test.observable.isError
 import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
@@ -84,7 +84,7 @@ class CombineLatestTest {
         emitter3.onComplete()
 
         assertFalse(observer.hasOnNext)
-        assertTrue(observer.isCompleted)
+        assertTrue(observer.isComplete)
     }
 
     @Test
@@ -93,7 +93,7 @@ class CombineLatestTest {
         emitter2.onNext("2")
         emitter2.onComplete()
 
-        assertFalse(observer.isCompleted)
+        assertFalse(observer.isComplete)
     }
 
     @Test
@@ -103,7 +103,7 @@ class CombineLatestTest {
         emitter3.onNext("3")
         emitter2.onComplete()
 
-        assertFalse(observer.isCompleted)
+        assertFalse(observer.isComplete)
     }
 
     @Test
@@ -123,7 +123,7 @@ class CombineLatestTest {
         emitter2.onNext("2")
         emitter2.onError(Throwable())
 
-        assertFalse(observer.isCompleted)
+        assertFalse(observer.isComplete)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ConcatMapTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ConcatMapTest.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.TestObservableObserver
 import com.badoo.reaktive.test.observable.hasOnNext
-import com.badoo.reaktive.test.observable.isCompleted
+import com.badoo.reaktive.test.observable.isComplete
 import com.badoo.reaktive.test.observable.isError
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.observable.values
@@ -101,7 +101,7 @@ class ConcatMapTest
 
         upstream.onComplete()
 
-        assertTrue(observer.isCompleted)
+        assertTrue(observer.isComplete)
     }
 
     @Test
@@ -111,7 +111,7 @@ class ConcatMapTest
         upstream.onNext(0)
         upstream.onComplete()
 
-        assertFalse(observer.isCompleted)
+        assertFalse(observer.isComplete)
     }
 
     @Test
@@ -127,7 +127,7 @@ class ConcatMapTest
         upstream.onComplete()
         inners[2].onComplete()
 
-        assertTrue(observer.isCompleted)
+        assertTrue(observer.isComplete)
     }
 
     @Test
@@ -142,7 +142,7 @@ class ConcatMapTest
         upstream.onComplete()
         inners[1].onComplete()
 
-        assertFalse(observer.isCompleted)
+        assertFalse(observer.isComplete)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeCompleteTest.kt
@@ -2,16 +2,20 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.test.observable.DefaultObservableObserver
 import com.badoo.reaktive.test.observable.TestObservable
+import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class DoOnBeforeCompleteTest
     : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeComplete {} }) {
 
+    private val upstream = TestObservable<Int>()
+
     @Test
     fun calls_action_before_completion() {
-        val upstream = TestObservable<Nothing>()
         val callOrder = SafeMutableList<String>()
 
         upstream
@@ -19,7 +23,7 @@ class DoOnBeforeCompleteTest
                 callOrder += "action"
             }
             .subscribe(
-                object : DefaultObservableObserver<Nothing> {
+                object : DefaultObservableObserver<Int> {
                     override fun onComplete() {
                         callOrder += "onComplete"
                     }
@@ -29,5 +33,35 @@ class DoOnBeforeCompleteTest
         upstream.onComplete()
 
         assertEquals(listOf("action", "onComplete"), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_emitted_value() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeComplete {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onNext(0)
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_produced_error() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeComplete {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onError(Throwable())
+
+        assertFalse(isCalled.value)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeCompleteTest.kt
@@ -1,0 +1,33 @@
+package com.badoo.reaktive.observable
+
+import com.badoo.reaktive.test.observable.DefaultObservableObserver
+import com.badoo.reaktive.test.observable.TestObservable
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeCompleteTest
+    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeComplete {} }) {
+
+    @Test
+    fun calls_action_before_completion() {
+        val upstream = TestObservable<Nothing>()
+        val callOrder = SafeMutableList<String>()
+
+        upstream
+            .doOnBeforeComplete {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultObservableObserver<Nothing> {
+                    override fun onComplete() {
+                        callOrder += "onComplete"
+                    }
+                }
+            )
+
+        upstream.onComplete()
+
+        assertEquals(listOf("action", "onComplete"), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeDisposeTest.kt
@@ -1,0 +1,31 @@
+package com.badoo.reaktive.observable
+
+import com.badoo.reaktive.disposable.disposable
+import com.badoo.reaktive.test.observable.test
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeDisposeTest
+    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeDispose {} }) {
+
+    @Test
+    fun calls_action_before_disposing_upstream() {
+        val callOrder = SafeMutableList<String>()
+
+        observableUnsafe<Nothing> { observer ->
+            observer.onSubscribe(
+                disposable {
+                    callOrder += "dispose"
+                }
+            )
+        }
+            .doOnBeforeDispose {
+                callOrder += "action"
+            }
+            .test()
+            .dispose()
+
+        assertEquals(listOf("action", "dispose"), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeDisposeTest.kt
@@ -1,13 +1,18 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.disposable.disposable
+import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class DoOnBeforeDisposeTest
     : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeDispose {} }) {
+
+    private val upstream = TestObservable<Int>()
 
     @Test
     fun calls_action_before_disposing_upstream() {
@@ -27,5 +32,50 @@ class DoOnBeforeDisposeTest
             .dispose()
 
         assertEquals(listOf("action", "dispose"), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_emitted_value() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeDispose {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onNext(0)
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_completed() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeDispose {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onComplete()
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_produced_error() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeDispose {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onError(Throwable())
+
+        assertFalse(isCalled.value)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeErrorTest.kt
@@ -2,16 +2,20 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.test.observable.DefaultObservableObserver
 import com.badoo.reaktive.test.observable.TestObservable
+import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class DoOnBeforeErrorTest
     : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeError {} }) {
 
+    private val upstream = TestObservable<Int>()
+
     @Test
     fun calls_action_before_failing() {
-        val upstream = TestObservable<Nothing>()
         val callOrder = SafeMutableList<Pair<String, Throwable>>()
         val exception = Exception()
 
@@ -20,7 +24,7 @@ class DoOnBeforeErrorTest
                 callOrder += "action" to error
             }
             .subscribe(
-                object : DefaultObservableObserver<Nothing> {
+                object : DefaultObservableObserver<Int> {
                     override fun onError(error: Throwable) {
                         callOrder += "onError" to error
                     }
@@ -30,5 +34,35 @@ class DoOnBeforeErrorTest
         upstream.onError(exception)
 
         assertEquals(listOf("action" to exception, "onError" to exception), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_emitted_value() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeError {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onNext(0)
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_completed() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeError {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onComplete()
+
+        assertFalse(isCalled.value)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeErrorTest.kt
@@ -1,0 +1,34 @@
+package com.badoo.reaktive.observable
+
+import com.badoo.reaktive.test.observable.DefaultObservableObserver
+import com.badoo.reaktive.test.observable.TestObservable
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeErrorTest
+    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeError {} }) {
+
+    @Test
+    fun calls_action_before_failing() {
+        val upstream = TestObservable<Nothing>()
+        val callOrder = SafeMutableList<Pair<String, Throwable>>()
+        val exception = Exception()
+
+        upstream
+            .doOnBeforeError { error ->
+                callOrder += "action" to error
+            }
+            .subscribe(
+                object : DefaultObservableObserver<Nothing> {
+                    override fun onError(error: Throwable) {
+                        callOrder += "onError" to error
+                    }
+                }
+            )
+
+        upstream.onError(exception)
+
+        assertEquals(listOf("action" to exception, "onError" to exception), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeFinallyTest.kt
@@ -9,11 +9,12 @@ import com.badoo.reaktive.utils.atomicreference.AtomicReference
 import com.badoo.reaktive.utils.atomicreference.update
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class DoOnBeforeFinallyTest
     : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeFinally {} }) {
 
-    private val upstream = TestObservable<Nothing>()
+    private val upstream = TestObservable<Int>()
 
     @Test
     fun calls_action_before_completion() {
@@ -24,7 +25,7 @@ class DoOnBeforeFinallyTest
                 callOrder += "action"
             }
             .subscribe(
-                object : DefaultObservableObserver<Nothing> {
+                object : DefaultObservableObserver<Int> {
                     override fun onComplete() {
                         callOrder += "onComplete"
                     }
@@ -46,7 +47,7 @@ class DoOnBeforeFinallyTest
                 callOrder += "action"
             }
             .subscribe(
-                object : DefaultObservableObserver<Nothing> {
+                object : DefaultObservableObserver<Int> {
                     override fun onError(error: Throwable) {
                         callOrder += "onError"
                     }
@@ -142,5 +143,20 @@ class DoOnBeforeFinallyTest
         observer.dispose()
 
         assertEquals(1, count.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_emitted_value() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeFinally {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onNext(0)
+
+        assertFalse(isCalled.value)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeFinallyTest.kt
@@ -1,0 +1,146 @@
+package com.badoo.reaktive.observable
+
+import com.badoo.reaktive.disposable.disposable
+import com.badoo.reaktive.test.observable.DefaultObservableObserver
+import com.badoo.reaktive.test.observable.TestObservable
+import com.badoo.reaktive.test.observable.test
+import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomicreference.update
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeFinallyTest
+    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeFinally {} }) {
+
+    private val upstream = TestObservable<Nothing>()
+
+    @Test
+    fun calls_action_before_completion() {
+        val callOrder = SafeMutableList<String>()
+
+        upstream
+            .doOnBeforeFinally {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultObservableObserver<Nothing> {
+                    override fun onComplete() {
+                        callOrder += "onComplete"
+                    }
+                }
+            )
+
+        upstream.onComplete()
+
+        assertEquals(listOf("action", "onComplete"), callOrder.items)
+    }
+
+    @Test
+    fun calls_action_before_failing() {
+        val callOrder = SafeMutableList<String>()
+        val exception = Exception()
+
+        upstream
+            .doOnBeforeFinally {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultObservableObserver<Nothing> {
+                    override fun onError(error: Throwable) {
+                        callOrder += "onError"
+                    }
+                }
+            )
+
+        upstream.onError(exception)
+
+        assertEquals(listOf("action", "onError"), callOrder.items)
+    }
+
+    @Test
+    fun calls_action_before_disposing_upstream() {
+        val callOrder = SafeMutableList<String>()
+
+        observableUnsafe<Unit> { observer ->
+            observer.onSubscribe(
+                disposable {
+                    callOrder += "dispose"
+                }
+            )
+        }
+            .doOnBeforeFinally {
+                callOrder += "action"
+            }
+            .test()
+            .dispose()
+
+        assertEquals(listOf("action", "dispose"), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_second_time_WHEN_downstream_disposed_and_upstream_completed() {
+        val count = AtomicReference(0)
+
+        upstream
+            .doOnBeforeFinally {
+                count.update(Int::inc)
+            }
+            .test()
+            .dispose()
+
+        upstream.onComplete()
+
+        assertEquals(1, count.value)
+    }
+
+    @Test
+    fun does_not_call_action_second_time_WHEN_downstream_disposed_and_upstream_produced_error() {
+        val count = AtomicReference(0)
+
+        upstream
+            .doOnBeforeFinally {
+                count.update(Int::inc)
+            }
+            .test()
+            .dispose()
+
+        upstream.onError(Throwable())
+
+        assertEquals(1, count.value)
+    }
+
+    @Test
+    fun does_not_call_action_second_time_WHEN_upstream_completed_and_downstream_disposed() {
+        val count = AtomicReference(0)
+
+        val observer =
+            upstream
+                .doOnBeforeFinally {
+                    count.update(Int::inc)
+                }
+                .test()
+
+        upstream.onComplete()
+        observer.dispose()
+
+        assertEquals(1, count.value)
+    }
+
+    @Test
+    fun does_not_call_action_second_time_WHEN_upstream_produced_error_and_downstream_disposed() {
+        val count = AtomicReference(0)
+
+        val observer =
+            upstream
+                .doOnBeforeFinally {
+                    count.update(Int::inc)
+                }
+                .test()
+
+        upstream.onError(Throwable())
+        observer.dispose()
+
+        assertEquals(1, count.value)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeNextTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeNextTest.kt
@@ -2,16 +2,20 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.test.observable.DefaultObservableObserver
 import com.badoo.reaktive.test.observable.TestObservable
+import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class DoOnBeforeNextTest
     : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeNext {} }) {
 
+    private val upstream = TestObservable<Int>()
+
     @Test
     fun calls_action_before_emitting() {
-        val upstream = TestObservable<Int>()
         val callOrder = SafeMutableList<String>()
 
         upstream
@@ -30,5 +34,35 @@ class DoOnBeforeNextTest
         upstream.onNext(1)
 
         assertEquals(listOf("action 0", "onNext 0", "action 1", "onNext 1"), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_completed() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeNext {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onComplete()
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_produced_error() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeNext {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onError(Throwable())
+
+        assertFalse(isCalled.value)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeNextTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeNextTest.kt
@@ -1,0 +1,34 @@
+package com.badoo.reaktive.observable
+
+import com.badoo.reaktive.test.observable.DefaultObservableObserver
+import com.badoo.reaktive.test.observable.TestObservable
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeNextTest
+    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeNext {} }) {
+
+    @Test
+    fun calls_action_before_emitting() {
+        val upstream = TestObservable<Int>()
+        val callOrder = SafeMutableList<String>()
+
+        upstream
+            .doOnBeforeNext { value ->
+                callOrder += "action $value"
+            }
+            .subscribe(
+                object : DefaultObservableObserver<Int> {
+                    override fun onNext(value: Int) {
+                        callOrder += "onNext $value"
+                    }
+                }
+            )
+
+        upstream.onNext(0)
+        upstream.onNext(1)
+
+        assertEquals(listOf("action 0", "onNext 0", "action 1", "onNext 1"), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeSubscribeTest.kt
@@ -3,6 +3,7 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.disposable
 import com.badoo.reaktive.test.observable.DefaultObservableObserver
+import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
 import com.badoo.reaktive.utils.atomicreference.AtomicReference
@@ -68,6 +69,58 @@ class DoOnBeforeSubscribeTest
                 isCalled.value = true
             }
             .test()
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_emitted_value() {
+        val isCalled = AtomicReference(false)
+        val upstream = TestObservable<Int>()
+
+        upstream
+            .doOnBeforeSubscribe {
+                isCalled.value = true
+            }
+            .test()
+
+        isCalled.value = false
+        upstream.onNext(0)
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_completed() {
+        val isCalled = AtomicReference(false)
+        val upstream = TestObservable<Nothing>()
+
+        upstream
+            .doOnBeforeSubscribe {
+                isCalled.value = true
+            }
+            .test()
+
+        isCalled.value = false
+        upstream.onComplete()
+
+        assertFalse(isCalled.value)
+    }
+
+
+    @Test
+    fun does_not_call_action_WHEN_produced_error() {
+        val isCalled = AtomicReference(false)
+        val upstream = TestObservable<Nothing>()
+
+        upstream
+            .doOnBeforeSubscribe {
+                isCalled.value = true
+            }
+            .test()
+
+        isCalled.value = false
+        upstream.onError(Throwable())
 
         assertFalse(isCalled.value)
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeSubscribeTest.kt
@@ -1,0 +1,74 @@
+package com.badoo.reaktive.observable
+
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.disposable
+import com.badoo.reaktive.test.observable.DefaultObservableObserver
+import com.badoo.reaktive.test.observable.test
+import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class DoOnBeforeSubscribeTest
+    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeSubscribe {} }) {
+
+    @Test
+    fun calls_action_before_downstream_onSubscribe_WHEN_action_does_not_throw_exception() {
+        val callOrder = SafeMutableList<String>()
+
+        observableUnsafe<Nothing> {}
+            .doOnBeforeSubscribe {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultObservableObserver<Nothing> {
+                    override fun onSubscribe(disposable: Disposable) {
+                        callOrder += "onSubscribe"
+                    }
+                }
+            )
+
+        assertEquals(listOf("action", "onSubscribe"), callOrder.items)
+    }
+
+    @Test
+    fun delegates_error_to_downstream_after_downstream_onSubscribe_WHEN_action_throws_exception() {
+        val callOrder = SafeMutableList<Any>()
+        val exception = Exception()
+
+        observableUnsafe<Nothing> {}
+            .doOnBeforeSubscribe {
+                throw exception
+            }
+            .subscribe(
+                object : DefaultObservableObserver<Nothing> {
+                    override fun onSubscribe(disposable: Disposable) {
+                        callOrder += "onSubscribe"
+                    }
+
+                    override fun onError(error: Throwable) {
+                        callOrder += error
+                    }
+                }
+            )
+
+        assertEquals(listOf("onSubscribe", exception), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_onSubscribe_received_from_upstream() {
+        val isCalled = AtomicReference(false)
+
+        observableUnsafe<Nothing> { observer ->
+            isCalled.value = false
+            observer.onSubscribe(disposable())
+        }
+            .doOnBeforeSubscribe {
+                isCalled.value = true
+            }
+            .test()
+
+        assertFalse(isCalled.value)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeTerminateTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeTerminateTest.kt
@@ -1,0 +1,56 @@
+package com.badoo.reaktive.observable
+
+import com.badoo.reaktive.test.observable.DefaultObservableObserver
+import com.badoo.reaktive.test.observable.TestObservable
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeTerminateTest
+    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeTerminate {} }) {
+
+    private val upstream = TestObservable<Nothing>()
+    private val callOrder = SafeMutableList<String>()
+
+    @Test
+    fun calls_action_before_completion() {
+
+        upstream
+            .doOnBeforeTerminate {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultObservableObserver<Nothing> {
+                    override fun onComplete() {
+                        callOrder += "onComplete"
+                    }
+                }
+            )
+
+        upstream.onComplete()
+
+        assertEquals(listOf("action", "onComplete"), callOrder.items)
+    }
+
+    @Test
+    fun calls_action_before_failing() {
+        val callOrder = SafeMutableList<String>()
+        val exception = Exception()
+
+        upstream
+            .doOnBeforeTerminate {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultObservableObserver<Nothing> {
+                    override fun onError(error: Throwable) {
+                        callOrder += "onError"
+                    }
+                }
+            )
+
+        upstream.onError(exception)
+
+        assertEquals(listOf("action", "onError"), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeTerminateTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeTerminateTest.kt
@@ -2,25 +2,27 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.test.observable.DefaultObservableObserver
 import com.badoo.reaktive.test.observable.TestObservable
+import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class DoOnBeforeTerminateTest
     : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeTerminate {} }) {
 
-    private val upstream = TestObservable<Nothing>()
+    private val upstream = TestObservable<Int>()
     private val callOrder = SafeMutableList<String>()
 
     @Test
     fun calls_action_before_completion() {
-
         upstream
             .doOnBeforeTerminate {
                 callOrder += "action"
             }
             .subscribe(
-                object : DefaultObservableObserver<Nothing> {
+                object : DefaultObservableObserver<Int> {
                     override fun onComplete() {
                         callOrder += "onComplete"
                     }
@@ -42,7 +44,7 @@ class DoOnBeforeTerminateTest
                 callOrder += "action"
             }
             .subscribe(
-                object : DefaultObservableObserver<Nothing> {
+                object : DefaultObservableObserver<Int> {
                     override fun onError(error: Throwable) {
                         callOrder += "onError"
                     }
@@ -52,5 +54,20 @@ class DoOnBeforeTerminateTest
         upstream.onError(exception)
 
         assertEquals(listOf("action", "onError"), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_emitted_value() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeFinally {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onNext(0)
+
+        assertFalse(isCalled.value)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FlatMapTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FlatMapTest.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.TestObservableObserver
 import com.badoo.reaktive.test.observable.hasOnNext
-import com.badoo.reaktive.test.observable.isCompleted
+import com.badoo.reaktive.test.observable.isComplete
 import com.badoo.reaktive.test.observable.isError
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.observable.values
@@ -68,7 +68,7 @@ class FlatMapTest
 
         source.onComplete()
 
-        assertTrue(observer.isCompleted)
+        assertTrue(observer.isComplete)
     }
 
     @Test
@@ -78,7 +78,7 @@ class FlatMapTest
         source.onNext(0)
         source.onComplete()
 
-        assertFalse(observer.isCompleted)
+        assertFalse(observer.isComplete)
     }
 
     @Test
@@ -94,7 +94,7 @@ class FlatMapTest
         source.onComplete()
         inners[2].onComplete()
 
-        assertTrue(observer.isCompleted)
+        assertTrue(observer.isComplete)
     }
 
     @Test
@@ -109,7 +109,7 @@ class FlatMapTest
         source.onComplete()
         inners[2].onComplete()
 
-        assertFalse(observer.isCompleted)
+        assertFalse(observer.isComplete)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableByEmitterTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableByEmitterTest.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.observable.getOnErrorValue
 import com.badoo.reaktive.test.observable.getOnNextEvent
 import com.badoo.reaktive.test.observable.getOnNextValue
 import com.badoo.reaktive.test.observable.hasOnNext
-import com.badoo.reaktive.test.observable.isCompleted
+import com.badoo.reaktive.test.observable.isComplete
 import com.badoo.reaktive.test.observable.isError
 import com.badoo.reaktive.test.observable.isOnCompleteEvent
 import com.badoo.reaktive.test.observable.test
@@ -72,7 +72,7 @@ class ObservableByEmitterTest {
     fun completed_WHEN_onComplete_signalled() {
         emitter.onComplete()
 
-        assertTrue(observer.isCompleted)
+        assertTrue(observer.isComplete)
     }
 
     @Test
@@ -127,7 +127,7 @@ class ObservableByEmitterTest {
         observer.reset()
         emitter.onComplete()
 
-        assertFalse(observer.isCompleted)
+        assertFalse(observer.isComplete)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableToObservableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableToObservableTests.kt
@@ -1,7 +1,7 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.test.observable.TestObservable
-import com.badoo.reaktive.test.observable.isCompleted
+import com.badoo.reaktive.test.observable.isComplete
 import com.badoo.reaktive.test.observable.isError
 import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
@@ -35,7 +35,7 @@ interface ObservableToObservableTests {
                 override fun completes_WHEN_upstream_is_completed() {
                     upstream.onComplete()
 
-                    assertTrue(observer.isCompleted)
+                    assertTrue(observer.isComplete)
                 }
 
                 override fun produces_error_WHEN_upstream_produced_error() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObserveOnTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObserveOnTest.kt
@@ -3,7 +3,7 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.hasOnNext
-import com.badoo.reaktive.test.observable.isCompleted
+import com.badoo.reaktive.test.observable.isComplete
 import com.badoo.reaktive.test.observable.isError
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.observable.values
@@ -50,7 +50,7 @@ class ObserveOnTest
     fun does_no_complete_synchronously() {
         upstream.onComplete()
 
-        assertFalse(observer.isCompleted)
+        assertFalse(observer.isComplete)
     }
 
     @Test
@@ -58,7 +58,7 @@ class ObserveOnTest
         upstream.onComplete()
         scheduler.process()
 
-        assertTrue(observer.isCompleted)
+        assertTrue(observer.isComplete)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SubscribeOnTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SubscribeOnTest.kt
@@ -2,7 +2,7 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.observable.TestObservable
-import com.badoo.reaktive.test.observable.isCompleted
+import com.badoo.reaktive.test.observable.isComplete
 import com.badoo.reaktive.test.observable.isError
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.observable.values
@@ -48,7 +48,7 @@ class SubscribeOnTest
         observer.reset()
         upstream.onComplete()
 
-        assertTrue(observer.isCompleted)
+        assertTrue(observer.isComplete)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SubscribeTest.kt
@@ -2,7 +2,7 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.TestObservableObserver
-import com.badoo.reaktive.test.observable.isCompleted
+import com.badoo.reaktive.test.observable.isComplete
 import com.badoo.reaktive.test.observable.isError
 import com.badoo.reaktive.test.observable.values
 import kotlin.test.Test
@@ -54,7 +54,7 @@ class SubscribeTest {
 
         upstream.onComplete()
 
-        assertTrue(observer.isCompleted)
+        assertTrue(observer.isComplete)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ZipTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ZipTest.kt
@@ -2,7 +2,7 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.hasOnNext
-import com.badoo.reaktive.test.observable.isCompleted
+import com.badoo.reaktive.test.observable.isComplete
 import com.badoo.reaktive.test.observable.isError
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.observable.values
@@ -68,7 +68,7 @@ class ZipTest {
         sources[0].onNext(0)
         sources[1].onComplete()
 
-        assertTrue(observer.isCompleted)
+        assertTrue(observer.isComplete)
     }
 
 
@@ -78,7 +78,7 @@ class ZipTest {
         sources[1].onNext(1)
         sources[1].onComplete()
 
-        assertFalse(observer.isCompleted)
+        assertFalse(observer.isComplete)
     }
 
     @Test
@@ -89,7 +89,7 @@ class ZipTest {
         observer.reset()
         sources[1].onNext(1)
 
-        assertTrue(observer.isCompleted)
+        assertTrue(observer.isComplete)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeDisposeTest.kt
@@ -1,0 +1,31 @@
+package com.badoo.reaktive.single
+
+import com.badoo.reaktive.disposable.disposable
+import com.badoo.reaktive.test.single.test
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeDisposeTest
+    : SingleToSingleTests by SingleToSingleTests<Unit>({ doOnBeforeDispose {} }) {
+
+    @Test
+    fun calls_action_before_disposing_upstream() {
+        val callOrder = SafeMutableList<String>()
+
+        singleUnsafe<Nothing> { observer ->
+            observer.onSubscribe(
+                disposable {
+                    callOrder += "dispose"
+                }
+            )
+        }
+            .doOnBeforeDispose {
+                callOrder += "action"
+            }
+            .test()
+            .dispose()
+
+        assertEquals(listOf("action", "dispose"), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeDisposeTest.kt
@@ -1,13 +1,18 @@
 package com.badoo.reaktive.single
 
 import com.badoo.reaktive.disposable.disposable
+import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.test.single.test
 import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class DoOnBeforeDisposeTest
     : SingleToSingleTests by SingleToSingleTests<Unit>({ doOnBeforeDispose {} }) {
+
+    private val upstream = TestSingle<Int>()
 
     @Test
     fun calls_action_before_disposing_upstream() {
@@ -27,5 +32,35 @@ class DoOnBeforeDisposeTest
             .dispose()
 
         assertEquals(listOf("action", "dispose"), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_succeeded() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeDispose {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onSuccess(0)
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_produced_error() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeDispose {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onError(Throwable())
+
+        assertFalse(isCalled.value)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeErrorTest.kt
@@ -1,0 +1,34 @@
+package com.badoo.reaktive.single
+
+import com.badoo.reaktive.test.single.DefaultSingleObserver
+import com.badoo.reaktive.test.single.TestSingle
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeErrorTest
+    : SingleToSingleTests by SingleToSingleTests<Unit>({ doOnBeforeError {} }) {
+
+    @Test
+    fun calls_action_before_failing() {
+        val upstream = TestSingle<Nothing>()
+        val callOrder = SafeMutableList<Pair<String, Throwable>>()
+        val exception = Exception()
+
+        upstream
+            .doOnBeforeError { error ->
+                callOrder += "action" to error
+            }
+            .subscribe(
+                object : DefaultSingleObserver<Nothing> {
+                    override fun onError(error: Throwable) {
+                        callOrder += "onError" to error
+                    }
+                }
+            )
+
+        upstream.onError(exception)
+
+        assertEquals(listOf("action" to exception, "onError" to exception), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeErrorTest.kt
@@ -2,16 +2,20 @@ package com.badoo.reaktive.single
 
 import com.badoo.reaktive.test.single.DefaultSingleObserver
 import com.badoo.reaktive.test.single.TestSingle
+import com.badoo.reaktive.test.single.test
 import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class DoOnBeforeErrorTest
     : SingleToSingleTests by SingleToSingleTests<Unit>({ doOnBeforeError {} }) {
 
+    private val upstream = TestSingle<Int>()
+
     @Test
     fun calls_action_before_failing() {
-        val upstream = TestSingle<Nothing>()
         val callOrder = SafeMutableList<Pair<String, Throwable>>()
         val exception = Exception()
 
@@ -20,7 +24,7 @@ class DoOnBeforeErrorTest
                 callOrder += "action" to error
             }
             .subscribe(
-                object : DefaultSingleObserver<Nothing> {
+                object : DefaultSingleObserver<Int> {
                     override fun onError(error: Throwable) {
                         callOrder += "onError" to error
                     }
@@ -30,5 +34,20 @@ class DoOnBeforeErrorTest
         upstream.onError(exception)
 
         assertEquals(listOf("action" to exception, "onError" to exception), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_succeeded_value() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeError {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onSuccess(0)
+
+        assertFalse(isCalled.value)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeFinallyTest.kt
@@ -1,0 +1,146 @@
+package com.badoo.reaktive.single
+
+import com.badoo.reaktive.disposable.disposable
+import com.badoo.reaktive.test.single.DefaultSingleObserver
+import com.badoo.reaktive.test.single.TestSingle
+import com.badoo.reaktive.test.single.test
+import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomicreference.update
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeFinallyTest
+    : SingleToSingleTests by SingleToSingleTests<Unit>({ doOnBeforeFinally {} }) {
+
+    private val upstream = TestSingle<Int>()
+
+    @Test
+    fun calls_action_before_success() {
+        val callOrder = SafeMutableList<String>()
+
+        upstream
+            .doOnBeforeFinally {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultSingleObserver<Int> {
+                    override fun onSuccess(value: Int) {
+                        callOrder += "onComplete"
+                    }
+                }
+            )
+
+        upstream.onSuccess(0)
+
+        assertEquals(listOf("action", "onComplete"), callOrder.items)
+    }
+
+    @Test
+    fun calls_action_before_failing() {
+        val callOrder = SafeMutableList<String>()
+        val exception = Exception()
+
+        upstream
+            .doOnBeforeFinally {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultSingleObserver<Int> {
+                    override fun onError(error: Throwable) {
+                        callOrder += "onError"
+                    }
+                }
+            )
+
+        upstream.onError(exception)
+
+        assertEquals(listOf("action", "onError"), callOrder.items)
+    }
+
+    @Test
+    fun calls_action_before_disposing_upstream() {
+        val callOrder = SafeMutableList<String>()
+
+        singleUnsafe<Unit> { observer ->
+            observer.onSubscribe(
+                disposable {
+                    callOrder += "dispose"
+                }
+            )
+        }
+            .doOnBeforeFinally {
+                callOrder += "action"
+            }
+            .test()
+            .dispose()
+
+        assertEquals(listOf("action", "dispose"), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_second_time_WHEN_downstream_disposed_and_upstream_succeded() {
+        val count = AtomicReference(0)
+
+        upstream
+            .doOnBeforeFinally {
+                count.update(Int::inc)
+            }
+            .test()
+            .dispose()
+
+        upstream.onSuccess(0)
+
+        assertEquals(1, count.value)
+    }
+
+    @Test
+    fun does_not_call_action_second_time_WHEN_downstream_disposed_and_upstream_produced_error() {
+        val count = AtomicReference(0)
+
+        upstream
+            .doOnBeforeFinally {
+                count.update(Int::inc)
+            }
+            .test()
+            .dispose()
+
+        upstream.onError(Throwable())
+
+        assertEquals(1, count.value)
+    }
+
+    @Test
+    fun does_not_call_action_second_time_WHEN_upstream_succeeded_and_downstream_disposed() {
+        val count = AtomicReference(0)
+
+        val observer =
+            upstream
+                .doOnBeforeFinally {
+                    count.update(Int::inc)
+                }
+                .test()
+
+        upstream.onSuccess(0)
+        observer.dispose()
+
+        assertEquals(1, count.value)
+    }
+
+    @Test
+    fun does_not_call_action_second_time_WHEN_upstream_produced_error_and_downstream_disposed() {
+        val count = AtomicReference(0)
+
+        val observer =
+            upstream
+                .doOnBeforeFinally {
+                    count.update(Int::inc)
+                }
+                .test()
+
+        upstream.onError(Throwable())
+        observer.dispose()
+
+        assertEquals(1, count.value)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSubscribeTest.kt
@@ -1,0 +1,74 @@
+package com.badoo.reaktive.single
+
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.disposable
+import com.badoo.reaktive.test.single.DefaultSingleObserver
+import com.badoo.reaktive.test.single.test
+import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class DoOnBeforeSubscribeTest
+    : SingleToSingleTests by SingleToSingleTests<Unit>({ doOnBeforeSubscribe {} }) {
+
+    @Test
+    fun calls_action_before_downstream_onSubscribe_WHEN_action_does_not_throw_exception() {
+        val callOrder = SafeMutableList<String>()
+
+        singleUnsafe<Nothing> {}
+            .doOnBeforeSubscribe {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultSingleObserver<Nothing> {
+                    override fun onSubscribe(disposable: Disposable) {
+                        callOrder += "onSubscribe"
+                    }
+                }
+            )
+
+        assertEquals(listOf("action", "onSubscribe"), callOrder.items)
+    }
+
+    @Test
+    fun delegates_error_to_downstream_after_downstream_onSubscribe_WHEN_action_throws_exception() {
+        val callOrder = SafeMutableList<Any>()
+        val exception = Exception()
+
+        singleUnsafe<Nothing> {}
+            .doOnBeforeSubscribe {
+                throw exception
+            }
+            .subscribe(
+                object : DefaultSingleObserver<Nothing> {
+                    override fun onSubscribe(disposable: Disposable) {
+                        callOrder += "onSubscribe"
+                    }
+
+                    override fun onError(error: Throwable) {
+                        callOrder += error
+                    }
+                }
+            )
+
+        assertEquals(listOf("onSubscribe", exception), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_onSubscribe_received_from_upstream() {
+        val isCalled = AtomicReference(false)
+
+        singleUnsafe<Nothing> { observer ->
+            isCalled.value = false
+            observer.onSubscribe(disposable())
+        }
+            .doOnBeforeSubscribe {
+                isCalled.value = true
+            }
+            .test()
+
+        assertFalse(isCalled.value)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSubscribeTest.kt
@@ -3,6 +3,7 @@ package com.badoo.reaktive.single
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.disposable
 import com.badoo.reaktive.test.single.DefaultSingleObserver
+import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.test.single.test
 import com.badoo.reaktive.test.utils.SafeMutableList
 import com.badoo.reaktive.utils.atomicreference.AtomicReference
@@ -68,6 +69,40 @@ class DoOnBeforeSubscribeTest
                 isCalled.value = true
             }
             .test()
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_succeeded() {
+        val isCalled = AtomicReference(false)
+        val upstream = TestSingle<Int>()
+
+        upstream
+            .doOnBeforeSubscribe {
+                isCalled.value = true
+            }
+            .test()
+
+        isCalled.value = false
+        upstream.onSuccess(0)
+
+        assertFalse(isCalled.value)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_produced_error() {
+        val isCalled = AtomicReference(false)
+        val upstream = TestSingle<Nothing>()
+
+        upstream
+            .doOnBeforeSubscribe {
+                isCalled.value = true
+            }
+            .test()
+
+        isCalled.value = false
+        upstream.onError(Throwable())
 
         assertFalse(isCalled.value)
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSuccessTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSuccessTest.kt
@@ -2,16 +2,20 @@ package com.badoo.reaktive.single
 
 import com.badoo.reaktive.test.single.DefaultSingleObserver
 import com.badoo.reaktive.test.single.TestSingle
+import com.badoo.reaktive.test.single.test
 import com.badoo.reaktive.test.utils.SafeMutableList
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class DoOnBeforeSuccessTest
     : SingleToSingleTests by SingleToSingleTests<Unit>({ doOnBeforeSuccess {} }) {
 
+    private val upstream = TestSingle<Int>()
+
     @Test
     fun calls_action_before_emitting() {
-        val upstream = TestSingle<Int>()
         val callOrder = SafeMutableList<String>()
 
         upstream
@@ -29,5 +33,20 @@ class DoOnBeforeSuccessTest
         upstream.onSuccess(0)
 
         assertEquals(listOf("action 0", "onNext 0"), callOrder.items)
+    }
+
+    @Test
+    fun does_not_call_action_WHEN_produced_error() {
+        val isCalled = AtomicReference(false)
+
+        upstream
+            .doOnBeforeSuccess {
+                isCalled.value = true
+            }
+            .test()
+
+        upstream.onError(Throwable())
+
+        assertFalse(isCalled.value)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSuccessTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSuccessTest.kt
@@ -1,0 +1,33 @@
+package com.badoo.reaktive.single
+
+import com.badoo.reaktive.test.single.DefaultSingleObserver
+import com.badoo.reaktive.test.single.TestSingle
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeSuccessTest
+    : SingleToSingleTests by SingleToSingleTests<Unit>({ doOnBeforeSuccess {} }) {
+
+    @Test
+    fun calls_action_before_emitting() {
+        val upstream = TestSingle<Int>()
+        val callOrder = SafeMutableList<String>()
+
+        upstream
+            .doOnBeforeSuccess { value ->
+                callOrder += "action $value"
+            }
+            .subscribe(
+                object : DefaultSingleObserver<Int> {
+                    override fun onSuccess(value: Int) {
+                        callOrder += "onNext $value"
+                    }
+                }
+            )
+
+        upstream.onSuccess(0)
+
+        assertEquals(listOf("action 0", "onNext 0"), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeTerminateTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeTerminateTest.kt
@@ -1,0 +1,56 @@
+package com.badoo.reaktive.single
+
+import com.badoo.reaktive.test.single.DefaultSingleObserver
+import com.badoo.reaktive.test.single.TestSingle
+import com.badoo.reaktive.test.utils.SafeMutableList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DoOnBeforeTerminateTest
+    : SingleToSingleTests by SingleToSingleTests<Unit>({ doOnBeforeTerminate {} }) {
+
+    private val upstream = TestSingle<Int>()
+
+    @Test
+    fun calls_action_before_success() {
+        val callOrder = SafeMutableList<String>()
+
+        upstream
+            .doOnBeforeTerminate {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultSingleObserver<Int> {
+                    override fun onSuccess(value: Int) {
+                        callOrder += "onComplete"
+                    }
+                }
+            )
+
+        upstream.onSuccess(0)
+
+        assertEquals(listOf("action", "onComplete"), callOrder.items)
+    }
+
+    @Test
+    fun calls_action_before_failing() {
+        val callOrder = SafeMutableList<String>()
+        val exception = Exception()
+
+        upstream
+            .doOnBeforeTerminate {
+                callOrder += "action"
+            }
+            .subscribe(
+                object : DefaultSingleObserver<Int> {
+                    override fun onError(error: Throwable) {
+                        callOrder += "onError"
+                    }
+                }
+            )
+
+        upstream.onError(exception)
+
+        assertEquals(listOf("action", "onError"), callOrder.items)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/FlattenTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/FlattenTest.kt
@@ -1,6 +1,6 @@
 package com.badoo.reaktive.single
 
-import com.badoo.reaktive.test.observable.isCompleted
+import com.badoo.reaktive.test.observable.isComplete
 import com.badoo.reaktive.test.observable.isError
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.observable.values
@@ -24,21 +24,21 @@ class FlattenTest {
 
     @Test
     fun does_not_complete_WHEN_upstream_not_succeeded() {
-        assertFalse(observer.isCompleted)
+        assertFalse(observer.isComplete)
     }
 
     @Test
     fun completes_WHEN_upstream_succeeded_with_values() {
         upstream.onSuccess(listOf(1))
 
-        assertTrue(observer.isCompleted)
+        assertTrue(observer.isComplete)
     }
 
     @Test
     fun completes_WHEN_upstream_succeeded_without_values() {
         upstream.onSuccess(emptyList())
 
-        assertTrue(observer.isCompleted)
+        assertTrue(observer.isComplete)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/subject/SubjectGenericTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/subject/SubjectGenericTests.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.observable.ObservableObserver
 import com.badoo.reaktive.test.observable.TestObservableObserver
 import com.badoo.reaktive.test.observable.hasOnNext
-import com.badoo.reaktive.test.observable.isCompleted
+import com.badoo.reaktive.test.observable.isComplete
 import com.badoo.reaktive.test.observable.isError
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.observable.values
@@ -112,7 +112,7 @@ private class SubjectGenericTestsImpl(
         subject.onComplete()
 
         observers.forEach {
-            assertTrue(it.isCompleted)
+            assertTrue(it.isComplete)
         }
     }
 
@@ -151,7 +151,7 @@ private class SubjectGenericTestsImpl(
         observer.reset()
         subject.onComplete()
 
-        assertFalse(observer.isCompleted)
+        assertFalse(observer.isComplete)
     }
 
     override fun does_not_produce_completion_WHEN_error_produced() {
@@ -159,7 +159,7 @@ private class SubjectGenericTestsImpl(
         subject.onError(Throwable())
         subject.onComplete()
 
-        assertFalse(observer.isCompleted)
+        assertFalse(observer.isComplete)
     }
 
     override fun does_not_produce_error_WHEN_completed() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/test/utils/SafeMutableList.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/test/utils/SafeMutableList.kt
@@ -1,0 +1,20 @@
+package com.badoo.reaktive.test.utils
+
+import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomicreference.update
+
+class SafeMutableList<T> {
+
+    private val ref = AtomicReference<List<T>>(emptyList(), true)
+    val items: List<T> get() = ref.value
+
+    operator fun get(index: Int): T = ref.value[index]
+
+    fun add(value: T) {
+        ref.update { it + value }
+    }
+
+    operator fun plusAssign(value: T) {
+        add(value)
+    }
+}


### PR DESCRIPTION
- renamed `.isCompleted` to `isComplete` (for `TestObservableObserver` and `TestCompletableObserver`)
- renamed `completable.UpstreamDownstreamGenericTests` to `CompletableToCompletableTests`
- added tests for `doOnBeforeXxx` for all sources
- found and fixed bugs in `doOnBeforeSubscribe`

_First commit is refactoring, so it's better to review by commits._