### PR TITLE
Kotlin version management

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,6 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap/' }
-    }
-    dependencies {
-        classpath 'org.jetbrains.kotlin:kotlin-frontend-plugin:0.0.45'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,8 @@ buildscript {
     }
 }
 
+apply from: 'gradle/versions.gradle.kts'
+
 allprojects {
     repositories {
         google()
@@ -20,20 +22,6 @@ allprojects {
             force 'com.android.support.constraint:constraint-layout:1.1.3'
             force 'io.reactivex.rxjava2:rxjava:2.2.7'
             force 'io.reactivex.rxjava2:rxandroid:2.1.1'
-        }
-    }
-
-    // TODO remove once https://github.com/Kotlin/kotlin-frontend-plugin/issues/141 is fixed
-    plugins.whenPluginAdded { plugin ->
-        if (plugin.class.name == 'org.jetbrains.kotlin.gradle.frontend.FrontendPlugin') {
-            def fixTask = tasks.register('webpack-config-fix') {
-                it.doLast { file('webpack.config.d').mkdir() }
-            }
-            afterEvaluate {
-                tasks.named('webpack-config').configure {
-                    it.dependsOn(fixTask)
-                }
-            }
         }
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,9 +7,11 @@ repositories {
     jcenter()
 }
 
+apply(from = "../gradle/versions.gradle.kts")
+
 dependencies {
-    implementation("com.moowork.gradle:gradle-node-plugin:1.3.1")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.31")
-    implementation("com.android.tools.build:gradle:3.4.1")
-    implementation("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4")
+    implementation("com.moowork.gradle:gradle-node-plugin:${property("node_gradle_version")}")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:${property("kotlin_version")}")
+    implementation("com.android.tools.build:gradle:${property("android_gradle_version")}")
+    implementation("com.jfrog.bintray.gradle:gradle-bintray-plugin:${property("bintray_gradle_version")}")
 }

--- a/buildSrc/src/main/kotlin/JsPlugin.kt
+++ b/buildSrc/src/main/kotlin/JsPlugin.kt
@@ -65,8 +65,8 @@ abstract class JsPlugin : Plugin<Project> {
             setArgs(
                 listOf(
                     "install",
-                    "kotlin@${project.findProperty("kotlin_version")}",
-                    "kotlin-test@${project.findProperty("kotlin_version")}",
+                    "kotlin@${project.property("kotlin_version")}",
+                    "kotlin-test@${project.property("kotlin_version")}",
                     "mocha@6.1.4"
                 )
             )

--- a/buildSrc/src/main/kotlin/JsPlugin.kt
+++ b/buildSrc/src/main/kotlin/JsPlugin.kt
@@ -58,16 +58,16 @@ abstract class JsPlugin : Plugin<Project> {
         target.pluginManager.apply(NodePlugin::class.java)
         target.extensions.configure(NodeExtension::class.java) {
             download = true
-            version = Versions.node
+            version = "12.2.0"
         }
 
         val dependenciesTask = target.tasks.register("installJsTestDependencies", NpmTask::class.java) {
             setArgs(
                 listOf(
                     "install",
-                    "kotlin@${Versions.kotlin}",
-                    "kotlin-test@${Versions.kotlin}",
-                    "mocha@${Versions.mocha}"
+                    "kotlin@${project.findProperty("kotlin_version")}",
+                    "kotlin-test@${project.findProperty("kotlin_version")}",
+                    "mocha@6.1.4"
                 )
             )
         }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,0 @@
-object Versions {
-
-    const val kotlin = "1.3.40"
-    const val mocha = "6.1.4"
-    const val node = "12.2.0"
-
-}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
-kotlin_version=1.3.31
 kotlin.code.style=official
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
+kotlin_version=1.3.31
 kotlin.code.style=official
 org.gradle.parallel=true

--- a/gradle/versions.gradle.kts
+++ b/gradle/versions.gradle.kts
@@ -1,0 +1,6 @@
+project.extra.run {
+    set("kotlin_version", "1.3.31")
+    set("node_gradle_version", "1.3.1")
+    set("android_gradle_version", "3.4.1")
+    set("bintray_gradle_version", "1.8.4")
+}

--- a/rxjava2-interop/build.gradle
+++ b/rxjava2-interop/build.gradle
@@ -15,7 +15,7 @@ publishing {
 }
 
 dependencies {
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation project(':reaktive')
     implementation 'io.reactivex.rxjava2:rxjava'
 }

--- a/sample-js-browser-app/build.gradle
+++ b/sample-js-browser-app/build.gradle
@@ -8,6 +8,20 @@ buildscript {
     }
 }
 
+// TODO remove once https://github.com/Kotlin/kotlin-frontend-plugin/issues/141 is fixed
+plugins.whenPluginAdded { plugin ->
+    if (plugin.class.name == 'org.jetbrains.kotlin.gradle.frontend.FrontendPlugin') {
+        def fixTask = tasks.register('webpack-config-fix') {
+            it.doLast { file('webpack.config.d').mkdir() }
+        }
+        afterEvaluate {
+            tasks.named('webpack-config').configure {
+                it.dependsOn(fixTask)
+            }
+        }
+    }
+}
+
 apply plugin: 'kotlin2js'
 apply plugin: 'org.jetbrains.kotlin.frontend'
 

--- a/sample-js-browser-app/build.gradle
+++ b/sample-js-browser-app/build.gradle
@@ -1,10 +1,18 @@
-plugins {
-    id 'kotlin2js'
-    id 'org.jetbrains.kotlin.frontend'
+buildscript {
+    repositories {
+        jcenter()
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap/' }
+    }
+    dependencies {
+        classpath 'org.jetbrains.kotlin:kotlin-frontend-plugin:0.0.45'
+    }
 }
 
+apply plugin: 'kotlin2js'
+apply plugin: 'org.jetbrains.kotlin.frontend'
+
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-js:${Versions.kotlin}"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-js:$kotlin_version"
     compile project(':reaktive')
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,21 +1,3 @@
-pluginManagement {
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.id == 'kotlin-multiplatform') {
-                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:${requested.version}")
-            }
-            if (requested.id.id == 'com.android.library') {
-                useModule("com.android.tools.build:gradle:${requested.version}")
-            }
-        }
-    }
-
-    repositories {
-        google()
-        jcenter()
-    }
-}
-
 enableFeaturePreview('GRADLE_METADATA')
 
 final target = Target.currentTarget()


### PR DESCRIPTION
Moved some dependency versions to separate `versions.gradle.kts` file and set them as project extra.
In future should probably be implemented as `resolutionStrategy` for all projects.