### PR TITLE
Addde sample-mpp-module with JVM, LinuxX64 and JS targets

### DIFF
--- a/sample-mpp-module/build.gradle
+++ b/sample-mpp-module/build.gradle
@@ -1,0 +1,25 @@
+/*
+ * In order to build this module for LinuxX64 you should install libcurl4-openssl-dev package in your system
+ */
+
+setupMultiplatformLibrary(project)
+
+kotlin {
+    linuxX64("linuxX64") {
+        compilations.main.cinterops {
+            libcurl.includeDirs.headerFilterOnly '/usr/include', '/usr/include/x86_64-linux-gnu'
+        }
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation kotlin('test-common')
+                implementation project(':reaktive')
+                implementation project(':reaktive-annotations')
+            }
+        }
+    }
+}
+
+setupAllTargetsWithDefaultSourceSets(project)

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/Config.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/Config.kt
@@ -1,0 +1,6 @@
+package com.badoo.reaktive.samplemppmodule
+
+internal object Config {
+
+    const val KITTEN_URL = "https://api.thecatapi.com/v1/images/search"
+}

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/SingleLifeEvent.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/SingleLifeEvent.kt
@@ -1,8 +1,0 @@
-package com.badoo.reaktive.samplemppmodule
-
-class SingleLifeEvent<out T : Any>(value: T) {
-
-    private var value: T? = value
-
-    fun handle(): T? = value.also { value = null }
-}

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/SingleLifeEvent.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/SingleLifeEvent.kt
@@ -1,0 +1,8 @@
+package com.badoo.reaktive.samplemppmodule
+
+class SingleLifeEvent<out T : Any>(value: T) {
+
+    private var value: T? = value
+
+    fun handle(): T? = value.also { value = null }
+}

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/binder/KittenBinder.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/binder/KittenBinder.kt
@@ -1,0 +1,48 @@
+package com.badoo.reaktive.samplemppmodule.binder
+
+import com.badoo.reaktive.disposable.CompositeDisposable
+import com.badoo.reaktive.observable.map
+import com.badoo.reaktive.observable.subscribe
+import com.badoo.reaktive.samplemppmodule.store.KittenStoreBuilder
+import com.badoo.reaktive.samplemppmodule.view.KittenView
+import com.badoo.reaktive.utils.atomic.AtomicReference
+
+class KittenBinder(
+    storeBuilder: KittenStoreBuilder
+) {
+
+    private var disposables = CompositeDisposable()
+    private val store = storeBuilder.build()
+    private var view = AtomicReference<KittenView?>(null, true)
+
+    fun onViewCreated(view: KittenView) {
+        this.view.value = view
+    }
+
+    fun onStart() {
+        disposables +=
+            view
+                .value!!
+                .events
+                .map(KittenViewEventToIntentMapper::invoke)
+                .subscribe(onNext = store::accept)
+
+        disposables +=
+            store
+                .states
+                .map(KittenStateToViewModelMapper::invoke)
+                .subscribe(onNext = { view.value!!.show(it) })
+    }
+
+    fun onStop() {
+        disposables.clear()
+    }
+
+    fun onViewDestroyed() {
+        view.value = null
+    }
+
+    fun onDestroy() {
+        store.dispose()
+    }
+}

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/binder/KittenBinder.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/binder/KittenBinder.kt
@@ -21,8 +21,7 @@ class KittenBinder(
 
     fun onStart() {
         disposables +=
-            view
-                .value!!
+            requireNotNull(view.value)
                 .events
                 .map(KittenViewEventToIntentMapper::invoke)
                 .subscribe(onNext = store::accept)
@@ -31,7 +30,7 @@ class KittenBinder(
             store
                 .states
                 .map(KittenStateToViewModelMapper::invoke)
-                .subscribe(onNext = { view.value!!.show(it) })
+                .subscribe(onNext = { requireNotNull(view.value).show(it) })
     }
 
     fun onStop() {

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/binder/KittenStateToViewModelMapper.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/binder/KittenStateToViewModelMapper.kt
@@ -1,0 +1,14 @@
+package com.badoo.reaktive.samplemppmodule.binder
+
+import com.badoo.reaktive.samplemppmodule.store.KittenStore.State
+import com.badoo.reaktive.samplemppmodule.view.KittenView.ViewModel
+
+internal object KittenStateToViewModelMapper {
+
+    operator fun invoke(state: State): ViewModel =
+        ViewModel(
+            isLoading = state.isLoading,
+            error = state.error,
+            kittenUrl = state.kittenUrl
+        )
+}

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/binder/KittenStateToViewModelMapper.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/binder/KittenStateToViewModelMapper.kt
@@ -8,7 +8,7 @@ internal object KittenStateToViewModelMapper {
     operator fun invoke(state: State): ViewModel =
         ViewModel(
             isLoading = state.isLoading,
-            error = state.error,
+            isError = state.isError,
             kittenUrl = state.kittenUrl
         )
 }

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/binder/KittenViewEventToIntentMapper.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/binder/KittenViewEventToIntentMapper.kt
@@ -1,0 +1,12 @@
+package com.badoo.reaktive.samplemppmodule.binder
+
+import com.badoo.reaktive.samplemppmodule.store.KittenStore.Intent
+import com.badoo.reaktive.samplemppmodule.view.KittenView.Event
+
+internal object KittenViewEventToIntentMapper {
+
+    operator fun invoke(event: Event): Intent =
+        when (event) {
+            is Event.Reload -> Intent.Reload
+        }
+}

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/binder/KittenViewEventToIntentMapper.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/binder/KittenViewEventToIntentMapper.kt
@@ -8,5 +8,6 @@ internal object KittenViewEventToIntentMapper {
     operator fun invoke(event: Event): Intent =
         when (event) {
             is Event.Reload -> Intent.Reload
+            is Event.ErrorShown -> Intent.DismissError
         }
 }

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/store/KittenLoader.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/store/KittenLoader.kt
@@ -1,0 +1,15 @@
+package com.badoo.reaktive.samplemppmodule.store
+
+import com.badoo.reaktive.annotations.EventsOnAnyScheduler
+import com.badoo.reaktive.single.Single
+
+internal interface KittenLoader {
+
+    @EventsOnAnyScheduler
+    fun load(): Single<Result>
+
+    sealed class Result {
+        class Success(val json: String) : Result()
+        object Error : Result()
+    }
+}

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/store/KittenStore.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/store/KittenStore.kt
@@ -2,7 +2,6 @@ package com.badoo.reaktive.samplemppmodule.store
 
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.observable.Observable
-import com.badoo.reaktive.samplemppmodule.SingleLifeEvent
 
 interface KittenStore : Disposable {
 
@@ -12,12 +11,13 @@ interface KittenStore : Disposable {
 
     data class State(
         val isLoading: Boolean = false,
-        val error: SingleLifeEvent<Unit>? = null,
+        val isError: Boolean = false,
         val kittenUrl: String? = null
     )
 
     sealed class Intent {
         object Reload : Intent()
+        object DismissError: Intent()
     }
 }
 

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/store/KittenStore.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/store/KittenStore.kt
@@ -1,0 +1,23 @@
+package com.badoo.reaktive.samplemppmodule.store
+
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.observable.Observable
+import com.badoo.reaktive.samplemppmodule.SingleLifeEvent
+
+interface KittenStore : Disposable {
+
+    val states: Observable<State>
+
+    fun accept(intent: Intent)
+
+    data class State(
+        val isLoading: Boolean = false,
+        val error: SingleLifeEvent<Unit>? = null,
+        val kittenUrl: String? = null
+    )
+
+    sealed class Intent {
+        object Reload : Intent()
+    }
+}
+

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/store/KittenStoreBuilder.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/store/KittenStoreBuilder.kt
@@ -1,0 +1,6 @@
+package com.badoo.reaktive.samplemppmodule.store
+
+interface KittenStoreBuilder {
+
+    fun build(): KittenStore
+}

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/store/KittenStoreImpl.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/store/KittenStoreImpl.kt
@@ -1,0 +1,84 @@
+package com.badoo.reaktive.samplemppmodule.store
+
+import com.badoo.reaktive.disposable.CompositeDisposable
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.observable.Observable
+import com.badoo.reaktive.samplemppmodule.SingleLifeEvent
+import com.badoo.reaktive.samplemppmodule.store.KittenStore.Intent
+import com.badoo.reaktive.samplemppmodule.store.KittenStore.State
+import com.badoo.reaktive.scheduler.computationScheduler
+import com.badoo.reaktive.scheduler.mainScheduler
+import com.badoo.reaktive.single.map
+import com.badoo.reaktive.single.observeOn
+import com.badoo.reaktive.single.subscribe
+import com.badoo.reaktive.subject.behavior.behaviorSubject
+
+internal class KittenStoreImpl(
+    private val loader: KittenLoader
+) : KittenStore {
+
+    private val _states = behaviorSubject(State())
+    override val states: Observable<State> = _states
+    private val state: State get() = _states.value
+
+    private val disposables = CompositeDisposable()
+    override val isDisposed: Boolean get() = disposables.isDisposed
+
+    override fun dispose() {
+        disposables.dispose()
+        _states.onComplete()
+    }
+
+    override fun accept(intent: Intent) {
+        execute(intent)?.also(disposables::add)
+    }
+
+    private fun execute(intent: Intent): Disposable? =
+        when (intent) {
+            is Intent.Reload -> reload()
+        }
+
+    private fun reload(): Disposable? =
+        if (state.isLoading) {
+            null
+        } else {
+            onResult(Result.LoadingStarted)
+
+            loader
+                .load()
+                .observeOn(computationScheduler)
+                .map {
+                    when (it) {
+                        is KittenLoader.Result.Success -> Result.Loaded(parseUrl(it.json))
+                        is KittenLoader.Result.Error -> Result.LoadingFailed
+                    }
+                }
+                .observeOn(mainScheduler)
+                .subscribe(onSuccess = ::onResult)
+        }
+
+    private fun onResult(result: Result) {
+        _states.onNext(Reducer(result, _states.value))
+    }
+
+    private companion object {
+        private val parseRegex = "(?:\"url\":\")(.*?)(?:\")".toRegex()
+
+        private fun parseUrl(json: String): String = parseRegex.find(json)!!.groupValues[1]
+    }
+
+    private sealed class Result {
+        object LoadingStarted : Result()
+        class Loaded(val kittenUrl: String?) : Result()
+        object LoadingFailed : Result()
+    }
+
+    private object Reducer {
+        operator fun invoke(result: Result, state: State): State =
+            when (result) {
+                is Result.LoadingStarted -> state.copy(isLoading = true, error = null, kittenUrl = null)
+                is Result.Loaded -> state.copy(isLoading = false, error = null, kittenUrl = result.kittenUrl)
+                is Result.LoadingFailed -> state.copy(isLoading = false, error = SingleLifeEvent(Unit))
+            }
+    }
+}

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/view/AbstractKittenView.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/view/AbstractKittenView.kt
@@ -1,0 +1,15 @@
+package com.badoo.reaktive.samplemppmodule.view
+
+import com.badoo.reaktive.observable.Observable
+import com.badoo.reaktive.samplemppmodule.view.KittenView.Event
+import com.badoo.reaktive.subject.publish.publishSubject
+
+abstract class AbstractKittenView : KittenView {
+
+    private val _events = publishSubject<Event>()
+    override val events: Observable<Event> = _events
+
+    fun dispatch(event: Event) {
+        _events.onNext(event)
+    }
+}

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/view/KittenView.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/view/KittenView.kt
@@ -16,5 +16,6 @@ interface KittenView {
 
     sealed class Event {
         object Reload : Event()
+        object ErrorShown: Event()
     }
 }

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/view/KittenView.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/view/KittenView.kt
@@ -1,7 +1,6 @@
 package com.badoo.reaktive.samplemppmodule.view
 
 import com.badoo.reaktive.observable.Observable
-import com.badoo.reaktive.samplemppmodule.SingleLifeEvent
 
 interface KittenView {
 
@@ -11,7 +10,7 @@ interface KittenView {
 
     data class ViewModel(
         val isLoading: Boolean,
-        val error: SingleLifeEvent<Unit>?,
+        val isError: Boolean,
         val kittenUrl: String?
     )
 

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/view/KittenView.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/view/KittenView.kt
@@ -1,0 +1,21 @@
+package com.badoo.reaktive.samplemppmodule.view
+
+import com.badoo.reaktive.observable.Observable
+import com.badoo.reaktive.samplemppmodule.SingleLifeEvent
+
+interface KittenView {
+
+    val events: Observable<Event>
+
+    fun show(model: ViewModel)
+
+    data class ViewModel(
+        val isLoading: Boolean,
+        val error: SingleLifeEvent<Unit>?,
+        val kittenUrl: String?
+    )
+
+    sealed class Event {
+        object Reload : Event()
+    }
+}

--- a/sample-mpp-module/src/jsMain/kotlin/com/badoo/reaktive/samplemppmodule/KittenLoaderImpl.kt
+++ b/sample-mpp-module/src/jsMain/kotlin/com/badoo/reaktive/samplemppmodule/KittenLoaderImpl.kt
@@ -1,0 +1,24 @@
+package com.badoo.reaktive.samplemppmodule
+
+import com.badoo.reaktive.promise.asSingle
+import com.badoo.reaktive.samplemppmodule.store.KittenLoader
+import com.badoo.reaktive.samplemppmodule.store.KittenLoader.Result
+import com.badoo.reaktive.single.Single
+import com.badoo.reaktive.single.flatMap
+import com.badoo.reaktive.single.map
+import com.badoo.reaktive.single.onErrorReturnValue
+import org.w3c.fetch.Response
+import kotlin.browser.window
+import kotlin.js.Promise
+
+internal class KittenLoaderImpl : KittenLoader {
+
+    override fun load(): Single<Result> =
+        window
+            .fetch(Config.KITTEN_URL)
+            .asSingle()
+            .map(Response::text)
+            .flatMap(Promise<String>::asSingle)
+            .map(Result::Success)
+            .onErrorReturnValue(Result.Error)
+}

--- a/sample-mpp-module/src/jsMain/kotlin/com/badoo/reaktive/samplemppmodule/KittenStoreBuilderImpl.kt
+++ b/sample-mpp-module/src/jsMain/kotlin/com/badoo/reaktive/samplemppmodule/KittenStoreBuilderImpl.kt
@@ -1,0 +1,10 @@
+package com.badoo.reaktive.samplemppmodule
+
+import com.badoo.reaktive.samplemppmodule.store.KittenStore
+import com.badoo.reaktive.samplemppmodule.store.KittenStoreBuilder
+import com.badoo.reaktive.samplemppmodule.store.KittenStoreImpl
+
+class KittenStoreBuilderImpl : KittenStoreBuilder {
+
+    override fun build(): KittenStore = KittenStoreImpl(loader = KittenLoaderImpl())
+}

--- a/sample-mpp-module/src/jvmMain/kotlin/com/badoo/reaktive/samplemppmodule/KittenLoaderImpl.kt
+++ b/sample-mpp-module/src/jvmMain/kotlin/com/badoo/reaktive/samplemppmodule/KittenLoaderImpl.kt
@@ -1,0 +1,31 @@
+package com.badoo.reaktive.samplemppmodule
+
+import com.badoo.reaktive.samplemppmodule.store.KittenLoader
+import com.badoo.reaktive.samplemppmodule.store.KittenLoader.Result
+import com.badoo.reaktive.scheduler.ioScheduler
+import com.badoo.reaktive.single.Single
+import com.badoo.reaktive.single.onErrorReturnValue
+import com.badoo.reaktive.single.singleFromFunction
+import com.badoo.reaktive.single.subscribeOn
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
+
+internal class KittenLoaderImpl : KittenLoader {
+
+    override fun load(): Single<Result> =
+        singleFromFunction<Result> {
+            val url = URL(Config.KITTEN_URL)
+            val connection = url.openConnection() as HttpURLConnection
+
+            if (connection.responseCode != 200) {
+                throw IOException("Invalid response: ${connection.responseCode}")
+            }
+
+            val input = connection.inputStream ?: throw IOException("No input stream")
+
+            Result.Success(input.bufferedReader().readText())
+        }
+            .subscribeOn(ioScheduler)
+            .onErrorReturnValue(Result.Error)
+}

--- a/sample-mpp-module/src/jvmMain/kotlin/com/badoo/reaktive/samplemppmodule/KittenStoreBuilderImpl.kt
+++ b/sample-mpp-module/src/jvmMain/kotlin/com/badoo/reaktive/samplemppmodule/KittenStoreBuilderImpl.kt
@@ -1,0 +1,10 @@
+package com.badoo.reaktive.samplemppmodule
+
+import com.badoo.reaktive.samplemppmodule.store.KittenStore
+import com.badoo.reaktive.samplemppmodule.store.KittenStoreBuilder
+import com.badoo.reaktive.samplemppmodule.store.KittenStoreImpl
+
+class KittenStoreBuilderImpl : KittenStoreBuilder {
+
+    override fun build(): KittenStore = KittenStoreImpl(loader = KittenLoaderImpl())
+}

--- a/sample-mpp-module/src/linuxX64Main/kotlin/com/badoo/reaktive/samplemppmodule/Curl.kt
+++ b/sample-mpp-module/src/linuxX64Main/kotlin/com/badoo/reaktive/samplemppmodule/Curl.kt
@@ -1,0 +1,58 @@
+package com.badoo.reaktive.samplemppmodule
+
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.COpaquePointer
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.StableRef
+import kotlinx.cinterop.asStableRef
+import kotlinx.cinterop.get
+import kotlinx.cinterop.staticCFunction
+import libcurl.CURLE_OK
+import libcurl.CURLOPT_URL
+import libcurl.CURLOPT_WRITEDATA
+import libcurl.CURLOPT_WRITEFUNCTION
+import libcurl.curl_easy_cleanup
+import libcurl.curl_easy_init
+import libcurl.curl_easy_perform
+import libcurl.curl_easy_setopt
+import platform.posix.size_t
+
+fun curl(url: String): ByteArray? {
+    val curl = curl_easy_init()
+    try {
+        curl_easy_setopt(curl, CURLOPT_URL, url)
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, staticCFunction(::writeCallback))
+
+        val data = arrayListOf<Byte>()
+
+        val dataRef = StableRef.create(data)
+        try {
+            curl_easy_setopt(curl, CURLOPT_WRITEDATA, dataRef.asCPointer())
+
+            if (curl_easy_perform(curl) != CURLE_OK) {
+                return null
+            }
+        } finally {
+            dataRef.dispose()
+        }
+
+        return ByteArray(data.size, data::get)
+    } finally {
+        curl_easy_cleanup(curl)
+    }
+}
+
+private fun writeCallback(buffer: CPointer<ByteVar>?, itemSize: size_t, itemCount: size_t, userData: COpaquePointer?): size_t {
+    if (buffer == null) {
+        return 0U
+    }
+
+    val data = userData?.asStableRef<MutableList<Byte>>()?.get()
+    if (data != null) {
+        for (i in 0 until itemCount.toInt()) {
+            data += buffer[i]
+        }
+    }
+
+    return itemSize * itemCount
+}

--- a/sample-mpp-module/src/linuxX64Main/kotlin/com/badoo/reaktive/samplemppmodule/KittenLoaderImpl.kt
+++ b/sample-mpp-module/src/linuxX64Main/kotlin/com/badoo/reaktive/samplemppmodule/KittenLoaderImpl.kt
@@ -1,0 +1,20 @@
+package com.badoo.reaktive.samplemppmodule
+
+import com.badoo.reaktive.samplemppmodule.store.KittenLoader
+import com.badoo.reaktive.samplemppmodule.store.KittenLoader.Result
+import com.badoo.reaktive.scheduler.ioScheduler
+import com.badoo.reaktive.single.Single
+import com.badoo.reaktive.single.map
+import com.badoo.reaktive.single.onErrorReturnValue
+import com.badoo.reaktive.single.singleFromFunction
+import com.badoo.reaktive.single.subscribeOn
+
+internal class KittenLoaderImpl : KittenLoader {
+
+    override fun load(): Single<Result> =
+        singleFromFunction { curl(Config.KITTEN_URL) ?: throw IllegalStateException("Unable to download a kitten") }
+            .subscribeOn(ioScheduler)
+            .map { it.stringFromUtf8OrThrow() }
+            .map(Result::Success)
+            .onErrorReturnValue(Result.Error)
+}

--- a/sample-mpp-module/src/linuxX64Main/kotlin/com/badoo/reaktive/samplemppmodule/KittenStoreBuilderImpl.kt
+++ b/sample-mpp-module/src/linuxX64Main/kotlin/com/badoo/reaktive/samplemppmodule/KittenStoreBuilderImpl.kt
@@ -1,0 +1,10 @@
+package com.badoo.reaktive.samplemppmodule
+
+import com.badoo.reaktive.samplemppmodule.store.KittenStore
+import com.badoo.reaktive.samplemppmodule.store.KittenStoreBuilder
+import com.badoo.reaktive.samplemppmodule.store.KittenStoreImpl
+
+class KittenStoreBuilderImpl : KittenStoreBuilder {
+
+    override fun build(): KittenStore = KittenStoreImpl(loader = KittenLoaderImpl())
+}

--- a/sample-mpp-module/src/main/AndroidManifest.xml
+++ b/sample-mpp-module/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.badoo.reaktive.samplemppmodule" />

--- a/sample-mpp-module/src/nativeInterop/cinterop/libcurl.def
+++ b/sample-mpp-module/src/nativeInterop/cinterop/libcurl.def
@@ -1,0 +1,5 @@
+headers = curl/curl.h
+headerFilter = curl/*
+linkerOpts.osx = -L/opt/local/lib -L/usr/local/opt/curl/lib -lcurl
+linkerOpts.linux = -L/usr/lib64 -L/usr/lib/x86_64-linux-gnu -lcurl
+linkerOpts.mingw = -lcurl

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@ println("Current environment: $target")
 include ':reaktive'
 include ':reaktive-test'
 include ':reaktive-annotations'
+include ':sample-mpp-module'
 if (target.isCommon()) {
     include ':sample-android-app'
     include ':sample-js-browser-app'


### PR DESCRIPTION
This is the first part. The next parts will be updating Android, JS and Linux sample apps. The new sample-mpp-module is implemented in "MVI" style. Apps should only implement views. I have code complete for Android, JS and Linux (GTK3).