### PR TITLE
Use trusty dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 matrix:
   include:
     - os: linux
+      dist: trusty
       language: android
       android:
         components:


### PR DESCRIPTION
> Android builds are only supported on our Trusty image at this time hence you’ll need to explicitely specify dist: trusty in your .travis.yml file.  [Read more](https://docs.travis-ci.com/user/languages/android/)