### PR TITLE
iOS plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       language: java
       env: MP_TARGET=IOS
       install: true
-      script: ./gradlew reaktive:ios32MainBinaries reaktive:ios64MainBinaries reaktive:iosSimMainBinaries reaktive:check reaktive:iosTest reaktive-test:ios32MainBinaries reaktive-test:ios64MainBinaries reaktive-test:iosSimMainBinaries reaktive-test:check reaktive-test:iosTest -DMP_TARGET=$MP_TARGET
+      script: ./gradlew reaktive:check reaktive-test:check -DMP_TARGET=$MP_TARGET
     - os: linux
       language: android
       android:

--- a/build.gradle
+++ b/build.gradle
@@ -196,6 +196,4 @@ void setupCommonTargets(Project project) {
 
 void setupIosTargets(Project project) {
     project.apply plugin: IosPlugin
-    // TODO Uncomment when TravisCI will be used for publishing
-    // tasks.check.dependsOn iosTest
 }

--- a/build.gradle
+++ b/build.gradle
@@ -150,33 +150,7 @@ void setupCommonTargets(Project project) {
 }
 
 void setupIosTargets(Project project) {
-    project.kotlin {
-        targets {
-            fromPreset(presets.iosArm32, 'ios32') {
-                binaries.framework()
-            }
-            fromPreset(presets.iosArm64, 'ios64') {
-                binaries.framework()
-            }
-            fromPreset(presets.iosX64, 'iosSim') {
-                binaries.framework()
-            }
-        }
-    }
-
-    project.task(dependsOn: 'linkTestDebugExecutableIosSim', 'iosTest') {
-        group 'verification'
-        doLast {
-            final binary = project.kotlin.targets.iosSim.compilations.test.getBinary('EXECUTABLE', 'DEBUG')
-            if (binary.exists()) {
-                exec {
-                    commandLine 'xcrun', 'simctl', 'spawn', 'iPhone X', binary.absolutePath
-                }
-            } else {
-                logger.warn('No test executable for iOS')
-            }
-        }
-    }
+    project.apply plugin: IosPlugin
     // TODO Uncomment when TravisCI will be used for publishing
     // tasks.check.dependsOn iosTest
 }

--- a/buildSrc/src/main/kotlin/IosPlugin.kt
+++ b/buildSrc/src/main/kotlin/IosPlugin.kt
@@ -1,0 +1,62 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.internal.AbstractTask
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.TaskAction
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+
+@Suppress("UnstableApiUsage")
+abstract class IosPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        configureIosCompilation(target)
+    }
+
+    private fun configureIosCompilation(target: Project) {
+        target.extensions.configure(KotlinMultiplatformExtension::class.java) {
+            iosArm32(name = "ios32") {
+                binaries {
+                    framework()
+                }
+            }
+            iosArm32(name = "ios64") {
+                binaries {
+                    framework()
+                }
+            }
+            iosX64(name = "iosSim") {
+                binaries {
+                    framework()
+                    executable(buildTypes = setOf(NativeBuildType.DEBUG))
+
+                    val testBinariesTaskName = compilations.getByName("test").binariesTaskName
+                    target.tasks.register("iosTest", RunIosTestTask::class.java) {
+                        group = "verification"
+                        dependsOn(target.tasks.named(testBinariesTaskName))
+                        testExecutables.from(getExecutable("test", NativeBuildType.DEBUG).outputFile)
+                    }
+                }
+            }
+        }
+    }
+
+    abstract class RunIosTestTask : AbstractTask() {
+
+        @InputFiles
+        open var testExecutables: ConfigurableFileCollection = project.objects.fileCollection()
+
+        @TaskAction
+        open fun runTest() {
+            val files = testExecutables.filter { it.exists() }.files.toTypedArray()
+            if (files.isNotEmpty()) {
+                project.exec {
+                    commandLine("xcrun", "simctl", "spawn", "iPhone X", *files)
+                }
+            } else {
+                logger.error("No test executable for iOS")
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/IosPlugin.kt
+++ b/buildSrc/src/main/kotlin/IosPlugin.kt
@@ -3,8 +3,12 @@ import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.internal.AbstractTask
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskAction
+import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinNativeBinaryContainer
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 
 @Suppress("UnstableApiUsage")
@@ -15,30 +19,65 @@ abstract class IosPlugin : Plugin<Project> {
     }
 
     private fun configureIosCompilation(target: Project) {
+        val buildBinariesTasks = mutableListOf<String>()
         target.extensions.configure(KotlinMultiplatformExtension::class.java) {
-            iosArm32(name = "ios32") {
+            iosArm32(TARGET_NAME_X32) {
                 binaries {
                     framework()
                 }
+                buildBinariesTasks += compilations.getByName(SourceSet.MAIN_SOURCE_SET_NAME).binariesTaskName
             }
-            iosArm32(name = "ios64") {
+            iosArm64(TARGET_NAME_X64) {
                 binaries {
                     framework()
                 }
+                buildBinariesTasks += compilations.getByName(SourceSet.MAIN_SOURCE_SET_NAME).binariesTaskName
             }
-            iosX64(name = "iosSim") {
+            iosX64(TARGET_NAME_SIM) {
                 binaries {
                     framework()
-                    executable(buildTypes = setOf(NativeBuildType.DEBUG))
+                    setupTest(this@iosX64, this, target)
+                }
+                buildBinariesTasks += compilations.getByName(SourceSet.MAIN_SOURCE_SET_NAME).binariesTaskName
+            }
+        }
+        target.logger.error(buildBinariesTasks.toString())
+        setupBuildAll(target, buildBinariesTasks)
+    }
 
-                    val testBinariesTaskName = compilations.getByName("test").binariesTaskName
-                    target.tasks.register("iosTest", RunIosTestTask::class.java) {
-                        group = "verification"
-                        dependsOn(target.tasks.named(testBinariesTaskName))
-                        testExecutables.from(getExecutable("test", NativeBuildType.DEBUG).outputFile)
-                    }
-                }
+    private fun setupTest(
+        kotlinNativeTarget: KotlinNativeTarget,
+        kotlinNativeBinaryContainer: KotlinNativeBinaryContainer,
+        target: Project
+    ) {
+        val testBinariesTaskName =
+            kotlinNativeTarget.compilations.getByName(SourceSet.TEST_SOURCE_SET_NAME).binariesTaskName
+        val iosTestProvider = target.tasks.register(TASK_NAME_IOS_TEST, RunIosTestTask::class.java) {
+            group = LifecycleBasePlugin.VERIFICATION_GROUP
+            dependsOn(target.tasks.named(testBinariesTaskName))
+            testExecutables.from(
+                kotlinNativeBinaryContainer.getExecutable(
+                    SourceSet.TEST_SOURCE_SET_NAME,
+                    NativeBuildType.DEBUG
+                ).outputFile
+            )
+        }
+        if (kotlinNativeTarget.publishable) {
+            target.tasks.named(LifecycleBasePlugin.CHECK_TASK_NAME) {
+                dependsOn(iosTestProvider)
             }
+        }
+    }
+
+    private fun setupBuildAll(
+        target: Project,
+        buildTasks: Collection<String>
+    ) {
+        val allBinariesTaskProvider = target.tasks.register(TASK_NAME_IOS_BINARIES) {
+            dependsOn(buildTasks.map { target.tasks.named(it) })
+        }
+        target.tasks.named(LifecycleBasePlugin.CHECK_TASK_NAME) {
+            dependsOn(allBinariesTaskProvider)
         }
     }
 
@@ -58,5 +97,14 @@ abstract class IosPlugin : Plugin<Project> {
                 logger.error("No test executable for iOS")
             }
         }
+    }
+
+    companion object {
+        const val TARGET_NAME_X32 = "ios32"
+        const val TARGET_NAME_X64 = "ios64"
+        const val TARGET_NAME_SIM = "iosSim"
+
+        const val TASK_NAME_IOS_BINARIES = "iosBinaries"
+        const val TASK_NAME_IOS_TEST = "iosTest"
     }
 }

--- a/buildSrc/src/main/kotlin/IosPlugin.kt
+++ b/buildSrc/src/main/kotlin/IosPlugin.kt
@@ -41,7 +41,6 @@ abstract class IosPlugin : Plugin<Project> {
                 buildBinariesTasks += compilations.getByName(SourceSet.MAIN_SOURCE_SET_NAME).binariesTaskName
             }
         }
-        target.logger.error(buildBinariesTasks.toString())
         setupBuildAll(target, buildBinariesTasks)
     }
 

--- a/buildSrc/src/main/kotlin/JsPlugin.kt
+++ b/buildSrc/src/main/kotlin/JsPlugin.kt
@@ -7,12 +7,12 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.InputFiles
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
-import java.io.File
 
 @Suppress("UnstableApiUsage")
 abstract class JsPlugin : Plugin<Project> {
@@ -81,7 +81,7 @@ abstract class JsPlugin : Plugin<Project> {
 
         val runMochaTask = target.tasks.register("runMocha", RunMochaTask::class.java) {
             dependsOn(dependenciesTask, compileTestJsTask, nodeModulesTask)
-            testJsFiles = listOf(compileTestJsTask.get().outputFile)
+            testJsFiles.from(compileTestJsTask.get().outputFile)
         }
 
         target.tasks.named("jsTest") {
@@ -138,7 +138,7 @@ abstract class JsPlugin : Plugin<Project> {
     abstract class RunMochaTask : NodeTask() {
 
         @InputFiles
-        var testJsFiles: Collection<File> = emptyList()
+        open var testJsFiles: ConfigurableFileCollection = project.objects.fileCollection()
 
         override fun exec() {
             val files = testJsFiles.mapNotNull {

--- a/buildSrc/src/main/kotlin/JsPlugin.kt
+++ b/buildSrc/src/main/kotlin/JsPlugin.kt
@@ -10,6 +10,7 @@ import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.SourceSet
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
@@ -24,13 +25,13 @@ abstract class JsPlugin : Plugin<Project> {
 
     private fun configureJsCompilation(target: Project) {
         target.extensions.configure(KotlinMultiplatformExtension::class.java) {
-            targetFromPreset(presets.getByName("js"), "js")
-            sourceSets.getByName("jsMain") {
+            js(TARGET_NAME_JS)
+            sourceSets.getByName("$TARGET_NAME_JS${SourceSet.MAIN_SOURCE_SET_NAME}") {
                 dependencies {
                     implementation(kotlin("stdlib-js"))
                 }
             }
-            sourceSets.getByName("jsTest") {
+            sourceSets.getByName("$TARGET_NAME_JS${SourceSet.TEST_SOURCE_SET_NAME}") {
                 dependencies {
                     implementation(kotlin("test-js"))
                 }
@@ -84,7 +85,7 @@ abstract class JsPlugin : Plugin<Project> {
             testJsFiles.from(compileTestJsTask.get().outputFile)
         }
 
-        target.tasks.named("jsTest") {
+        target.tasks.named(TASK_NAME_JS_TEST) {
             dependsOn(runMochaTask)
         }
     }
@@ -158,10 +159,14 @@ abstract class JsPlugin : Plugin<Project> {
         }
     }
 
-    private companion object {
+    companion object {
         private const val TASK_COMPILE_KOTLIN_JS = "compileKotlinJs"
         private const val TASK_COMPILE_KOTLIN_JS_TEST = "compileTestKotlinJs"
         private const val PATH_MOCHA = "node_modules/mocha/bin/mocha"
+
+        const val TARGET_NAME_JS = "js"
+
+        const val TASK_NAME_JS_TEST = "jsTest"
     }
 
 }

--- a/buildSrc/src/main/kotlin/JsPlugin.kt
+++ b/buildSrc/src/main/kotlin/JsPlugin.kt
@@ -1,4 +1,4 @@
-import JsPlugin.CopyLocalNodeModulesTask.Companion.FOLDER_NODE_MODULES
+import com.android.utils.appendCapitalized
 import com.moowork.gradle.node.NodeExtension
 import com.moowork.gradle.node.NodePlugin
 import com.moowork.gradle.node.npm.NpmTask
@@ -26,12 +26,12 @@ abstract class JsPlugin : Plugin<Project> {
     private fun configureJsCompilation(target: Project) {
         target.extensions.configure(KotlinMultiplatformExtension::class.java) {
             js(TARGET_NAME_JS)
-            sourceSets.getByName("$TARGET_NAME_JS${SourceSet.MAIN_SOURCE_SET_NAME}") {
+            sourceSets.getByName(TARGET_NAME_JS.appendCapitalized(SourceSet.MAIN_SOURCE_SET_NAME)) {
                 dependencies {
                     implementation(kotlin("stdlib-js"))
                 }
             }
-            sourceSets.getByName("$TARGET_NAME_JS${SourceSet.TEST_SOURCE_SET_NAME}") {
+            sourceSets.getByName(TARGET_NAME_JS.appendCapitalized(SourceSet.TEST_SOURCE_SET_NAME)) {
                 dependencies {
                     implementation(kotlin("test-js"))
                 }
@@ -99,7 +99,8 @@ abstract class JsPlugin : Plugin<Project> {
     }
 
     /**
-     * Copy all js files from current project and project dependencies into [FOLDER_NODE_MODULES]
+     * Copy all js files from current project and project dependencies
+     * into [CopyLocalNodeModulesTask.FOLDER_NODE_MODULES]
      * to make them discoverable by NodeJS.
      */
     @Suppress("LeakingThis")


### PR DESCRIPTION
- Move iOS configuration to plugin
- Remove TODO to turn on/off `check` task dependency on `iosTask`
- Make `check` depends on `iosTask` and all iOS binaries compilation tasks to verify, that lib can be built for all platforms and to simplify Travis configuration (fixes https://github.com/badoo/Reaktive/issues/81)
- Use new API to get path to executable iOS test binary (fixes https://github.com/badoo/Reaktive/issues/89)