### PR TITLE
Use List instead of Set in DefaultSubject

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicList.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicList.kt
@@ -24,6 +24,22 @@ fun <T> AtomicList<T>.removeAt(index: Int): T =
         it.filterIndexed { i, _ -> i != index }
     }[index]
 
+fun <T> AtomicList<T>.remove(element: T): Boolean {
+    var removed = false
+
+    update {
+        val newList = it - element
+        removed = newList.size < it.size
+        newList
+    }
+
+    return removed
+}
+
+operator fun <T> AtomicList<T>.minusAssign(element: T) {
+    remove(element)
+}
+
 fun <T> AtomicList<T>.clear() {
     update { emptyList() }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/subject/SubjectGenericTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/subject/SubjectGenericTests.kt
@@ -53,6 +53,9 @@ interface SubjectGenericTests {
     @Test
     fun does_not_emit_anything_WHEN_subscribed_after_error()
 
+    @Test
+    fun does_not_emit_values_to_unsubscribed_observers()
+
     companion object {
         operator fun invoke(subject: Subject<Int?>): SubjectGenericTests = SubjectGenericTestsImpl(subject)
     }
@@ -191,5 +194,11 @@ private class SubjectGenericTestsImpl(
         val observer = subject.test()
 
         observer.assertNoValues()
+    }
+
+    override fun does_not_emit_values_to_unsubscribed_observers() {
+        val observer = subject.test()
+        observer.dispose()
+        subject.onNext(0)
     }
 }


### PR DESCRIPTION
Adding elements to immutable List is ~20% faster in K/N than with immutable Set. As we don't need constant time `contains` we can replace `Set` with `List`.