### PR TITLE
Primitive atomics

### DIFF
--- a/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/base/TestObserver.kt
+++ b/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/base/TestObserver.kt
@@ -2,8 +2,8 @@ package com.badoo.reaktive.test.base
 
 import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.update
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.update
 
 open class TestObserver<Event> : Observer, Disposable {
 

--- a/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/base/TestSource.kt
+++ b/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/base/TestSource.kt
@@ -4,15 +4,16 @@ import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.base.Source
 import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.update
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.update
 
 open class TestSource<O> : Source<O>, Disposable, ErrorCallback where O : Observer, O : ErrorCallback {
 
     private val _observers: AtomicReference<List<O>> = AtomicReference(emptyList(), true)
     val observers get() = _observers.value
 
-    private val _isDisposed = AtomicReference(false)
+    private val _isDisposed = AtomicBoolean()
     override val isDisposed: Boolean get() = _isDisposed.value
 
     override fun subscribe(observer: O) {

--- a/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/scheduler/TestScheduler.kt
+++ b/reaktive-test/src/commonMain/kotlin/com/badoo/reaktive/test/scheduler/TestScheduler.kt
@@ -47,7 +47,7 @@ class TestScheduler(
         }
 
         fun advanceBy(millis: Long) {
-            timeMillis.incrementAndGet(millis)
+            timeMillis.addAndGet(millis)
             listeners.value.forEach { it() }
         }
     }
@@ -133,7 +133,7 @@ class TestScheduler(
         val periodMillis: Long?,
         val task: () -> Unit
     ) : Comparable<Task> {
-        private val sequenceNumber = sequencer.incrementAndGet(1L)
+        private val sequenceNumber = sequencer.addAndGet(1L)
 
         override fun compareTo(other: Task): Int =
             if (this === other) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Concat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Concat.kt
@@ -3,8 +3,7 @@ package com.badoo.reaktive.completable
 import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.updateAndGet
+import com.badoo.reaktive.utils.atomic.AtomicInt
 
 fun Iterable<Completable>.concat(): Completable =
     completableUnsafe { observer ->
@@ -18,7 +17,7 @@ fun Iterable<Completable>.concat(): Completable =
             return@completableUnsafe
         }
 
-        val sourceIndex = AtomicReference(0)
+        val sourceIndex = AtomicInt()
 
         val upstreamObserver =
             object : CompletableObserver, CompletableCallbacks by observer {
@@ -28,7 +27,7 @@ fun Iterable<Completable>.concat(): Completable =
 
                 override fun onComplete() {
                     sourceIndex
-                        .updateAndGet { it + 1 }
+                        .incrementAndGet(1)
                         .let(sources::getOrNull)
                         ?.subscribeSafe(this)
                         ?: observer.onComplete()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Concat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Concat.kt
@@ -27,7 +27,7 @@ fun Iterable<Completable>.concat(): Completable =
 
                 override fun onComplete() {
                     sourceIndex
-                        .incrementAndGet(1)
+                        .addAndGet(1)
                         .let(sources::getOrNull)
                         ?.subscribeSafe(this)
                         ?: observer.onComplete()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/DoOnBefore.kt
@@ -2,11 +2,11 @@ package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.base.CompleteCallback
 import com.badoo.reaktive.base.ErrorCallback
+import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.wrap
-import com.badoo.reaktive.base.subscribeSafe
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 
 fun Completable.doOnBeforeSubscribe(action: (Disposable) -> Unit): Completable =
     completableUnsafe { observer ->
@@ -110,7 +110,7 @@ fun Completable.doOnBeforeDispose(action: () -> Unit): Completable =
 
 fun Completable.doOnBeforeFinally(action: () -> Unit): Completable =
     completableUnsafe { observer ->
-        val isFinished = AtomicReference(false)
+        val isFinished = AtomicBoolean()
 
         fun onFinally() {
             @Suppress("BooleanLiteralArgument") // Not allowed for expected classes

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
@@ -1,7 +1,8 @@
 package com.badoo.reaktive.disposable
 
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.getAndUpdate
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.getAndSet
+import com.badoo.reaktive.utils.atomic.getAndUpdate
 
 /**
  * Thread-safe collection of [Disposable]

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/DisposableWrapper.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/DisposableWrapper.kt
@@ -1,7 +1,7 @@
 package com.badoo.reaktive.disposable
 
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.getAndUpdate
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.getAndUpdate
 
 /**
  * Thread-safe container of one [Disposable]

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/Various.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/Various.kt
@@ -1,11 +1,11 @@
 package com.badoo.reaktive.disposable
 
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 
 inline fun disposable(crossinline onDispose: () -> Unit = {}): Disposable =
     object : Disposable {
         @Suppress("ObjectPropertyName") // Backing property
-        private var _isDisposed = AtomicReference(false)
+        private var _isDisposed = AtomicBoolean()
         override val isDisposed: Boolean get() = _isDisposed.value
 
         override fun dispose() {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DoOnBefore.kt
@@ -8,7 +8,7 @@ import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.wrap
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 
 fun <T> Maybe<T>.doOnBeforeSubscribe(action: (Disposable) -> Unit): Maybe<T> =
     maybeUnsafe { observer ->
@@ -136,7 +136,7 @@ fun <T> Maybe<T>.doOnBeforeDispose(action: () -> Unit): Maybe<T> =
 
 fun <T> Maybe<T>.doOnBeforeFinally(action: () -> Unit): Maybe<T> =
     maybeUnsafe { observer ->
-        val isFinished = AtomicReference(false)
+        val isFinished = AtomicBoolean()
 
         fun onFinally() {
             @Suppress("BooleanLiteralArgument") // Not allowed for expected classes

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Collect.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Collect.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.single.Single
 import com.badoo.reaktive.single.single
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicReference
 
 fun <T, C> Observable<T>.collect(initialCollection: C, accumulator: (C, T) -> C): Single<C> =
     single { emitter ->

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/CombineLatest.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/CombineLatest.kt
@@ -45,7 +45,7 @@ fun <T, R> Collection<Observable<T>>.combineLatest(mapper: (List<T>) -> R): Obse
                     }
 
                     is CombineLatestEvent.OnComplete -> {
-                        val remainingActiveSources = activeSourceCount.incrementAndGet(-1)
+                        val remainingActiveSources = activeSourceCount.addAndGet(-1)
 
                         // Complete if all sources are completed or a source is completed without a value
                         val allCompleted = (remainingActiveSources == 0) || (values.value[event.index] === Uninitialized)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/CombineLatest.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/CombineLatest.kt
@@ -4,8 +4,9 @@ import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.utils.Uninitialized
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.updateAndGet
+import com.badoo.reaktive.utils.atomic.AtomicInt
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.updateAndGet
 import com.badoo.reaktive.utils.replace
 import com.badoo.reaktive.utils.serializer.serializer
 
@@ -14,7 +15,7 @@ fun <T, R> Collection<Observable<T>>.combineLatest(mapper: (List<T>) -> R): Obse
         val disposables = CompositeDisposable()
         emitter.setDisposable(disposables)
         val values = AtomicReference<List<Any?>>(List(size) { Uninitialized }, true)
-        val activeSourceCount = AtomicReference(size)
+        val activeSourceCount = AtomicInt(size)
 
         val serializer =
             serializer<CombineLatestEvent<T>> { event ->
@@ -44,7 +45,7 @@ fun <T, R> Collection<Observable<T>>.combineLatest(mapper: (List<T>) -> R): Obse
                     }
 
                     is CombineLatestEvent.OnComplete -> {
-                        val remainingActiveSources = activeSourceCount.updateAndGet { it - 1 }
+                        val remainingActiveSources = activeSourceCount.incrementAndGet(-1)
 
                         // Complete if all sources are completed or a source is completed without a value
                         val allCompleted = (remainingActiveSources == 0) || (values.value[event.index] === Uninitialized)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Concat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Concat.kt
@@ -27,7 +27,7 @@ fun <T> Iterable<Observable<T>>.concat(): Observable<T> =
 
                 override fun onComplete() {
                     sourceIndex
-                        .incrementAndGet(1)
+                        .addAndGet(1)
                         .let(sources::getOrNull)
                         ?.subscribeSafe(this)
                         ?: observer.onComplete()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Concat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Concat.kt
@@ -3,9 +3,7 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.freeze
-import com.badoo.reaktive.utils.atomicreference.updateAndGet
+import com.badoo.reaktive.utils.atomic.AtomicInt
 
 fun <T> Iterable<Observable<T>>.concat(): Observable<T> =
     observableUnsafe { observer ->
@@ -19,7 +17,7 @@ fun <T> Iterable<Observable<T>>.concat(): Observable<T> =
             return@observableUnsafe
         }
 
-        val sourceIndex = AtomicReference(0)
+        val sourceIndex = AtomicInt()
 
         val upstreamObserver =
             object : ObservableObserver<T>, ObservableCallbacks<T> by observer {
@@ -29,7 +27,7 @@ fun <T> Iterable<Observable<T>>.concat(): Observable<T> =
 
                 override fun onComplete() {
                     sourceIndex
-                        .updateAndGet { it + 1 }
+                        .incrementAndGet(1)
                         .let(sources::getOrNull)
                         ?.subscribeSafe(this)
                         ?: observer.onComplete()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ConcatMap.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ConcatMap.kt
@@ -6,9 +6,9 @@ import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.getAndUpdate
-import com.badoo.reaktive.utils.atomicreference.updateAndGet
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.getAndUpdate
+import com.badoo.reaktive.utils.atomic.updateAndGet
 
 fun <T, R> Observable<T>.concatMap(mapper: (T) -> Observable<R>): Observable<R> =
     observable { emitter ->

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Debounce.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Debounce.kt
@@ -4,8 +4,8 @@ import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.update
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.update
 
 fun <T> Observable<T>.debounce(timeoutMillis: Long, scheduler: Scheduler): Observable<T> =
     observable { emitter ->

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DistinctUntilChanged.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DistinctUntilChanged.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.utils.Uninitialized
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicReference
 
 fun <T> Observable<T>.distinctUntilChanged(comparator: (T, T) -> Boolean = ::equals): Observable<T> =
     distinctUntilChanged({ it }, comparator)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DoOnBefore.kt
@@ -8,7 +8,7 @@ import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.wrap
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 
 fun <T> Observable<T>.doOnBeforeSubscribe(action: (Disposable) -> Unit): Observable<T> =
     observableUnsafe { observer ->
@@ -131,7 +131,7 @@ fun <T> Observable<T>.doOnBeforeDispose(action: () -> Unit): Observable<T> =
 
 fun <T> Observable<T>.doOnBeforeFinally(action: () -> Unit): Observable<T> =
     observableUnsafe { observer ->
-        val isFinished = AtomicReference(false)
+        val isFinished = AtomicBoolean()
 
         fun onFinally() {
             @Suppress("BooleanLiteralArgument") // Not allowed for expected classes

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMap.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMap.kt
@@ -30,7 +30,7 @@ fun <T, R> Observable<T>.flatMap(mapper: (T) -> Observable<R>): Observable<R> =
                 }
 
                 override fun onNext(value: T) {
-                    activeSourceCount.incrementAndGet(1)
+                    activeSourceCount.addAndGet(1)
 
                     serializedEmitter.tryCatch({ mapper(value) }) {
                         it.subscribeSafe(mappedObserver)
@@ -38,7 +38,7 @@ fun <T, R> Observable<T>.flatMap(mapper: (T) -> Observable<R>): Observable<R> =
                 }
 
                 override fun onComplete() {
-                    if (activeSourceCount.incrementAndGet(-1) <= 0) {
+                    if (activeSourceCount.addAndGet(-1) <= 0) {
                         serializedEmitter.onComplete()
                     }
                 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Sample.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Sample.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicReference
 
 fun <T> Observable<T>.sample(windowMillis: Long, scheduler: Scheduler): Observable<T> =
     observable { emitter ->

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Scan.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Scan.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.utils.Uninitialized
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicReference
 
 fun <T> Observable<T>.scan(accumulate: (acc: T, value: T) -> T): Observable<T> =
     observable { emitter ->

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Skip.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Skip.kt
@@ -3,8 +3,7 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.update
+import com.badoo.reaktive.utils.atomic.AtomicLong
 
 fun <T> Observable<T>.skip(count: Long): Observable<T> =
     observableUnsafe { observer ->
@@ -13,14 +12,14 @@ fun <T> Observable<T>.skip(count: Long): Observable<T> =
 
         subscribeSafe(
             object : ObservableObserver<T>, ObservableCallbacks<T> by observer {
-                private var remaining = AtomicReference(count)
+                private var remaining = AtomicLong(count)
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)
                 }
 
                 override fun onNext(value: T) {
                     if (remaining.value != 0L) {
-                        remaining.update { it - 1 }
+                        remaining.incrementAndGet(-1)
                     } else {
                         observer.onNext(value)
                     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Skip.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Skip.kt
@@ -19,7 +19,7 @@ fun <T> Observable<T>.skip(count: Long): Observable<T> =
 
                 override fun onNext(value: T) {
                     if (remaining.value != 0L) {
-                        remaining.incrementAndGet(-1)
+                        remaining.addAndGet(-1)
                     } else {
                         observer.onNext(value)
                     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SwitchIfEmpty.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SwitchIfEmpty.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 
 fun <T> Observable<T>.switchIfEmpty(otherObservable: Observable<T>): Observable<T> =
     switchIfEmpty { otherObservable }
@@ -17,7 +17,7 @@ fun <T> Observable<T>.switchIfEmpty(otherObservable: () -> Observable<T>): Obser
 
         subscribeSafe(
             object : ObservableObserver<T>, ErrorCallback by emitter {
-                private val isEmpty = AtomicReference(true)
+                private val isEmpty = AtomicBoolean(true)
 
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Throttle.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Throttle.kt
@@ -3,7 +3,7 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicLong
 import com.badoo.reaktive.utils.uptimeMillis
 
 private val getTimeMillis = ::uptimeMillis
@@ -17,7 +17,7 @@ internal fun <T> Observable<T>.throttle(windowMillis: Long, getTimeMillis: () ->
 
         subscribeSafe(
             object : ObservableObserver<T>, ObservableCallbacks<T> by observer {
-                private val lastTime = AtomicReference(-windowMillis)
+                private val lastTime = AtomicLong(-windowMillis)
 
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/WithLatestFrom.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/WithLatestFrom.kt
@@ -7,8 +7,8 @@ import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.utils.Uninitialized
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.update
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.update
 import com.badoo.reaktive.utils.replace
 
 fun <T, U, R> Observable<T>.withLatestFrom(

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Zip.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Zip.kt
@@ -3,11 +3,11 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicReference
 import com.badoo.reaktive.utils.replace
 import com.badoo.reaktive.utils.serializer.serializer
-import com.badoo.reaktive.utils.atomicreference.update
-import com.badoo.reaktive.utils.atomicreference.updateAndGet
+import com.badoo.reaktive.utils.atomic.update
+import com.badoo.reaktive.utils.atomic.updateAndGet
 
 fun <T, R> Collection<Observable<T>>.zip(mapper: (List<T>) -> R): Observable<R> =
     observable { emitter ->

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/scheduler/Schedulers.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/scheduler/Schedulers.kt
@@ -1,6 +1,6 @@
 package com.badoo.reaktive.scheduler
 
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicReference
 import kotlin.native.concurrent.SharedImmutable
 
 /**

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/scheduler/TrampolineScheduler.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/scheduler/TrampolineScheduler.kt
@@ -88,7 +88,7 @@ internal class TrampolineScheduler(
             val periodMillis: Long,
             val task: () -> Unit
         ) : Comparable<Task> {
-            private val sequenceNumber = sequencer.incrementAndGet(1)
+            private val sequenceNumber = sequencer.addAndGet(1)
 
             override fun compareTo(other: Task): Int =
                 if (this === other) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/scheduler/TrampolineScheduler.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/scheduler/TrampolineScheduler.kt
@@ -1,8 +1,8 @@
 package com.badoo.reaktive.scheduler
 
 import com.badoo.reaktive.disposable.CompositeDisposable
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.updateAndGet
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
+import com.badoo.reaktive.utils.atomic.AtomicLong
 import com.badoo.reaktive.utils.serializer.serializer
 import com.badoo.reaktive.utils.uptimeMillis
 
@@ -27,7 +27,7 @@ internal class TrampolineScheduler(
     ) : Scheduler.Executor {
 
         private val serializer = serializer(comparator = Comparator(Task::compareTo), onValue = ::execute)
-        private val _isDisposed = AtomicReference(false)
+        private val _isDisposed = AtomicBoolean()
         override val isDisposed: Boolean get() = _isDisposed.value
 
         override fun dispose() {
@@ -88,7 +88,7 @@ internal class TrampolineScheduler(
             val periodMillis: Long,
             val task: () -> Unit
         ) : Comparable<Task> {
-            private val sequenceNumber = sequencer.updateAndGet(Long::inc)
+            private val sequenceNumber = sequencer.incrementAndGet(1)
 
             override fun compareTo(other: Task): Int =
                 if (this === other) {
@@ -101,7 +101,7 @@ internal class TrampolineScheduler(
                 }
 
             private companion object {
-                private val sequencer = AtomicReference(0L)
+                private val sequencer = AtomicLong()
             }
         }
     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/BlockingGet.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/BlockingGet.kt
@@ -1,7 +1,7 @@
 package com.badoo.reaktive.single
 
 import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicReference
 import com.badoo.reaktive.utils.synchronized
 import com.badoo.reaktive.utils.useCondition
 import com.badoo.reaktive.utils.useLock

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/DoOnBefore.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.wrap
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 
 fun <T> Single<T>.doOnBeforeSubscribe(action: (Disposable) -> Unit): Single<T> =
     singleUnsafe { observer ->
@@ -110,7 +110,7 @@ fun <T> Single<T>.doOnBeforeDispose(action: () -> Unit): Single<T> =
 
 fun <T> Single<T>.doOnBeforeFinally(action: () -> Unit): Single<T> =
     singleUnsafe { observer ->
-        val isFinished = AtomicReference(false)
+        val isFinished = AtomicBoolean()
 
         fun onFinally() {
             @Suppress("BooleanLiteralArgument") // Not allowed for expected classes

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/DefaultSubject.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/DefaultSubject.kt
@@ -3,8 +3,8 @@ package com.badoo.reaktive.subject
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.disposable
 import com.badoo.reaktive.observable.ObservableObserver
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.update
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.update
 import com.badoo.reaktive.utils.serializer.serializer
 
 internal open class DefaultSubject<T> : Subject<T> {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/behavior/Various.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/behavior/Various.kt
@@ -2,7 +2,7 @@ package com.badoo.reaktive.subject.behavior
 
 import com.badoo.reaktive.observable.ObservableObserver
 import com.badoo.reaktive.subject.DefaultSubject
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicReference
 
 fun <T> behaviorSubject(initialValue: T): BehaviorSubject<T> =
     object : DefaultSubject<T>(), BehaviorSubject<T> {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/UncaughtErrorHandler.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/UncaughtErrorHandler.kt
@@ -1,6 +1,6 @@
 package com.badoo.reaktive.utils
 
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicReference
 import kotlin.native.concurrent.SharedImmutable
 
 @SharedImmutable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicBoolean.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicBoolean.kt
@@ -1,0 +1,8 @@
+package com.badoo.reaktive.utils.atomic
+
+expect class AtomicBoolean(initialValue: Boolean = false) {
+
+    var value: Boolean
+
+    fun compareAndSet(expectedValue: Boolean, newValue: Boolean): Boolean
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicInt.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicInt.kt
@@ -4,7 +4,7 @@ expect class AtomicInt(initialValue: Int = 0) {
 
     var value: Int
 
-    fun incrementAndGet(delta: Int): Int
+    fun addAndGet(delta: Int): Int
 
     fun compareAndSet(expectedValue: Int, newValue: Int): Boolean
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicInt.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicInt.kt
@@ -1,0 +1,10 @@
+package com.badoo.reaktive.utils.atomic
+
+expect class AtomicInt(initialValue: Int = 0) {
+
+    var value: Int
+
+    fun incrementAndGet(delta: Int): Int
+
+    fun compareAndSet(expectedValue: Int, newValue: Int): Boolean
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLong.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLong.kt
@@ -4,7 +4,7 @@ expect class AtomicLong(initialValue: Long = 0L) {
 
     var value: Long
 
-    fun incrementAndGet(delta: Long): Long
+    fun addAndGet(delta: Long): Long
 
     fun compareAndSet(expectedValue: Long, newValue: Long): Boolean
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLong.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLong.kt
@@ -1,0 +1,10 @@
+package com.badoo.reaktive.utils.atomic
+
+expect class AtomicLong(initialValue: Long = 0L) {
+
+    var value: Long
+
+    fun incrementAndGet(delta: Long): Long
+
+    fun compareAndSet(expectedValue: Long, newValue: Long): Boolean
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicReference.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicReference.kt
@@ -1,4 +1,4 @@
-package com.badoo.reaktive.utils.atomicreference
+package com.badoo.reaktive.utils.atomic
 
 expect class AtomicReference<T>(
     initialValue: T,
@@ -6,8 +6,6 @@ expect class AtomicReference<T>(
 ) {
 
     var value: T
-
-    fun getAndSet(value: T): T
 
     fun compareAndSet(expectedValue: T, newValue: T): Boolean
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicReferenceExt.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicReferenceExt.kt
@@ -1,4 +1,6 @@
-package com.badoo.reaktive.utils.atomicreference
+package com.badoo.reaktive.utils.atomic
+
+fun <T> AtomicReference<T>.getAndSet(value: T): T = getAndUpdate { value }
 
 inline fun <T> AtomicReference<T>.getAndUpdate(update: (T) -> T): T {
     var prev: T

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeCompleteTest.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.test.completable.DefaultCompletableObserver
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -37,7 +37,7 @@ class DoOnBeforeCompleteTest
 
     @Test
     fun does_not_call_action_WHEN_produced_error() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeComplete {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeDisposeTest.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.disposable.disposable
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -36,7 +36,7 @@ class DoOnBeforeDisposeTest
 
     @Test
     fun does_not_call_action_WHEN_completed() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeDispose {
@@ -51,7 +51,7 @@ class DoOnBeforeDisposeTest
 
     @Test
     fun does_not_call_action_WHEN_produced_error() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeDispose {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeErrorTest.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.test.completable.DefaultCompletableObserver
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -38,7 +38,7 @@ class DoOnBeforeErrorTest
 
     @Test
     fun does_not_call_action_WHEN_completed() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeError {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeFinallyTest.kt
@@ -83,7 +83,7 @@ class DoOnBeforeFinallyTest
 
         upstream
             .doOnBeforeFinally {
-                count.incrementAndGet(1)
+                count.addAndGet(1)
             }
             .test()
             .dispose()
@@ -99,7 +99,7 @@ class DoOnBeforeFinallyTest
 
         upstream
             .doOnBeforeFinally {
-                count.incrementAndGet(1)
+                count.addAndGet(1)
             }
             .test()
             .dispose()
@@ -116,7 +116,7 @@ class DoOnBeforeFinallyTest
         val observer =
             upstream
                 .doOnBeforeFinally {
-                    count.incrementAndGet(1)
+                    count.addAndGet(1)
                 }
                 .test()
 
@@ -133,7 +133,7 @@ class DoOnBeforeFinallyTest
         val observer =
             upstream
                 .doOnBeforeFinally {
-                    count.incrementAndGet(1)
+                    count.addAndGet(1)
                 }
                 .test()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeFinallyTest.kt
@@ -5,8 +5,7 @@ import com.badoo.reaktive.test.completable.DefaultCompletableObserver
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.update
+import com.badoo.reaktive.utils.atomic.AtomicInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -80,11 +79,11 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun does_not_call_action_second_time_WHEN_downstream_disposed_and_upstream_completed() {
-        val count = AtomicReference(0)
+        val count = AtomicInt()
 
         upstream
             .doOnBeforeFinally {
-                count.update(Int::inc)
+                count.incrementAndGet(1)
             }
             .test()
             .dispose()
@@ -96,11 +95,11 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun does_not_call_action_second_time_WHEN_downstream_disposed_and_upstream_produced_error() {
-        val count = AtomicReference(0)
+        val count = AtomicInt()
 
         upstream
             .doOnBeforeFinally {
-                count.update(Int::inc)
+                count.incrementAndGet(1)
             }
             .test()
             .dispose()
@@ -112,12 +111,12 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun does_not_call_action_second_time_WHEN_upstream_completed_and_downstream_disposed() {
-        val count = AtomicReference(0)
+        val count = AtomicInt()
 
         val observer =
             upstream
                 .doOnBeforeFinally {
-                    count.update(Int::inc)
+                    count.incrementAndGet(1)
                 }
                 .test()
 
@@ -129,12 +128,12 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun does_not_call_action_second_time_WHEN_upstream_produced_error_and_downstream_disposed() {
-        val count = AtomicReference(0)
+        val count = AtomicInt()
 
         val observer =
             upstream
                 .doOnBeforeFinally {
-                    count.update(Int::inc)
+                    count.incrementAndGet(1)
                 }
                 .test()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeSubscribeTest.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.completable.DefaultCompletableObserver
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -59,7 +59,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun does_not_call_action_WHEN_onSubscribe_received_from_upstream() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         completableUnsafe { observer ->
             isCalled.value = false
@@ -75,7 +75,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun does_not_call_action_WHEN_completed() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
         val upstream = TestCompletable()
 
         upstream
@@ -93,7 +93,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun does_not_call_action_WHEN_produced_error() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
         val upstream = TestCompletable()
 
         upstream

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeCompleteTest.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -37,7 +37,7 @@ class DoOnBeforeCompleteTest
 
     @Test
     fun does_not_call_action_WHEN_succeeded() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeComplete {
@@ -52,7 +52,7 @@ class DoOnBeforeCompleteTest
 
     @Test
     fun does_not_call_action_WHEN_produced_error() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeComplete {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeDisposeTest.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.disposable.disposable
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -36,7 +36,7 @@ class DoOnBeforeDisposeTest
 
     @Test
     fun does_not_call_action_WHEN_succeeded() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeDispose {
@@ -51,7 +51,7 @@ class DoOnBeforeDisposeTest
 
     @Test
     fun does_not_call_action_WHEN_completed() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeDispose {
@@ -66,7 +66,7 @@ class DoOnBeforeDisposeTest
 
     @Test
     fun does_not_call_action_WHEN_produced_error() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeDispose {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeErrorTest.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -38,7 +38,7 @@ class DoOnBeforeErrorTest
 
     @Test
     fun does_not_call_action_WHEN_succeeded_value() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeError {
@@ -53,7 +53,7 @@ class DoOnBeforeErrorTest
 
     @Test
     fun does_not_call_action_WHEN_completed() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeError {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeFinallyTest.kt
@@ -5,8 +5,7 @@ import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.update
+import com.badoo.reaktive.utils.atomic.AtomicInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -80,11 +79,11 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun does_not_call_action_second_time_WHEN_downstream_disposed_and_upstream_completed() {
-        val count = AtomicReference(0)
+        val count = AtomicInt()
 
         upstream
             .doOnBeforeFinally {
-                count.update(Int::inc)
+                count.incrementAndGet(1)
             }
             .test()
             .dispose()
@@ -96,11 +95,11 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun does_not_call_action_second_time_WHEN_downstream_disposed_and_upstream_produced_error() {
-        val count = AtomicReference(0)
+        val count = AtomicInt()
 
         upstream
             .doOnBeforeFinally {
-                count.update(Int::inc)
+                count.incrementAndGet(1)
             }
             .test()
             .dispose()
@@ -112,12 +111,12 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun does_not_call_action_second_time_WHEN_upstream_completed_and_downstream_disposed() {
-        val count = AtomicReference(0)
+        val count = AtomicInt()
 
         val observer =
             upstream
                 .doOnBeforeFinally {
-                    count.update(Int::inc)
+                    count.incrementAndGet(1)
                 }
                 .test()
 
@@ -129,12 +128,12 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun does_not_call_action_second_time_WHEN_upstream_produced_error_and_downstream_disposed() {
-        val count = AtomicReference(0)
+        val count = AtomicInt()
 
         val observer =
             upstream
                 .doOnBeforeFinally {
-                    count.update(Int::inc)
+                    count.incrementAndGet(1)
                 }
                 .test()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeFinallyTest.kt
@@ -83,7 +83,7 @@ class DoOnBeforeFinallyTest
 
         upstream
             .doOnBeforeFinally {
-                count.incrementAndGet(1)
+                count.addAndGet(1)
             }
             .test()
             .dispose()
@@ -99,7 +99,7 @@ class DoOnBeforeFinallyTest
 
         upstream
             .doOnBeforeFinally {
-                count.incrementAndGet(1)
+                count.addAndGet(1)
             }
             .test()
             .dispose()
@@ -116,7 +116,7 @@ class DoOnBeforeFinallyTest
         val observer =
             upstream
                 .doOnBeforeFinally {
-                    count.incrementAndGet(1)
+                    count.addAndGet(1)
                 }
                 .test()
 
@@ -133,7 +133,7 @@ class DoOnBeforeFinallyTest
         val observer =
             upstream
                 .doOnBeforeFinally {
-                    count.incrementAndGet(1)
+                    count.addAndGet(1)
                 }
                 .test()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSubscribeTest.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -59,7 +59,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun does_not_call_action_WHEN_onSubscribe_received_from_upstream() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         maybeUnsafe<Nothing> { observer ->
             isCalled.value = false
@@ -75,7 +75,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun does_not_call_action_WHEN_succeeded() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
         val upstream = TestMaybe<Int>()
 
         upstream
@@ -92,7 +92,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun does_not_call_action_WHEN_completed() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
         val upstream = TestMaybe<Nothing>()
 
         upstream
@@ -110,7 +110,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun does_not_call_action_WHEN_produced_error() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
         val upstream = TestMaybe<Nothing>()
 
         upstream

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSuccessTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSuccessTest.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -37,7 +37,7 @@ class DoOnBeforeSuccessTest
 
     @Test
     fun does_not_call_action_WHEN_completed() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeSuccess {
@@ -52,7 +52,7 @@ class DoOnBeforeSuccessTest
 
     @Test
     fun does_not_call_action_WHEN_produced_error() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeSuccess {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeCompleteTest.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.test.observable.DefaultObservableObserver
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -37,7 +37,7 @@ class DoOnBeforeCompleteTest
 
     @Test
     fun does_not_call_action_WHEN_emitted_value() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeComplete {
@@ -52,7 +52,7 @@ class DoOnBeforeCompleteTest
 
     @Test
     fun does_not_call_action_WHEN_produced_error() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeComplete {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeDisposeTest.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.disposable.disposable
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -36,7 +36,7 @@ class DoOnBeforeDisposeTest
 
     @Test
     fun does_not_call_action_WHEN_emitted_value() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeDispose {
@@ -51,7 +51,7 @@ class DoOnBeforeDisposeTest
 
     @Test
     fun does_not_call_action_WHEN_completed() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeDispose {
@@ -66,7 +66,7 @@ class DoOnBeforeDisposeTest
 
     @Test
     fun does_not_call_action_WHEN_produced_error() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeDispose {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeErrorTest.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.test.observable.DefaultObservableObserver
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -38,7 +38,7 @@ class DoOnBeforeErrorTest
 
     @Test
     fun does_not_call_action_WHEN_emitted_value() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeError {
@@ -53,7 +53,7 @@ class DoOnBeforeErrorTest
 
     @Test
     fun does_not_call_action_WHEN_completed() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeError {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeFinallyTest.kt
@@ -5,8 +5,8 @@ import com.badoo.reaktive.test.observable.DefaultObservableObserver
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.update
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
+import com.badoo.reaktive.utils.atomic.AtomicInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -81,11 +81,11 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun does_not_call_action_second_time_WHEN_downstream_disposed_and_upstream_completed() {
-        val count = AtomicReference(0)
+        val count = AtomicInt()
 
         upstream
             .doOnBeforeFinally {
-                count.update(Int::inc)
+                count.incrementAndGet(1)
             }
             .test()
             .dispose()
@@ -97,11 +97,11 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun does_not_call_action_second_time_WHEN_downstream_disposed_and_upstream_produced_error() {
-        val count = AtomicReference(0)
+        val count = AtomicInt()
 
         upstream
             .doOnBeforeFinally {
-                count.update(Int::inc)
+                count.incrementAndGet(1)
             }
             .test()
             .dispose()
@@ -113,12 +113,12 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun does_not_call_action_second_time_WHEN_upstream_completed_and_downstream_disposed() {
-        val count = AtomicReference(0)
+        val count = AtomicInt()
 
         val observer =
             upstream
                 .doOnBeforeFinally {
-                    count.update(Int::inc)
+                    count.incrementAndGet(1)
                 }
                 .test()
 
@@ -130,12 +130,12 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun does_not_call_action_second_time_WHEN_upstream_produced_error_and_downstream_disposed() {
-        val count = AtomicReference(0)
+        val count = AtomicInt()
 
         val observer =
             upstream
                 .doOnBeforeFinally {
-                    count.update(Int::inc)
+                    count.incrementAndGet(1)
                 }
                 .test()
 
@@ -147,7 +147,7 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun does_not_call_action_WHEN_emitted_value() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeFinally {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeFinallyTest.kt
@@ -85,7 +85,7 @@ class DoOnBeforeFinallyTest
 
         upstream
             .doOnBeforeFinally {
-                count.incrementAndGet(1)
+                count.addAndGet(1)
             }
             .test()
             .dispose()
@@ -101,7 +101,7 @@ class DoOnBeforeFinallyTest
 
         upstream
             .doOnBeforeFinally {
-                count.incrementAndGet(1)
+                count.addAndGet(1)
             }
             .test()
             .dispose()
@@ -118,7 +118,7 @@ class DoOnBeforeFinallyTest
         val observer =
             upstream
                 .doOnBeforeFinally {
-                    count.incrementAndGet(1)
+                    count.addAndGet(1)
                 }
                 .test()
 
@@ -135,7 +135,7 @@ class DoOnBeforeFinallyTest
         val observer =
             upstream
                 .doOnBeforeFinally {
-                    count.incrementAndGet(1)
+                    count.addAndGet(1)
                 }
                 .test()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeNextTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeNextTest.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.test.observable.DefaultObservableObserver
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -38,7 +38,7 @@ class DoOnBeforeNextTest
 
     @Test
     fun does_not_call_action_WHEN_completed() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeNext {
@@ -53,7 +53,7 @@ class DoOnBeforeNextTest
 
     @Test
     fun does_not_call_action_WHEN_produced_error() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeNext {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeSubscribeTest.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.observable.DefaultObservableObserver
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -59,7 +59,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun does_not_call_action_WHEN_onSubscribe_received_from_upstream() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         observableUnsafe<Nothing> { observer ->
             isCalled.value = false
@@ -75,7 +75,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun does_not_call_action_WHEN_emitted_value() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
         val upstream = TestObservable<Int>()
 
         upstream
@@ -92,7 +92,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun does_not_call_action_WHEN_completed() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
         val upstream = TestObservable<Nothing>()
 
         upstream
@@ -110,7 +110,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun does_not_call_action_WHEN_produced_error() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
         val upstream = TestObservable<Nothing>()
 
         upstream

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeTerminateTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeTerminateTest.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.test.observable.DefaultObservableObserver
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -58,7 +58,7 @@ class DoOnBeforeTerminateTest
 
     @Test
     fun does_not_call_action_WHEN_emitted_value() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeFinally {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ThrottleTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ThrottleTest.kt
@@ -4,14 +4,14 @@ import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.hasOnNext
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.observable.values
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicLong
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class ThrottleTest : ObservableToObservableTests by ObservableToObservableTests<Unit>({ throttle(0L) }) {
 
-    private val timeMillis = AtomicReference(0L)
+    private val timeMillis = AtomicLong(0L)
     private val upstream = TestObservable<Int>()
     private val observer = upstream.throttle(100L, timeMillis::value).test()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeDisposeTest.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.disposable.disposable
 import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.test.single.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -36,7 +36,7 @@ class DoOnBeforeDisposeTest
 
     @Test
     fun does_not_call_action_WHEN_succeeded() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeDispose {
@@ -51,7 +51,7 @@ class DoOnBeforeDisposeTest
 
     @Test
     fun does_not_call_action_WHEN_produced_error() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeDispose {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeErrorTest.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.test.single.DefaultSingleObserver
 import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.test.single.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -38,7 +38,7 @@ class DoOnBeforeErrorTest
 
     @Test
     fun does_not_call_action_WHEN_succeeded_value() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeError {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeFinallyTest.kt
@@ -83,7 +83,7 @@ class DoOnBeforeFinallyTest
 
         upstream
             .doOnBeforeFinally {
-                count.incrementAndGet(1)
+                count.addAndGet(1)
             }
             .test()
             .dispose()
@@ -99,7 +99,7 @@ class DoOnBeforeFinallyTest
 
         upstream
             .doOnBeforeFinally {
-                count.incrementAndGet(1)
+                count.addAndGet(1)
             }
             .test()
             .dispose()
@@ -116,7 +116,7 @@ class DoOnBeforeFinallyTest
         val observer =
             upstream
                 .doOnBeforeFinally {
-                    count.incrementAndGet(1)
+                    count.addAndGet(1)
                 }
                 .test()
 
@@ -133,7 +133,7 @@ class DoOnBeforeFinallyTest
         val observer =
             upstream
                 .doOnBeforeFinally {
-                    count.incrementAndGet(1)
+                    count.addAndGet(1)
                 }
                 .test()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeFinallyTest.kt
@@ -5,8 +5,7 @@ import com.badoo.reaktive.test.single.DefaultSingleObserver
 import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.test.single.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.update
+import com.badoo.reaktive.utils.atomic.AtomicInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -80,11 +79,11 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun does_not_call_action_second_time_WHEN_downstream_disposed_and_upstream_succeded() {
-        val count = AtomicReference(0)
+        val count = AtomicInt()
 
         upstream
             .doOnBeforeFinally {
-                count.update(Int::inc)
+                count.incrementAndGet(1)
             }
             .test()
             .dispose()
@@ -96,11 +95,11 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun does_not_call_action_second_time_WHEN_downstream_disposed_and_upstream_produced_error() {
-        val count = AtomicReference(0)
+        val count = AtomicInt()
 
         upstream
             .doOnBeforeFinally {
-                count.update(Int::inc)
+                count.incrementAndGet(1)
             }
             .test()
             .dispose()
@@ -112,12 +111,12 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun does_not_call_action_second_time_WHEN_upstream_succeeded_and_downstream_disposed() {
-        val count = AtomicReference(0)
+        val count = AtomicInt()
 
         val observer =
             upstream
                 .doOnBeforeFinally {
-                    count.update(Int::inc)
+                    count.incrementAndGet(1)
                 }
                 .test()
 
@@ -129,12 +128,12 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun does_not_call_action_second_time_WHEN_upstream_produced_error_and_downstream_disposed() {
-        val count = AtomicReference(0)
+        val count = AtomicInt()
 
         val observer =
             upstream
                 .doOnBeforeFinally {
-                    count.update(Int::inc)
+                    count.incrementAndGet(1)
                 }
                 .test()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSubscribeTest.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.single.DefaultSingleObserver
 import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.test.single.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -59,7 +59,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun does_not_call_action_WHEN_onSubscribe_received_from_upstream() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         singleUnsafe<Nothing> { observer ->
             isCalled.value = false
@@ -75,7 +75,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun does_not_call_action_WHEN_succeeded() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
         val upstream = TestSingle<Int>()
 
         upstream
@@ -92,7 +92,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun does_not_call_action_WHEN_produced_error() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
         val upstream = TestSingle<Nothing>()
 
         upstream

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSuccessTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSuccessTest.kt
@@ -4,7 +4,7 @@ import com.badoo.reaktive.test.single.DefaultSingleObserver
 import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.test.single.test
 import com.badoo.reaktive.test.utils.SafeMutableList
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -37,7 +37,7 @@ class DoOnBeforeSuccessTest
 
     @Test
     fun does_not_call_action_WHEN_produced_error() {
-        val isCalled = AtomicReference(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnBeforeSuccess {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/subject/SubjectGenericTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/subject/SubjectGenericTests.kt
@@ -86,7 +86,7 @@ private class SubjectGenericTestsImpl(
                 }
 
                 override fun onNext(value: Int?) {
-                    count.incrementAndGet(1)
+                    count.addAndGet(1)
                     if (value == 0) {
                         subject.onNext(1)
                         success.value = count.value == 1

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/subject/SubjectGenericTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/subject/SubjectGenericTests.kt
@@ -8,8 +8,8 @@ import com.badoo.reaktive.test.observable.isComplete
 import com.badoo.reaktive.test.observable.isError
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.observable.values
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.update
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
+import com.badoo.reaktive.utils.atomic.AtomicInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -77,8 +77,8 @@ private class SubjectGenericTestsImpl(
     }
 
     override fun does_not_emit_values_recursively() {
-        val count = AtomicReference(0)
-        val success = AtomicReference(false)
+        val count = AtomicInt()
+        val success = AtomicBoolean()
 
         subject.subscribe(
             object : ObservableObserver<Int?> {
@@ -86,7 +86,7 @@ private class SubjectGenericTestsImpl(
                 }
 
                 override fun onNext(value: Int?) {
-                    count.update { it + 1 }
+                    count.incrementAndGet(1)
                     if (value == 0) {
                         subject.onNext(1)
                         success.value = count.value == 1

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/test/utils/SafeMutableList.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/test/utils/SafeMutableList.kt
@@ -1,7 +1,7 @@
 package com.badoo.reaktive.test.utils
 
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.update
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.update
 
 class SafeMutableList<T> {
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicBooleanTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicBooleanTest.kt
@@ -1,0 +1,45 @@
+package com.badoo.reaktive.utils.atomic
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AtomicBooleanTest {
+
+    @Test
+    fun default_initial_value_is_false() {
+        assertFalse(AtomicBoolean().value)
+    }
+
+    @Test
+    fun compareAndSet_success_from_false_to_true() {
+        val ref = AtomicBoolean(false)
+        val result = ref.compareAndSet(false, true)
+        assertTrue(result)
+        assertTrue(ref.value)
+    }
+
+    @Test
+    fun compareAndSet_fail_from_false_to_true() {
+        val ref = AtomicBoolean(false)
+        val result = ref.compareAndSet(true, true)
+        assertFalse(result)
+        assertFalse(ref.value)
+    }
+
+    @Test
+    fun compareAndSet_success_from_true_to_false() {
+        val ref = AtomicBoolean(true)
+        val result = ref.compareAndSet(true, false)
+        assertTrue(result)
+        assertFalse(ref.value)
+    }
+
+    @Test
+    fun compareAndSet_fail_from_true_to_false() {
+        val ref = AtomicBoolean(true)
+        val result = ref.compareAndSet(false, false)
+        assertFalse(result)
+        assertTrue(ref.value)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicIntTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicIntTest.kt
@@ -8,6 +8,13 @@ import kotlin.test.assertTrue
 class AtomicIntTest {
 
     @Test
+    fun foo() {
+        val ref = AtomicReference(128)
+        val v = ref.value
+        assertTrue(ref.compareAndSet(v, 129))
+    }
+
+    @Test
     fun default_initial_value_is_0() {
         assertEquals(0, AtomicInt().value)
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicIntTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicIntTest.kt
@@ -8,13 +8,6 @@ import kotlin.test.assertTrue
 class AtomicIntTest {
 
     @Test
-    fun foo() {
-        val ref = AtomicReference(128)
-        val v = ref.value
-        assertTrue(ref.compareAndSet(v, 129))
-    }
-
-    @Test
     fun default_initial_value_is_0() {
         assertEquals(0, AtomicInt().value)
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicIntTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicIntTest.kt
@@ -13,31 +13,31 @@ class AtomicIntTest {
     }
 
     @Test
-    fun incrementAndGet_MAX_VALUE_minus_one() {
+    fun addAndGet_MAX_VALUE_minus_one() {
         val ref = AtomicInt(Int.MAX_VALUE)
-        ref.incrementAndGet(-1)
+        ref.addAndGet(-1)
         assertEquals(Int.MAX_VALUE - 1, ref.value)
     }
 
     @Test
-    fun incrementAndGet_MAX_VALUE_plus_one() {
+    fun addAndGet_MAX_VALUE_plus_one() {
         val ref = AtomicInt(Int.MAX_VALUE)
-        ref.incrementAndGet(1)
+        ref.addAndGet(1)
         assertEquals(Int.MIN_VALUE, ref.value)
     }
 
 
     @Test
-    fun incrementAndGet_MIN_VALUE_minus_one() {
+    fun addAndGet_MIN_VALUE_minus_one() {
         val ref = AtomicInt(Int.MIN_VALUE)
-        ref.incrementAndGet(-1)
+        ref.addAndGet(-1)
         assertEquals(Int.MAX_VALUE, ref.value)
     }
 
     @Test
-    fun incrementAndGet_MIN_VALUE_plus_one() {
+    fun addAndGet_MIN_VALUE_plus_one() {
         val ref = AtomicInt(Int.MIN_VALUE)
-        ref.incrementAndGet(1)
+        ref.addAndGet(1)
         assertEquals(Int.MIN_VALUE + 1, ref.value)
     }
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicIntTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicIntTest.kt
@@ -1,0 +1,75 @@
+package com.badoo.reaktive.utils.atomic
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AtomicIntTest {
+
+    @Test
+    fun default_initial_value_is_0() {
+        assertEquals(0, AtomicInt().value)
+    }
+
+    @Test
+    fun incrementAndGet_MAX_VALUE_minus_one() {
+        val ref = AtomicInt(Int.MAX_VALUE)
+        ref.incrementAndGet(-1)
+        assertEquals(Int.MAX_VALUE - 1, ref.value)
+    }
+
+    @Test
+    fun incrementAndGet_MAX_VALUE_plus_one() {
+        val ref = AtomicInt(Int.MAX_VALUE)
+        ref.incrementAndGet(1)
+        assertEquals(Int.MIN_VALUE, ref.value)
+    }
+
+
+    @Test
+    fun incrementAndGet_MIN_VALUE_minus_one() {
+        val ref = AtomicInt(Int.MIN_VALUE)
+        ref.incrementAndGet(-1)
+        assertEquals(Int.MAX_VALUE, ref.value)
+    }
+
+    @Test
+    fun incrementAndGet_MIN_VALUE_plus_one() {
+        val ref = AtomicInt(Int.MIN_VALUE)
+        ref.incrementAndGet(1)
+        assertEquals(Int.MIN_VALUE + 1, ref.value)
+    }
+
+    @Test
+    fun compareAndSet_success_from_MAX_VALUE_to_0() {
+        val ref = AtomicInt(Int.MAX_VALUE)
+        val result = ref.compareAndSet(Int.MAX_VALUE, 0)
+        assertTrue(result)
+        assertEquals(0, ref.value)
+    }
+
+    @Test
+    fun compareAndSet_fail_from_MAX_VALUE_to_0() {
+        val ref = AtomicInt(Int.MAX_VALUE)
+        val result = ref.compareAndSet(0, 0)
+        assertFalse(result)
+        assertEquals(Int.MAX_VALUE, ref.value)
+    }
+
+    @Test
+    fun compareAndSet_success_from_MIN_VALUE_to_0() {
+        val ref = AtomicInt(Int.MIN_VALUE)
+        val result = ref.compareAndSet(Int.MIN_VALUE, 0)
+        assertTrue(result)
+        assertEquals(0, ref.value)
+    }
+
+    @Test
+    fun compareAndSet_fail_from_MIN_VALUE_to_0() {
+        val ref = AtomicInt(Int.MIN_VALUE)
+        val result = ref.compareAndSet(0, 0)
+        assertFalse(result)
+        assertEquals(Int.MIN_VALUE, ref.value)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicLongTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicLongTest.kt
@@ -1,0 +1,75 @@
+package com.badoo.reaktive.utils.atomic
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AtomicLongTest {
+
+    @Test
+    fun default_initial_value_is_0() {
+        assertEquals(0L, AtomicLong().value)
+    }
+
+    @Test
+    fun incrementAndGet_MAX_VALUE_minus_one() {
+        val ref = AtomicLong(Long.MAX_VALUE)
+        ref.incrementAndGet(-1L)
+        assertEquals(Long.MAX_VALUE - 1L, ref.value)
+    }
+
+    @Test
+    fun incrementAndGet_MAX_VALUE_plus_one() {
+        val ref = AtomicLong(Long.MAX_VALUE)
+        ref.incrementAndGet(1L)
+        assertEquals(Long.MIN_VALUE, ref.value)
+    }
+
+
+    @Test
+    fun incrementAndGet_MIN_VALUE_minus_one() {
+        val ref = AtomicLong(Long.MIN_VALUE)
+        ref.incrementAndGet(-1L)
+        assertEquals(Long.MAX_VALUE, ref.value)
+    }
+
+    @Test
+    fun incrementAndGet_MIN_VALUE_plus_one() {
+        val ref = AtomicLong(Long.MIN_VALUE)
+        ref.incrementAndGet(1L)
+        assertEquals(Long.MIN_VALUE + 1L, ref.value)
+    }
+
+    @Test
+    fun compareAndSet_success_from_MAX_VALUE_to_0() {
+        val ref = AtomicLong(Long.MAX_VALUE)
+        val result = ref.compareAndSet(Long.MAX_VALUE, 0L)
+        assertTrue(result)
+        assertEquals(0L, ref.value)
+    }
+
+    @Test
+    fun compareAndSet_fail_from_MAX_VALUE_to_0() {
+        val ref = AtomicLong(Long.MAX_VALUE)
+        val result = ref.compareAndSet(0L, 0L)
+        assertFalse(result)
+        assertEquals(Long.MAX_VALUE, ref.value)
+    }
+
+    @Test
+    fun compareAndSet_success_from_MIN_VALUE_to_0() {
+        val ref = AtomicLong(Long.MIN_VALUE)
+        val result = ref.compareAndSet(Long.MIN_VALUE, 0L)
+        assertTrue(result)
+        assertEquals(0L, ref.value)
+    }
+
+    @Test
+    fun compareAndSet_fail_from_MIN_VALUE_to_0() {
+        val ref = AtomicLong(Long.MIN_VALUE)
+        val result = ref.compareAndSet(0L, 0L)
+        assertFalse(result)
+        assertEquals(Long.MIN_VALUE, ref.value)
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicLongTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicLongTest.kt
@@ -13,31 +13,30 @@ class AtomicLongTest {
     }
 
     @Test
-    fun incrementAndGet_MAX_VALUE_minus_one() {
+    fun addAndGet_MAX_VALUE_minus_one() {
         val ref = AtomicLong(Long.MAX_VALUE)
-        ref.incrementAndGet(-1L)
+        ref.addAndGet(-1L)
         assertEquals(Long.MAX_VALUE - 1L, ref.value)
     }
 
     @Test
-    fun incrementAndGet_MAX_VALUE_plus_one() {
+    fun addAndGet_MAX_VALUE_plus_one() {
         val ref = AtomicLong(Long.MAX_VALUE)
-        ref.incrementAndGet(1L)
+        ref.addAndGet(1L)
         assertEquals(Long.MIN_VALUE, ref.value)
     }
 
-
     @Test
-    fun incrementAndGet_MIN_VALUE_minus_one() {
+    fun addAndGet_MIN_VALUE_minus_one() {
         val ref = AtomicLong(Long.MIN_VALUE)
-        ref.incrementAndGet(-1L)
+        ref.addAndGet(-1L)
         assertEquals(Long.MAX_VALUE, ref.value)
     }
 
     @Test
-    fun incrementAndGet_MIN_VALUE_plus_one() {
+    fun addAndGet_MIN_VALUE_plus_one() {
         val ref = AtomicLong(Long.MIN_VALUE)
-        ref.incrementAndGet(1L)
+        ref.addAndGet(1L)
         assertEquals(Long.MIN_VALUE + 1L, ref.value)
     }
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicReferenceTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicReferenceTest.kt
@@ -58,6 +58,5 @@ class AtomicReferenceTest {
         private const val VALUE_1 = "a"
         private const val VALUE_2 = "b"
         private const val VALUE_3 = "c"
-
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicReferenceTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicReferenceTest.kt
@@ -1,0 +1,63 @@
+package com.badoo.reaktive.utils.atomic
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class AtomicReferenceTest {
+
+    @Test
+    fun compareAndSet_success() {
+        val ref = AtomicReference(VALUE_1)
+        val result = ref.compareAndSet(VALUE_1, VALUE_2)
+        assertTrue(result)
+        assertSame(VALUE_2, ref.value)
+    }
+
+    @Test
+    fun compareAndSet_fail() {
+        val ref = AtomicReference(VALUE_1)
+        val result = ref.compareAndSet(VALUE_2, VALUE_3)
+        assertFalse(result)
+        assertSame(VALUE_1, ref.value)
+    }
+
+    @Test
+    fun getAndUpdate() {
+        val ref = AtomicReference(VALUE_1)
+        val result = ref.getAndUpdate { VALUE_2 }
+        assertSame(VALUE_1, result)
+        assertSame(VALUE_2, ref.value)
+    }
+
+    @Test
+    fun updateAndGet() {
+        val ref = AtomicReference(VALUE_1)
+        val result = ref.updateAndGet { VALUE_2 }
+        assertSame(VALUE_2, result)
+        assertSame(VALUE_2, ref.value)
+    }
+
+    @Test
+    fun getAndSet() {
+        val ref = AtomicReference(VALUE_1)
+        val result = ref.getAndSet(VALUE_2)
+        assertSame(VALUE_1, result)
+        assertSame(VALUE_2, ref.value)
+    }
+
+    @Test
+    fun update() {
+        val ref = AtomicReference(VALUE_1)
+        ref.update { VALUE_2 }
+        assertSame(VALUE_2, ref.value)
+    }
+
+    private companion object {
+        private const val VALUE_1 = "a"
+        private const val VALUE_2 = "b"
+        private const val VALUE_3 = "c"
+
+    }
+}

--- a/reaktive/src/iosCommonMain/kotlin/com/badoo/reaktive/scheduler/MainScheduler.kt
+++ b/reaktive/src/iosCommonMain/kotlin/com/badoo/reaktive/scheduler/MainScheduler.kt
@@ -3,6 +3,7 @@ package com.badoo.reaktive.scheduler
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.getAndSet
 import platform.darwin.DISPATCH_TIME_NOW
 import platform.darwin.dispatch_after
 import platform.darwin.dispatch_get_main_queue

--- a/reaktive/src/iosCommonMain/kotlin/com/badoo/reaktive/scheduler/MainScheduler.kt
+++ b/reaktive/src/iosCommonMain/kotlin/com/badoo/reaktive/scheduler/MainScheduler.kt
@@ -2,7 +2,7 @@ package com.badoo.reaktive.scheduler
 
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
+import com.badoo.reaktive.utils.atomic.AtomicReference
 import platform.darwin.DISPATCH_TIME_NOW
 import platform.darwin.dispatch_after
 import platform.darwin.dispatch_get_main_queue

--- a/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicBoolean.kt
+++ b/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicBoolean.kt
@@ -1,0 +1,14 @@
+package com.badoo.reaktive.utils.atomic
+
+actual class AtomicBoolean actual constructor(initialValue: Boolean) {
+
+    actual var value: Boolean = initialValue
+
+    actual fun compareAndSet(expectedValue: Boolean, newValue: Boolean): Boolean =
+        if (value == expectedValue) {
+            value = newValue
+            true
+        } else {
+            false
+        }
+}

--- a/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicInt.kt
+++ b/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicInt.kt
@@ -4,7 +4,7 @@ actual class AtomicInt actual constructor(initialValue: Int) {
 
     actual var value: Int = initialValue
 
-    actual fun incrementAndGet(delta: Int): Int {
+    actual fun addAndGet(delta: Int): Int {
         value += delta
 
         return value

--- a/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicInt.kt
+++ b/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicInt.kt
@@ -1,0 +1,20 @@
+package com.badoo.reaktive.utils.atomic
+
+actual class AtomicInt actual constructor(initialValue: Int) {
+
+    actual var value: Int = initialValue
+
+    actual fun incrementAndGet(delta: Int): Int {
+        value += delta
+
+        return value
+    }
+
+    actual fun compareAndSet(expectedValue: Int, newValue: Int): Boolean =
+        if (value == expectedValue) {
+            value = newValue
+            true
+        } else {
+            false
+        }
+}

--- a/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLong.kt
+++ b/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLong.kt
@@ -4,7 +4,7 @@ actual class AtomicLong actual constructor(initialValue: Long) {
 
     actual var value: Long = initialValue
 
-    actual fun incrementAndGet(delta: Long): Long {
+    actual fun addAndGet(delta: Long): Long {
         value += delta
 
         return value

--- a/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLong.kt
+++ b/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLong.kt
@@ -1,0 +1,20 @@
+package com.badoo.reaktive.utils.atomic
+
+actual class AtomicLong actual constructor(initialValue: Long) {
+
+    actual var value: Long = initialValue
+
+    actual fun incrementAndGet(delta: Long): Long {
+        value += delta
+
+        return value
+    }
+
+    actual fun compareAndSet(expectedValue: Long, newValue: Long): Boolean =
+        if (value == expectedValue) {
+            value = newValue
+            true
+        } else {
+            false
+        }
+}

--- a/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicReference.kt
+++ b/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicReference.kt
@@ -1,4 +1,4 @@
-package com.badoo.reaktive.utils.atomicreference
+package com.badoo.reaktive.utils.atomic
 
 actual class AtomicReference<T> actual constructor(
     initialValue: T,
@@ -6,13 +6,6 @@ actual class AtomicReference<T> actual constructor(
 ) {
 
     actual var value: T = initialValue
-
-    actual fun getAndSet(value: T): T {
-        val oldValue = this.value
-        this.value = value
-
-        return oldValue
-    }
 
     actual fun compareAndSet(expectedValue: T, newValue: T): Boolean =
         if (value == expectedValue) {

--- a/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicBoolean.kt
+++ b/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicBoolean.kt
@@ -1,0 +1,15 @@
+package com.badoo.reaktive.utils.atomic
+
+actual class AtomicBoolean actual constructor(initialValue: Boolean) {
+
+    private val delegate = java.util.concurrent.atomic.AtomicBoolean(initialValue)
+
+    actual var value: Boolean
+        get() = delegate.get()
+        set(value) {
+            delegate.set(value)
+        }
+
+
+    actual fun compareAndSet(expectedValue: Boolean, newValue: Boolean): Boolean = delegate.compareAndSet(expectedValue, newValue)
+}

--- a/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicInt.kt
+++ b/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicInt.kt
@@ -1,0 +1,16 @@
+package com.badoo.reaktive.utils.atomic
+
+actual class AtomicInt actual constructor(initialValue: Int) {
+
+    private val delegate = java.util.concurrent.atomic.AtomicInteger(initialValue)
+
+    actual var value: Int
+        get() = delegate.get()
+        set(value) {
+            delegate.set(value)
+        }
+
+    actual fun incrementAndGet(delta: Int): Int = delegate.addAndGet(delta)
+
+    actual fun compareAndSet(expectedValue: Int, newValue: Int): Boolean = delegate.compareAndSet(expectedValue, newValue)
+}

--- a/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicInt.kt
+++ b/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicInt.kt
@@ -10,7 +10,7 @@ actual class AtomicInt actual constructor(initialValue: Int) {
             delegate.set(value)
         }
 
-    actual fun incrementAndGet(delta: Int): Int = delegate.addAndGet(delta)
+    actual fun addAndGet(delta: Int): Int = delegate.addAndGet(delta)
 
     actual fun compareAndSet(expectedValue: Int, newValue: Int): Boolean = delegate.compareAndSet(expectedValue, newValue)
 }

--- a/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLong.kt
+++ b/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLong.kt
@@ -1,0 +1,16 @@
+package com.badoo.reaktive.utils.atomic
+
+actual class AtomicLong actual constructor(initialValue: Long) {
+
+    private val delegate = java.util.concurrent.atomic.AtomicLong(initialValue)
+
+    actual var value: Long
+        get() = delegate.get()
+        set(value) {
+            delegate.set(value)
+        }
+
+    actual fun incrementAndGet(delta: Long): Long = delegate.addAndGet(delta)
+
+    actual fun compareAndSet(expectedValue: Long, newValue: Long): Boolean = delegate.compareAndSet(expectedValue, newValue)
+}

--- a/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLong.kt
+++ b/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLong.kt
@@ -10,7 +10,7 @@ actual class AtomicLong actual constructor(initialValue: Long) {
             delegate.set(value)
         }
 
-    actual fun incrementAndGet(delta: Long): Long = delegate.addAndGet(delta)
+    actual fun addAndGet(delta: Long): Long = delegate.addAndGet(delta)
 
     actual fun compareAndSet(expectedValue: Long, newValue: Long): Boolean = delegate.compareAndSet(expectedValue, newValue)
 }

--- a/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicReference.kt
+++ b/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicReference.kt
@@ -1,4 +1,4 @@
-package com.badoo.reaktive.utils.atomicreference
+package com.badoo.reaktive.utils.atomic
 
 actual class AtomicReference<T> actual constructor(
     initialValue: T,
@@ -12,8 +12,6 @@ actual class AtomicReference<T> actual constructor(
         set(value) {
             delegate.set(value)
         }
-
-    actual fun getAndSet(value: T): T = delegate.getAndSet(value)
 
     actual fun compareAndSet(expectedValue: T, newValue: T): Boolean = delegate.compareAndSet(expectedValue, newValue)
 }

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/looperthread/MessageQueue.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/looperthread/MessageQueue.kt
@@ -1,8 +1,8 @@
 package com.badoo.reaktive.looperthread
 
 import com.badoo.reaktive.utils.Lock
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.update
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.update
 import com.badoo.reaktive.utils.synchronized
 import kotlin.native.concurrent.AtomicLong
 import kotlin.system.getTimeNanos

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/scheduler/BufferedExecutor.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/scheduler/BufferedExecutor.kt
@@ -1,7 +1,7 @@
 package com.badoo.reaktive.scheduler
 
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.getAndUpdate
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.getAndUpdate
 
 internal actual class BufferedExecutor<in T> actual constructor(
     private val executor: Scheduler.Executor,

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicBoolean.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicBoolean.kt
@@ -1,0 +1,20 @@
+package com.badoo.reaktive.utils.atomic
+
+actual class AtomicBoolean actual constructor(initialValue: Boolean) {
+
+    private val delegate = kotlin.native.concurrent.AtomicInt(initialValue.intValue)
+
+    actual var value: Boolean
+        get() = delegate.value != 0
+        set(value) {
+            delegate.value = value.intValue
+        }
+
+
+    actual fun compareAndSet(expectedValue: Boolean, newValue: Boolean): Boolean =
+        delegate.compareAndSet(expectedValue.intValue, newValue.intValue)
+
+    private companion object {
+        private val Boolean.intValue: Int get() = if (this) 1 else 0
+    }
+}

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicBoolean.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicBoolean.kt
@@ -10,7 +10,6 @@ actual class AtomicBoolean actual constructor(initialValue: Boolean) {
             delegate.value = value.intValue
         }
 
-
     actual fun compareAndSet(expectedValue: Boolean, newValue: Boolean): Boolean =
         delegate.compareAndSet(expectedValue.intValue, newValue.intValue)
 

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicInt.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicInt.kt
@@ -1,0 +1,16 @@
+package com.badoo.reaktive.utils.atomic
+
+actual class AtomicInt actual constructor(initialValue: Int) {
+
+    private val delegate = kotlin.native.concurrent.AtomicInt(initialValue)
+
+    actual var value: Int
+        get() = delegate.value
+        set(value) {
+            delegate.value = value
+        }
+
+    actual fun incrementAndGet(delta: Int): Int = delegate.addAndGet(delta)
+
+    actual fun compareAndSet(expectedValue: Int, newValue: Int): Boolean = delegate.compareAndSet(expectedValue, newValue)
+}

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicInt.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicInt.kt
@@ -10,7 +10,7 @@ actual class AtomicInt actual constructor(initialValue: Int) {
             delegate.value = value
         }
 
-    actual fun incrementAndGet(delta: Int): Int = delegate.addAndGet(delta)
+    actual fun addAndGet(delta: Int): Int = delegate.addAndGet(delta)
 
     actual fun compareAndSet(expectedValue: Int, newValue: Int): Boolean = delegate.compareAndSet(expectedValue, newValue)
 }

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLong.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLong.kt
@@ -1,0 +1,16 @@
+package com.badoo.reaktive.utils.atomic
+
+actual class AtomicLong actual constructor(initialValue: Long) {
+
+    private val delegate = kotlin.native.concurrent.AtomicLong(initialValue)
+
+    actual var value: Long
+        get() = delegate.value
+        set(value) {
+            delegate.value = value
+        }
+
+    actual fun incrementAndGet(delta: Long): Long = delegate.addAndGet(delta)
+
+    actual fun compareAndSet(expectedValue: Long, newValue: Long): Boolean = delegate.compareAndSet(expectedValue, newValue)
+}

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLong.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLong.kt
@@ -10,7 +10,7 @@ actual class AtomicLong actual constructor(initialValue: Long) {
             delegate.value = value
         }
 
-    actual fun incrementAndGet(delta: Long): Long = delegate.addAndGet(delta)
+    actual fun addAndGet(delta: Long): Long = delegate.addAndGet(delta)
 
     actual fun compareAndSet(expectedValue: Long, newValue: Long): Boolean = delegate.compareAndSet(expectedValue, newValue)
 }

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicReference.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicReference.kt
@@ -1,4 +1,4 @@
-package com.badoo.reaktive.utils.atomicreference
+package com.badoo.reaktive.utils.atomic
 
 import com.badoo.reaktive.utils.freeze
 
@@ -14,16 +14,6 @@ actual class AtomicReference<T> actual constructor(
         set(value) {
             delegate.value = value.freezeIfNeeded()
         }
-
-    actual fun getAndSet(value: T): T {
-        value.freezeIfNeeded()
-        var v: T
-        do {
-            v = delegate.value
-        } while (!delegate.compareAndSet(v, value))
-
-        return v
-    }
 
     actual fun compareAndSet(expectedValue: T, newValue: T): Boolean =
         delegate.compareAndSet(expectedValue, newValue.freezeIfNeeded())

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/serializer/SerializerImpl.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/serializer/SerializerImpl.kt
@@ -1,8 +1,8 @@
 package com.badoo.reaktive.utils.serializer
 
-import com.badoo.reaktive.utils.atomicreference.AtomicReference
-import com.badoo.reaktive.utils.atomicreference.getAndUpdate
-import com.badoo.reaktive.utils.atomicreference.update
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.getAndUpdate
+import com.badoo.reaktive.utils.atomic.update
 
 internal abstract class SerializerImpl<in T>(
     private val comparator: Comparator<in T>? = null


### PR DESCRIPTION
K/N variant of `AtomicReference` does not work well with primitive types. The following code prints `false`:
```
    val ref = AtomicReference(1000L)
    val v = ref.value
    println(ref.compareAndSet(v, 2000L))
```
This is because in K/N value gets unboxed (type of `v` is actually primitive `Long`) and then boxed back, so another instance of value is passed. Though it works fine with numbers up to 127 as they are cached.

This PR introduces `AtomicInt`, `AtomicLong` and `AtomicBoolean` and updates all corresponding usages of `AtomicReference`. Please check thoroughly.