### PR TITLE
Export dependencies and change sample to support new swift declarations

### DIFF
--- a/sample-ios-app/build.gradle
+++ b/sample-ios-app/build.gradle
@@ -6,17 +6,23 @@ kotlin {
     targets {
         // fromPreset(presets.iosArm64, 'iosCommon')
         fromPreset(presets.iosArm64, 'ios64') {
-            binaries.framework('ReactiveSample')
+            binaries.framework('ReactiveSample') {
+                export project(':reaktive')
+                transitiveExport = true
+            }
         }
         fromPreset(presets.iosX64, 'iosSim') {
-            binaries.framework('ReactiveSample')
+            binaries.framework('ReactiveSample') {
+                export project(':reaktive')
+                transitiveExport = true
+            }
         }
     }
     sourceSets {
         iosCommonMain {
             dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-common'
-                implementation project(':reaktive')
+                api 'org.jetbrains.kotlin:kotlin-stdlib-common'
+                api project(':reaktive')
             }
         }
         ios64Main.dependsOn iosCommonMain

--- a/sample-ios-app/xcode/sample-ios-app/ViewController.swift
+++ b/sample-ios-app/xcode/sample-ios-app/ViewController.swift
@@ -24,7 +24,7 @@ class ViewController: UIViewController {
         indicator.isHidden = true
     }
     
-    class ResultObserver: ReaktiveSingleObserver {
+    class ResultObserver: SingleObserver {
         
         let showResult: (String) -> Void
         
@@ -32,7 +32,7 @@ class ViewController: UIViewController {
             self.showResult = showResult
         }
         
-        func onSubscribe(disposable: ReaktiveDisposable) {
+        func onSubscribe(disposable: Disposable) {
             // no-op
         }
         


### PR DESCRIPTION
- Configure `export` for iOS sample
- Replace generated Obj-C names with new generated Swift names (support was added recently)
- Fixes https://github.com/badoo/Reaktive/issues/111

https://kotlinlang.org/docs/reference/building-mpp-with-gradle.html#building-final-native-binaries