### PR TITLE
Rename RxJava2 interop functions to asXxx

### DIFF
--- a/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Completable.kt
+++ b/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Completable.kt
@@ -5,49 +5,49 @@ import com.badoo.reaktive.completable.CompletableObserver
 import com.badoo.reaktive.completable.completableUnsafe
 import com.badoo.reaktive.disposable.Disposable
 
-fun Completable.toRxJava2Source(): io.reactivex.CompletableSource =
+fun Completable.asRxJava2Source(): io.reactivex.CompletableSource =
     io.reactivex.CompletableSource { observer ->
-        subscribe(observer.toReaktive())
+        subscribe(observer.asReaktive())
     }
 
-fun Completable.toRxJava2(): io.reactivex.Completable =
+fun Completable.asRxJava2(): io.reactivex.Completable =
     object : io.reactivex.Completable() {
         override fun subscribeActual(observer: io.reactivex.CompletableObserver) {
-            this@toRxJava2.subscribe(observer.toReaktive())
+            this@asRxJava2.subscribe(observer.asReaktive())
         }
     }
 
-fun <T> io.reactivex.CompletableSource.toReaktive(): Completable =
+fun <T> io.reactivex.CompletableSource.asReaktive(): Completable =
     completableUnsafe { observer ->
-        subscribe(observer.toRxJava2())
+        subscribe(observer.asRxJava2())
     }
 
-fun io.reactivex.CompletableObserver.toReaktive(): CompletableObserver =
+fun io.reactivex.CompletableObserver.asReaktive(): CompletableObserver =
     object : CompletableObserver {
         override fun onSubscribe(disposable: Disposable) {
-            this@toReaktive.onSubscribe(disposable.toRxJava2())
+            this@asReaktive.onSubscribe(disposable.asRxJava2())
         }
 
         override fun onComplete() {
-            this@toReaktive.onComplete()
+            this@asReaktive.onComplete()
         }
 
         override fun onError(error: Throwable) {
-            this@toReaktive.onError(error)
+            this@asReaktive.onError(error)
         }
     }
 
-fun CompletableObserver.toRxJava2(): io.reactivex.CompletableObserver =
+fun CompletableObserver.asRxJava2(): io.reactivex.CompletableObserver =
     object : io.reactivex.CompletableObserver {
         override fun onSubscribe(disposable: io.reactivex.disposables.Disposable) {
-            this@toRxJava2.onSubscribe(disposable.toReaktive())
+            this@asRxJava2.onSubscribe(disposable.asReaktive())
         }
 
         override fun onComplete() {
-            this@toRxJava2.onComplete()
+            this@asRxJava2.onComplete()
         }
 
         override fun onError(error: Throwable) {
-            this@toRxJava2.onError(error)
+            this@asRxJava2.onError(error)
         }
     }

--- a/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Disposable.kt
+++ b/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Disposable.kt
@@ -2,20 +2,20 @@ package com.badoo.reaktive.rxjavainterop
 
 import com.badoo.reaktive.disposable.Disposable
 
-fun Disposable.toRxJava2(): io.reactivex.disposables.Disposable =
+fun Disposable.asRxJava2(): io.reactivex.disposables.Disposable =
     object : io.reactivex.disposables.Disposable {
-        override fun isDisposed(): Boolean = this@toRxJava2.isDisposed
+        override fun isDisposed(): Boolean = this@asRxJava2.isDisposed
 
         override fun dispose() {
-            this@toRxJava2.dispose()
+            this@asRxJava2.dispose()
         }
     }
 
-fun io.reactivex.disposables.Disposable.toReaktive(): Disposable =
+fun io.reactivex.disposables.Disposable.asReaktive(): Disposable =
     object : Disposable {
-        override val isDisposed: Boolean get() = this@toReaktive.isDisposed
+        override val isDisposed: Boolean get() = this@asReaktive.isDisposed
 
         override fun dispose() {
-            this@toReaktive.dispose()
+            this@asReaktive.dispose()
         }
     }

--- a/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Maybe.kt
+++ b/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Maybe.kt
@@ -5,57 +5,57 @@ import com.badoo.reaktive.maybe.Maybe
 import com.badoo.reaktive.maybe.MaybeObserver
 import com.badoo.reaktive.maybe.maybeUnsafe
 
-fun <T> Maybe<T>.toRxJava2Source(): io.reactivex.MaybeSource<T> =
+fun <T> Maybe<T>.asRxJava2Source(): io.reactivex.MaybeSource<T> =
     io.reactivex.MaybeSource { observer ->
-        subscribe(observer.toReaktive())
+        subscribe(observer.asReaktive())
     }
 
-fun <T> Maybe<T>.toRxJava2(): io.reactivex.Maybe<T> =
+fun <T> Maybe<T>.asRxJava2(): io.reactivex.Maybe<T> =
     object : io.reactivex.Maybe<T>() {
         override fun subscribeActual(observer: io.reactivex.MaybeObserver<in T>) {
-            this@toRxJava2.subscribe(observer.toReaktive())
+            this@asRxJava2.subscribe(observer.asReaktive())
         }
     }
 
-fun <T> io.reactivex.MaybeSource<out T>.toReaktive(): Maybe<T> =
+fun <T> io.reactivex.MaybeSource<out T>.asReaktive(): Maybe<T> =
     maybeUnsafe { observer ->
-        subscribe(observer.toRxJava2())
+        subscribe(observer.asRxJava2())
     }
 
-fun <T> io.reactivex.MaybeObserver<in T>.toReaktive(): MaybeObserver<T> =
+fun <T> io.reactivex.MaybeObserver<in T>.asReaktive(): MaybeObserver<T> =
     object : MaybeObserver<T> {
         override fun onSubscribe(disposable: Disposable) {
-            this@toReaktive.onSubscribe(disposable.toRxJava2())
+            this@asReaktive.onSubscribe(disposable.asRxJava2())
         }
 
         override fun onSuccess(value: T) {
-            this@toReaktive.onSuccess(value)
+            this@asReaktive.onSuccess(value)
         }
 
         override fun onComplete() {
-            this@toReaktive.onComplete()
+            this@asReaktive.onComplete()
         }
 
         override fun onError(error: Throwable) {
-            this@toReaktive.onError(error)
+            this@asReaktive.onError(error)
         }
     }
 
-fun <T> MaybeObserver<T>.toRxJava2(): io.reactivex.MaybeObserver<T> =
+fun <T> MaybeObserver<T>.asRxJava2(): io.reactivex.MaybeObserver<T> =
     object : io.reactivex.MaybeObserver<T> {
         override fun onSubscribe(disposable: io.reactivex.disposables.Disposable) {
-            this@toRxJava2.onSubscribe(disposable.toReaktive())
+            this@asRxJava2.onSubscribe(disposable.asReaktive())
         }
 
         override fun onSuccess(value: T) {
-            this@toRxJava2.onSuccess(value)
+            this@asRxJava2.onSuccess(value)
         }
 
         override fun onComplete() {
-            this@toRxJava2.onComplete()
+            this@asRxJava2.onComplete()
         }
 
         override fun onError(error: Throwable) {
-            this@toRxJava2.onError(error)
+            this@asRxJava2.onError(error)
         }
     }

--- a/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Observable.kt
+++ b/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Observable.kt
@@ -5,57 +5,57 @@ import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.observable.ObservableObserver
 import com.badoo.reaktive.observable.observableUnsafe
 
-fun <T> Observable<T>.toRxJava2Source(): io.reactivex.ObservableSource<T> =
+fun <T> Observable<T>.asRxJava2Source(): io.reactivex.ObservableSource<T> =
     io.reactivex.ObservableSource { observer ->
-        subscribe(observer.toReaktive())
+        subscribe(observer.asReaktive())
     }
 
-fun <T> Observable<T>.toRxJava2(): io.reactivex.Observable<T> =
+fun <T> Observable<T>.asRxJava2(): io.reactivex.Observable<T> =
     object : io.reactivex.Observable<T>() {
         override fun subscribeActual(observer: io.reactivex.Observer<in T>) {
-            this@toRxJava2.subscribe(observer.toReaktive())
+            this@asRxJava2.subscribe(observer.asReaktive())
         }
     }
 
-fun <T> io.reactivex.ObservableSource<out T>.toReaktive(): Observable<T> =
+fun <T> io.reactivex.ObservableSource<out T>.asReaktive(): Observable<T> =
     observableUnsafe { observer ->
-        subscribe(observer.toRxJava2())
+        subscribe(observer.asRxJava2())
     }
 
-fun <T> io.reactivex.Observer<in T>.toReaktive(): ObservableObserver<T> =
+fun <T> io.reactivex.Observer<in T>.asReaktive(): ObservableObserver<T> =
     object : ObservableObserver<T> {
         override fun onSubscribe(disposable: Disposable) {
-            this@toReaktive.onSubscribe(disposable.toRxJava2())
+            this@asReaktive.onSubscribe(disposable.asRxJava2())
         }
 
         override fun onNext(value: T) {
-            this@toReaktive.onNext(value)
+            this@asReaktive.onNext(value)
         }
 
         override fun onComplete() {
-            this@toReaktive.onComplete()
+            this@asReaktive.onComplete()
         }
 
         override fun onError(error: Throwable) {
-            this@toReaktive.onError(error)
+            this@asReaktive.onError(error)
         }
     }
 
-fun <T> ObservableObserver<T>.toRxJava2(): io.reactivex.Observer<T> =
+fun <T> ObservableObserver<T>.asRxJava2(): io.reactivex.Observer<T> =
     object : io.reactivex.Observer<T> {
         override fun onSubscribe(disposable: io.reactivex.disposables.Disposable) {
-            this@toRxJava2.onSubscribe(disposable.toReaktive())
+            this@asRxJava2.onSubscribe(disposable.asReaktive())
         }
 
         override fun onNext(value: T) {
-            this@toRxJava2.onNext(value)
+            this@asRxJava2.onNext(value)
         }
 
         override fun onComplete() {
-            this@toRxJava2.onComplete()
+            this@asRxJava2.onComplete()
         }
 
         override fun onError(error: Throwable) {
-            this@toRxJava2.onError(error)
+            this@asRxJava2.onError(error)
         }
     }

--- a/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Scheduler.kt
+++ b/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Scheduler.kt
@@ -4,44 +4,44 @@ import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.scheduler.Scheduler
 import java.util.concurrent.TimeUnit
 
-fun io.reactivex.Scheduler.toReaktive(): Scheduler =
+fun io.reactivex.Scheduler.asReaktive(): Scheduler =
     object : Scheduler {
         private val disposables = CompositeDisposable()
 
         override fun newExecutor(): Scheduler.Executor =
-            this@toReaktive
+            this@asReaktive
                 .createWorker()
-                .toExecutor()
+                .asExecutor()
                 .also(disposables::add)
 
         override fun destroy() {
             disposables.dispose()
-            this@toReaktive.shutdown()
+            this@asReaktive.shutdown()
         }
     }
 
-private fun io.reactivex.Scheduler.Worker.toExecutor(): Scheduler.Executor =
+private fun io.reactivex.Scheduler.Worker.asExecutor(): Scheduler.Executor =
     object : Scheduler.Executor {
         private val disposables = CompositeDisposable()
         override val isDisposed: Boolean get() = disposables.isDisposed
 
         override fun dispose() {
             disposables.dispose()
-            this@toExecutor.dispose()
+            this@asExecutor.dispose()
         }
 
         override fun submit(delayMillis: Long, task: () -> Unit) {
             disposables +=
-                this@toExecutor
+                this@asExecutor
                     .schedule(task, delayMillis, TimeUnit.MILLISECONDS)
-                    .toReaktive()
+                    .asReaktive()
         }
 
         override fun submitRepeating(startDelayMillis: Long, periodMillis: Long, task: () -> Unit) {
             disposables +=
-                this@toExecutor
+                this@asExecutor
                     .schedulePeriodically(task, startDelayMillis, periodMillis, TimeUnit.MILLISECONDS)
-                    .toReaktive()
+                    .asReaktive()
         }
 
         override fun cancel() {

--- a/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Single.kt
+++ b/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Single.kt
@@ -5,49 +5,49 @@ import com.badoo.reaktive.single.Single
 import com.badoo.reaktive.single.SingleObserver
 import com.badoo.reaktive.single.singleUnsafe
 
-fun <T> Single<T>.toRxJava2Source(): io.reactivex.SingleSource<T> =
+fun <T> Single<T>.asRxJava2Source(): io.reactivex.SingleSource<T> =
     io.reactivex.SingleSource { observer ->
-        subscribe(observer.toReaktive())
+        subscribe(observer.asReaktive())
     }
 
-fun <T> Single<T>.toRxJava2(): io.reactivex.Single<T> =
+fun <T> Single<T>.asRxJava2(): io.reactivex.Single<T> =
     object : io.reactivex.Single<T>() {
         override fun subscribeActual(observer: io.reactivex.SingleObserver<in T>) {
-            this@toRxJava2.subscribe(observer.toReaktive())
+            this@asRxJava2.subscribe(observer.asReaktive())
         }
     }
 
-fun <T> io.reactivex.SingleSource<out T>.toReaktive(): Single<T> =
+fun <T> io.reactivex.SingleSource<out T>.asReaktive(): Single<T> =
     singleUnsafe { observer ->
-        subscribe(observer.toRxJava2())
+        subscribe(observer.asRxJava2())
     }
 
-fun <T> io.reactivex.SingleObserver<in T>.toReaktive(): SingleObserver<T> =
+fun <T> io.reactivex.SingleObserver<in T>.asReaktive(): SingleObserver<T> =
     object : SingleObserver<T> {
         override fun onSubscribe(disposable: Disposable) {
-            this@toReaktive.onSubscribe(disposable.toRxJava2())
+            this@asReaktive.onSubscribe(disposable.asRxJava2())
         }
 
         override fun onSuccess(value: T) {
-            this@toReaktive.onSuccess(value)
+            this@asReaktive.onSuccess(value)
         }
 
         override fun onError(error: Throwable) {
-            this@toReaktive.onError(error)
+            this@asReaktive.onError(error)
         }
     }
 
-fun <T> SingleObserver<T>.toRxJava2(): io.reactivex.SingleObserver<T> =
+fun <T> SingleObserver<T>.asRxJava2(): io.reactivex.SingleObserver<T> =
     object : io.reactivex.SingleObserver<T> {
         override fun onSubscribe(disposable: io.reactivex.disposables.Disposable) {
-            this@toRxJava2.onSubscribe(disposable.toReaktive())
+            this@asRxJava2.onSubscribe(disposable.asReaktive())
         }
 
         override fun onSuccess(value: T) {
-            this@toRxJava2.onSuccess(value)
+            this@asRxJava2.onSuccess(value)
         }
 
         override fun onError(error: Throwable) {
-            this@toRxJava2.onError(error)
+            this@asRxJava2.onError(error)
         }
     }


### PR DESCRIPTION
Naming should match existing Kotlin style: `asFlow`, `asPublisher`, `asSequence`, etc. And similar Reaktive style: `asObservable`, `asSingle`, etc.