### PR TITLE
Kotlin 1.3.50

### DIFF
--- a/buildSrc/src/main/kotlin/IosPlugin.kt
+++ b/buildSrc/src/main/kotlin/IosPlugin.kt
@@ -54,12 +54,7 @@ abstract class IosPlugin : Plugin<Project> {
         val iosTestProvider = target.tasks.register(TASK_NAME_IOS_TEST, RunIosTestTask::class.java) {
             group = LifecycleBasePlugin.VERIFICATION_GROUP
             dependsOn(target.tasks.named(testBinariesTaskName))
-            testExecutables.from(
-                kotlinNativeBinaryContainer.getExecutable(
-                    SourceSet.TEST_SOURCE_SET_NAME,
-                    NativeBuildType.DEBUG
-                ).outputFile
-            )
+            testExecutables.from(kotlinNativeBinaryContainer.getTest(NativeBuildType.DEBUG).outputFile)
         }
         if (kotlinNativeTarget.publishable) {
             target.tasks.named(LifecycleBasePlugin.CHECK_TASK_NAME) {

--- a/buildSrc/src/main/kotlin/JsPlugin.kt
+++ b/buildSrc/src/main/kotlin/JsPlugin.kt
@@ -11,6 +11,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.SourceSet
+import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
@@ -82,10 +83,18 @@ abstract class JsPlugin : Plugin<Project> {
 
         val runMochaTask = target.tasks.register("runMocha", RunMochaTask::class.java) {
             dependsOn(dependenciesTask, compileTestJsTask, nodeModulesTask)
+            group = LifecycleBasePlugin.VERIFICATION_GROUP
             testJsFiles.from(compileTestJsTask.get().outputFile)
         }
 
         target.tasks.named(TASK_NAME_JS_TEST) {
+            // We don't support new JS test runners because of module naming issues
+            // NodeJsRootExtension creates reaktive-test folder as output for test sources of reaktive
+            // and reaktive-test folder as output for main sources of reaktive-test
+            onlyIf { false }
+        }
+
+        target.tasks.named(LifecycleBasePlugin.CHECK_TASK_NAME) {
             dependsOn(runMochaTask)
         }
     }

--- a/gradle/versions.gradle.kts
+++ b/gradle/versions.gradle.kts
@@ -1,5 +1,5 @@
 project.extra.run {
-    set("kotlin_version", "1.3.31")
+    set("kotlin_version", "1.3.50")
     set("node_gradle_version", "1.3.1")
     set("android_gradle_version", "3.4.1")
     set("bintray_gradle_version", "1.8.4")


### PR DESCRIPTION
#### Plan
- [x] ~~Split `js` to `node` and `browser`, remove check in `uptime()` function.~~ Naming issues, see comment in code.
- [x] ~~Use default `jsTest` instead of custom `mocha` run task.~~ Naming issues, see comment in code.
- [x] ~~Enable `-Xobjc-generics` for iOS sample to check `Swift` generics support and update.~~ Implement it in https://github.com/badoo/Reaktive/issues/164.
- [x] Use new `test` binaries configuration for native platform.
- [ ] Verify samples work fine.

[1.3.40 Changelog](https://blog.jetbrains.com/kotlin/2019/06/kotlin-1-3-40-released/)
[1.3.50 Changelog](https://blog.jetbrains.com/kotlin/2019/08/kotlin-1-3-50-released/)