### PR TITLE
Handle exceptions in subscribe callbacks

### DIFF
--- a/reaktive/build.gradle
+++ b/reaktive/build.gradle
@@ -78,6 +78,12 @@ if (target.isIos() || target.isMeta()) {
         }
 
         sourceSets {
+            jvmNativeCommonMain.dependsOn commonMain
+            jvmNativeCommonTest.dependsOn commonTest
+
+            nativeCommonMain.dependsOn jvmNativeCommonMain
+            nativeCommonTest.dependsOn jvmNativeCommonTest
+
             iosCommonMain.dependsOn nativeCommonMain
             iosCommonTest.dependsOn nativeCommonTest
 

--- a/reaktive/src/androidMain/kotlin/com/badoo/reaktive/utils/PrintError.kt
+++ b/reaktive/src/androidMain/kotlin/com/badoo/reaktive/utils/PrintError.kt
@@ -1,7 +1,11 @@
+@file:JvmName("PrintError")
+
 package com.badoo.reaktive.utils
 
 import android.util.Log
 
 internal actual fun printError(error: Any?) {
-    Log.e("Reaktive", error.toString())
+    if (isPrintErrorEnabled) {
+        Log.e("Reaktive", error.toString())
+    }
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/SubscribeInternal.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/SubscribeInternal.kt
@@ -1,0 +1,113 @@
+package com.badoo.reaktive.base
+
+import com.badoo.reaktive.base.exceptions.CompositeException
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.doIfNotDisposed
+import com.badoo.reaktive.utils.handleSourceError
+
+internal fun <O, C> Source<O>.subscribeInternal(
+    callbacks: C,
+    observer: O
+) where O : Observer, O : ErrorCallback, C : Disposable, C : SubscribeCallback, C : SubscribeErrorCallback {
+    try {
+        callbacks.onSubscribeCallback?.invoke(callbacks)
+    } catch (e: Throwable) {
+        try {
+            handleSourceError(e, callbacks.onErrorCallback)
+        } finally {
+            callbacks.dispose()
+        }
+
+        return
+    }
+
+    subscribeSafe(observer)
+}
+
+internal fun <C> C.onError(error: Throwable) where C : Disposable, C : SubscribeErrorCallback {
+    doIfNotDisposed(dispose = true) {
+        val callback: ((Throwable) -> Unit)? =
+            try {
+                onErrorCallback
+            } catch (e: Throwable) {
+                handleSourceError(CompositeException(error, e))
+                return
+            }
+
+        handleSourceError(error, callback)
+    }
+}
+
+internal fun <C> C.onComplete() where C : Disposable, C : SubscribeCompleteCallback {
+    doIfNotDisposed(dispose = true) {
+        val callback =
+            try {
+                onCompleteCallback ?: return
+            } catch (e: Throwable) {
+                handleSourceError(e)
+                return
+            }
+
+        try {
+            callback()
+        } catch (e: Throwable) {
+            handleSourceError(e)
+        }
+    }
+}
+
+internal fun <T, C> C.onSuccess(value: T) where C : Disposable, C : SubscribeSuccessCallback<T> {
+    doIfNotDisposed(dispose = true) {
+        val callback =
+            try {
+                onSuccessCallback ?: return
+            } catch (e: Throwable) {
+                handleSourceError(e)
+                return
+            }
+
+        try {
+            callback(value)
+        } catch (e: Throwable) {
+            handleSourceError(e)
+        }
+    }
+}
+
+internal fun <T, C> C.onNext(value: T) where C : Disposable, C : SubscribeValueCallback<T>, C : SubscribeErrorCallback {
+    doIfNotDisposed {
+        val callback =
+            try {
+                onNextCallback ?: return
+            } catch (e: Throwable) {
+                handleSourceError(e)
+                return
+            }
+
+        try {
+            callback(value)
+        } catch (e: Throwable) {
+            onError(e)
+        }
+    }
+}
+
+internal interface SubscribeCallback {
+    val onSubscribeCallback: ((Disposable) -> Unit)?
+}
+
+internal interface SubscribeErrorCallback {
+    val onErrorCallback: ((Throwable) -> Unit)?
+}
+
+internal interface SubscribeCompleteCallback {
+    val onCompleteCallback: (() -> Unit)?
+}
+
+internal interface SubscribeSuccessCallback<T> {
+    val onSuccessCallback: ((T) -> Unit)?
+}
+
+interface SubscribeValueCallback<T> {
+    val onNextCallback: ((T) -> Unit)?
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/SubscribeInternal.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/SubscribeInternal.kt
@@ -2,7 +2,6 @@ package com.badoo.reaktive.base
 
 import com.badoo.reaktive.base.exceptions.CompositeException
 import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.disposable.doIfNotDisposed
 import com.badoo.reaktive.utils.handleSourceError
 
 internal fun <O, C> Source<O>.subscribeInternal(
@@ -25,72 +24,56 @@ internal fun <O, C> Source<O>.subscribeInternal(
 }
 
 internal fun <C> C.onError(error: Throwable) where C : Disposable, C : SubscribeErrorCallback {
-    doIfNotDisposed(dispose = true) {
-        val callback: ((Throwable) -> Unit)? =
-            try {
-                onErrorCallback
-            } catch (e: Throwable) {
-                handleSourceError(CompositeException(error, e))
-                return
-            }
-
-        handleSourceError(error, callback)
+    if (!checkDisposed(error)) {
+        try {
+            handleSourceError(error, onErrorCallback)
+        } finally {
+            dispose()
+        }
     }
 }
 
 internal fun <C> C.onComplete() where C : Disposable, C : SubscribeCompleteCallback {
-    doIfNotDisposed(dispose = true) {
-        val callback =
-            try {
-                onCompleteCallback ?: return
-            } catch (e: Throwable) {
-                handleSourceError(e)
-                return
-            }
-
+    if (!checkDisposed()) {
         try {
-            callback()
+            onCompleteCallback?.invoke()
         } catch (e: Throwable) {
             handleSourceError(e)
+        } finally {
+            dispose()
         }
     }
 }
 
 internal fun <T, C> C.onSuccess(value: T) where C : Disposable, C : SubscribeSuccessCallback<T> {
-    doIfNotDisposed(dispose = true) {
-        val callback =
-            try {
-                onSuccessCallback ?: return
-            } catch (e: Throwable) {
-                handleSourceError(e)
-                return
-            }
-
+    if (!checkDisposed()) {
         try {
-            callback(value)
+            onSuccessCallback?.invoke(value)
         } catch (e: Throwable) {
             handleSourceError(e)
+        } finally {
+            dispose()
         }
     }
 }
 
 internal fun <T, C> C.onNext(value: T) where C : Disposable, C : SubscribeValueCallback<T>, C : SubscribeErrorCallback {
-    doIfNotDisposed {
-        val callback =
-            try {
-                onNextCallback ?: return
-            } catch (e: Throwable) {
-                handleSourceError(e)
-                return
-            }
-
+    if (!checkDisposed()) {
         try {
-            callback(value)
+            onNextCallback?.invoke(value)
         } catch (e: Throwable) {
             onError(e)
         }
     }
 }
+
+private fun Disposable.checkDisposed(existingException: Throwable? = null): Boolean =
+    try {
+        isDisposed
+    } catch (e: Throwable) {
+        handleSourceError(if (existingException == null) e else CompositeException(existingException, e))
+        true
+    }
 
 internal interface SubscribeCallback {
     val onSubscribeCallback: ((Disposable) -> Unit)?

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/DisposableExt.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/DisposableExt.kt
@@ -11,15 +11,3 @@ fun <T : Disposable> T.addTo(compositeDisposable: CompositeDisposable): T {
 
     return this
 }
-
-internal inline fun Disposable.doIfNotDisposed(dispose: Boolean = false, block: () -> Unit) {
-    if (!isDisposed) {
-        try {
-            block()
-        } finally {
-            if (dispose) {
-                dispose()
-            }
-        }
-    }
-}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/DisposableExt.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/DisposableExt.kt
@@ -11,3 +11,15 @@ fun <T : Disposable> T.addTo(compositeDisposable: CompositeDisposable): T {
 
     return this
 }
+
+internal inline fun Disposable.doIfNotDisposed(dispose: Boolean = false, block: () -> Unit) {
+    if (!isDisposed) {
+        try {
+            block()
+        } finally {
+            if (dispose) {
+                dispose()
+            }
+        }
+    }
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Subscribe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Subscribe.kt
@@ -1,10 +1,16 @@
 package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.annotations.UseReturnValue
-import com.badoo.reaktive.base.subscribeSafe
+import com.badoo.reaktive.base.SubscribeCallback
+import com.badoo.reaktive.base.SubscribeCompleteCallback
+import com.badoo.reaktive.base.SubscribeErrorCallback
+import com.badoo.reaktive.base.SubscribeSuccessCallback
+import com.badoo.reaktive.base.onComplete
+import com.badoo.reaktive.base.onError
+import com.badoo.reaktive.base.onSuccess
+import com.badoo.reaktive.base.subscribeInternal
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
-import com.badoo.reaktive.utils.handleSourceError
 import com.badoo.reaktive.utils.ThreadLocalStorage
 
 @UseReturnValue
@@ -15,94 +21,75 @@ fun <T> Maybe<T>.subscribe(
     onComplete: (() -> Unit)? = null,
     onSuccess: ((T) -> Unit)? = null
 ): Disposable {
-    val callbacks =
-        object : Callbacks<T> {
-            override val onSubscribe: ((Disposable) -> Unit)? = onSubscribe
-            override val onError: ((Throwable) -> Unit)? = onError
-            override val onComplete: (() -> Unit)? = onComplete
-            override val onSuccess: ((T) -> Unit)? = onSuccess
+    val disposableWrapper = DisposableWrapper()
 
-            override fun dispose() {
-                // no-op
-            }
+    val callbacks =
+        object : Callbacks<T>, Disposable by disposableWrapper {
+            override val onSubscribeCallback: ((Disposable) -> Unit)? = onSubscribe
+            override val onErrorCallback: ((Throwable) -> Unit)? = onError
+            override val onCompleteCallback: (() -> Unit)? = onComplete
+            override val onSuccessCallback: ((T) -> Unit)? = onSuccess
         }
 
-    return if (isThreadLocal) {
-        subscribeThreadLocal(callbacks)
-    } else {
-        subscribeActual(callbacks)
+    if (isThreadLocal) {
+        return subscribeThreadLocal(disposableWrapper, callbacks)
     }
+
+    subscribeActual(disposableWrapper, callbacks)
+
+    return callbacks
 }
 
 @UseReturnValue
-private fun <T> Maybe<T>.subscribeThreadLocal(callbacks: Callbacks<T>): Disposable {
+private fun <T> Maybe<T>.subscribeThreadLocal(disposableWrapper: DisposableWrapper, callbacks: Callbacks<T>): Disposable {
     val storage = ThreadLocalStorage(callbacks)
 
-    return subscribeActual(
+    val threadLocalCallbacks =
         object : Callbacks<T> {
-            override val onSubscribe: ((Disposable) -> Unit)? get() = storage.value?.onSubscribe
-            override val onError: ((Throwable) -> Unit)? get() = storage.value?.onError
-            override val onComplete: (() -> Unit)? get() = storage.value?.onComplete
-            override val onSuccess: ((T) -> Unit)? get() = storage.value?.onSuccess
+            override val onSubscribeCallback: ((Disposable) -> Unit)? get() = storage.value?.onSubscribeCallback
+            override val onErrorCallback: ((Throwable) -> Unit)? get() = storage.value?.onErrorCallback
+            override val onCompleteCallback: (() -> Unit)? get() = storage.value?.onCompleteCallback
+            override val onSuccessCallback: ((T) -> Unit)? get() = storage.value?.onSuccessCallback
+            override val isDisposed: Boolean get() = storage.value?.isDisposed ?: true
 
             override fun dispose() {
                 storage.value?.dispose()
                 storage.dispose()
             }
         }
-    )
+
+    subscribeActual(disposableWrapper, threadLocalCallbacks)
+
+    return threadLocalCallbacks
 }
 
 @UseReturnValue
-private fun <T> Maybe<T>.subscribeActual(callbacks: Callbacks<T>): Disposable {
-    val disposableWrapper = DisposableWrapper()
-    callbacks.onSubscribe?.invoke(disposableWrapper)
-
-    subscribeSafe(
+private fun <T> Maybe<T>.subscribeActual(disposableWrapper: DisposableWrapper, callbacks: Callbacks<T>) {
+    val observer =
         object : MaybeObserver<T> {
             override fun onSubscribe(disposable: Disposable) {
                 disposableWrapper.set(disposable)
             }
 
             override fun onSuccess(value: T) {
-                try {
-                    callbacks.onSuccess?.invoke(value)
-                } finally {
-                    disposableWrapper.dispose()
-                }
+                callbacks.onSuccess(value)
             }
 
             override fun onComplete() {
-                try {
-                    callbacks.onComplete?.invoke()
-                } finally {
-                    disposableWrapper.dispose()
-                }
+                callbacks.onComplete()
             }
 
             override fun onError(error: Throwable) {
-                try {
-                    handleSourceError(error, callbacks.onError)
-                } finally {
-                    disposableWrapper.dispose()
-                }
+                callbacks.onError(error)
             }
         }
-    )
 
-    return object : Disposable by disposableWrapper {
-        override fun dispose() {
-            disposableWrapper.dispose()
-            callbacks.dispose()
-        }
-    }
+    subscribeInternal(callbacks, observer)
 }
 
-private interface Callbacks<T> {
-    val onSubscribe: ((Disposable) -> Unit)?
-    val onError: ((Throwable) -> Unit)?
-    val onComplete: (() -> Unit)?
-    val onSuccess: ((T) -> Unit)?
-
-    fun dispose()
-}
+private interface Callbacks<T> :
+    SubscribeCallback,
+    SubscribeErrorCallback,
+    SubscribeCompleteCallback,
+    SubscribeSuccessCallback<T>,
+    Disposable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Subscribe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Subscribe.kt
@@ -1,10 +1,16 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.annotations.UseReturnValue
-import com.badoo.reaktive.base.subscribeSafe
+import com.badoo.reaktive.base.SubscribeCallback
+import com.badoo.reaktive.base.SubscribeCompleteCallback
+import com.badoo.reaktive.base.SubscribeErrorCallback
+import com.badoo.reaktive.base.SubscribeValueCallback
+import com.badoo.reaktive.base.onComplete
+import com.badoo.reaktive.base.onError
+import com.badoo.reaktive.base.onNext
+import com.badoo.reaktive.base.subscribeInternal
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
-import com.badoo.reaktive.utils.handleSourceError
 import com.badoo.reaktive.utils.ThreadLocalStorage
 
 @UseReturnValue
@@ -15,90 +21,82 @@ fun <T> Observable<T>.subscribe(
     onComplete: (() -> Unit)? = null,
     onNext: ((T) -> Unit)? = null
 ): Disposable {
+    val disposableWrapper = DisposableWrapper()
+
     val callbacks =
         object : Callbacks<T> {
-            override val onSubscribe: ((Disposable) -> Unit)? = onSubscribe
-            override val onError: ((Throwable) -> Unit)? = onError
-            override val onComplete: (() -> Unit)? = onComplete
-            override val onNext: ((T) -> Unit)? = onNext
+            override val onSubscribeCallback: ((Disposable) -> Unit)? = onSubscribe
+            override val onErrorCallback: ((Throwable) -> Unit)? = onError
+            override val onCompleteCallback: (() -> Unit)? = onComplete
+            override val onNextCallback: ((T) -> Unit)? = onNext
+
+            override val isDisposed: Boolean
+                get() = disposableWrapper.isDisposed
 
             override fun dispose() {
-                // no-op
+                disposableWrapper.dispose()
             }
         }
 
-    return if (isThreadLocal) {
-        subscribeThreadLocal(callbacks)
-    } else {
-        subscribeActual(callbacks)
+    if (isThreadLocal) {
+        return subscribeThreadLocal(disposableWrapper, callbacks)
     }
+
+    subscribeActual(disposableWrapper, callbacks)
+
+    return callbacks
 }
 
 @UseReturnValue
-private fun <T> Observable<T>.subscribeThreadLocal(callbacks: Callbacks<T>): Disposable {
+private fun <T> Observable<T>.subscribeThreadLocal(disposableWrapper: DisposableWrapper, callbacks: Callbacks<T>): Disposable {
     val storage = ThreadLocalStorage(callbacks)
 
-    return subscribeActual(
+    val threadLocalCallbacks =
         object : Callbacks<T> {
-            override val onSubscribe: ((Disposable) -> Unit)? get() = storage.value?.onSubscribe
-            override val onError: ((Throwable) -> Unit)? get() = storage.value?.onError
-            override val onComplete: (() -> Unit)? get() = storage.value?.onComplete
-            override val onNext: ((T) -> Unit)? get() = storage.value?.onNext
+            override val onSubscribeCallback: ((Disposable) -> Unit)? get() = storage.value?.onSubscribeCallback
+            override val onErrorCallback: ((Throwable) -> Unit)? get() = storage.value?.onErrorCallback
+            override val onCompleteCallback: (() -> Unit)? get() = storage.value?.onCompleteCallback
+            override val onNextCallback: ((T) -> Unit)? get() = storage.value?.onNextCallback
+            override val isDisposed: Boolean get() = storage.value?.isDisposed ?: true
 
             override fun dispose() {
                 storage.value?.dispose()
                 storage.dispose()
             }
         }
-    )
+
+    subscribeActual(disposableWrapper, threadLocalCallbacks)
+
+    return threadLocalCallbacks
 }
 
 @UseReturnValue
-private fun <T> Observable<T>.subscribeActual(callbacks: Callbacks<T>): Disposable {
-    val disposableWrapper = DisposableWrapper()
-    callbacks.onSubscribe?.invoke(disposableWrapper)
-
-    subscribeSafe(
+private fun <T> Observable<T>.subscribeActual(disposableWrapper: DisposableWrapper, callbacks: Callbacks<T>) {
+    val observer =
         object : ObservableObserver<T> {
             override fun onSubscribe(disposable: Disposable) {
                 disposableWrapper.set(disposable)
             }
 
             override fun onNext(value: T) {
-                callbacks.onNext?.invoke(value)
+                callbacks.onNext(value)
             }
 
             override fun onComplete() {
-                try {
-                    callbacks.onComplete?.invoke()
-                } finally {
-                    disposableWrapper.dispose()
-                }
+                callbacks.onComplete()
             }
 
             override fun onError(error: Throwable) {
-                try {
-                    handleSourceError(error, callbacks.onError)
-                } finally {
-                    disposableWrapper.dispose()
-                }
+                callbacks.onError(error)
             }
         }
-    )
 
-    return object : Disposable by disposableWrapper {
-        override fun dispose() {
-            disposableWrapper.dispose()
-            callbacks.dispose()
-        }
-    }
+    subscribeInternal(callbacks, observer)
 }
 
-private interface Callbacks<T> {
-    val onSubscribe: ((Disposable) -> Unit)?
-    val onError: ((Throwable) -> Unit)?
-    val onComplete: (() -> Unit)?
-    val onNext: ((T) -> Unit)?
-
-    fun dispose()
-}
+private interface Callbacks<T> :
+    SubscribeCallback,
+    SubscribeErrorCallback,
+    SubscribeValueCallback<T>,
+    SubscribeCompleteCallback,
+    Disposable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Subscribe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Subscribe.kt
@@ -53,7 +53,7 @@ private fun <T> Single<T>.subscribeThreadLocal(disposableWrapper: DisposableWrap
             }
         }
 
-    subscribeActual(disposableWrapper, callbacks)
+    subscribeActual(disposableWrapper, threadLocalCallbacks)
 
     return threadLocalCallbacks
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/PrintError.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/PrintError.kt
@@ -1,3 +1,14 @@
 package com.badoo.reaktive.utils
 
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
+
+@Suppress("ObjectPropertyName") // Backing field
+private val _isPrintErrorEnabled = AtomicBoolean(true)
+
+internal var isPrintErrorEnabled
+    get() = _isPrintErrorEnabled.value
+    set(value) {
+        _isPrintErrorEnabled.value = value
+    }
+
 internal expect fun printError(error: Any?)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/UncaughtErrorHandler.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/UncaughtErrorHandler.kt
@@ -14,4 +14,8 @@ var reaktiveUncaughtErrorHandler: (Throwable) -> Unit
         _reaktiveUncaughtErrorHandler.value = value
     }
 
+fun resetReaktiveUncaughtErrorHandler() {
+    reaktiveUncaughtErrorHandler = createDefaultUncaughtErrorHandler()
+}
+
 internal expect fun createDefaultUncaughtErrorHandler(): (Throwable) -> Unit

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/Utils.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/Utils.kt
@@ -1,5 +1,7 @@
 package com.badoo.reaktive.utils
 
+import com.badoo.reaktive.base.exceptions.CompositeException
+
 internal fun handleSourceError(error: Throwable, onError: ((Throwable) -> Unit)? = null) {
     try {
         if (onError == null) {
@@ -10,7 +12,8 @@ internal fun handleSourceError(error: Throwable, onError: ((Throwable) -> Unit)?
             } catch (e: Throwable) {
                 printError("onError callback failed ($error): $e")
                 error.printStack()
-                reaktiveUncaughtErrorHandler(e)
+                e.printStack()
+                reaktiveUncaughtErrorHandler(CompositeException(error, e))
             }
         }
     } catch (e: Throwable) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/Utils.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/Utils.kt
@@ -9,17 +9,17 @@ internal fun handleSourceError(error: Throwable, onError: ((Throwable) -> Unit)?
         } else {
             try {
                 onError(error)
-            } catch (e: Throwable) {
-                printError("onError callback failed ($error): $e")
+            } catch (errorHandlerException: Throwable) {
+                printError("onError callback failed ($error): $errorHandlerException")
                 error.printStack()
-                e.printStack()
-                reaktiveUncaughtErrorHandler(CompositeException(error, e))
+                errorHandlerException.printStack()
+                reaktiveUncaughtErrorHandler(CompositeException(error, errorHandlerException))
             }
         }
-    } catch (e: Throwable) {
-        printError("Error delivering uncaught error ($error): $e")
+    } catch (errorDeliveryException: Throwable) {
+        printError("Error delivering uncaught error ($error): $errorDeliveryException")
         error.printStack()
-        e.printStack()
+        errorDeliveryException.printStack()
     }
 }
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/SubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/SubscribeTest.kt
@@ -1,14 +1,13 @@
-package com.badoo.reaktive.observable
+package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.base.exceptions.CompositeException
 import com.badoo.reaktive.disposable.disposable
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertSubscribed
 import com.badoo.reaktive.test.base.hasSubscribers
-import com.badoo.reaktive.test.observable.TestObservable
-import com.badoo.reaktive.test.observable.TestObservableObserver
-import com.badoo.reaktive.test.observable.assertComplete
-import com.badoo.reaktive.test.observable.assertValues
+import com.badoo.reaktive.test.completable.TestCompletable
+import com.badoo.reaktive.test.completable.TestCompletableObserver
+import com.badoo.reaktive.test.completable.assertComplete
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import com.badoo.reaktive.utils.isPrintErrorEnabled
@@ -23,8 +22,8 @@ import kotlin.test.assertTrue
 
 class SubscribeTest {
 
-    private val upstream = TestObservable<Int?>()
-    private val observer = TestObservableObserver<Int?>()
+    private val upstream = TestCompletable()
+    private val observer = TestCompletableObserver()
 
     @BeforeTest
     fun before() {
@@ -57,18 +56,6 @@ class SubscribeTest {
     }
 
     @Test
-    fun calls_onNext_in_the_same_order_WHEN_upstream_emitted_values() {
-        observer.onSubscribe(disposable())
-        upstream.subscribe(onNext = observer::onNext)
-
-        upstream.onNext(null)
-        upstream.onNext(1)
-        upstream.onNext(2)
-
-        observer.assertValues(null, 1, 2)
-    }
-
-    @Test
     fun calls_onComplete_WHEN_upstream_is_completed() {
         observer.onSubscribe(disposable())
         upstream.subscribe(onComplete = observer::onComplete)
@@ -77,16 +64,6 @@ class SubscribeTest {
 
         observer.assertComplete()
     }
-
-    @Test
-    fun disposes_disposable_WHEN_upstream_is_completed() {
-        val disposable = upstream.subscribe()
-
-        upstream.onComplete()
-
-        assertTrue(disposable.isDisposed)
-    }
-
 
     @Test
     fun calls_onError_WHEN_upstream_produced_an_error() {
@@ -142,32 +119,6 @@ class SubscribeTest {
         )
 
         assertFalse(upstream.hasSubscribers)
-    }
-
-    @Test
-    fun calls_onError_WHEN_onNext_thrown_exception() {
-        val exception = Exception()
-        val caughtException: AtomicReference<Throwable?> = AtomicReference(null, true)
-
-        upstream.subscribe(
-            onError = { caughtException.value = it },
-            onNext = { throw exception }
-        )
-        upstream.onNext(0)
-
-        assertSame(exception, caughtException.value)
-    }
-
-    @Test
-    fun calls_uncaught_exception_handler_WHEN_onComplete_thrown_exception() {
-        val exception = Exception()
-        val caughtException: AtomicReference<Throwable?> = AtomicReference(null, true)
-        reaktiveUncaughtErrorHandler = { caughtException.value = it }
-
-        upstream.subscribe(onComplete = { throw exception })
-        upstream.onComplete()
-
-        assertSame(exception, caughtException.value)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/SubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/SubscribeTest.kt
@@ -1,19 +1,40 @@
 package com.badoo.reaktive.single
 
+import com.badoo.reaktive.base.exceptions.CompositeException
 import com.badoo.reaktive.disposable.disposable
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertSubscribed
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.test.single.TestSingleObserver
 import com.badoo.reaktive.test.single.assertSuccess
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.isPrintErrorEnabled
+import com.badoo.reaktive.utils.reaktiveUncaughtErrorHandler
+import com.badoo.reaktive.utils.resetReaktiveUncaughtErrorHandler
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class SubscribeTest {
 
     private val upstream = TestSingle<Int?>()
     private val observer = TestSingleObserver<Int?>()
+
+    @BeforeTest
+    fun before() {
+        isPrintErrorEnabled = false
+    }
+
+    @AfterTest
+    fun after() {
+        isPrintErrorEnabled = true
+        resetReaktiveUncaughtErrorHandler()
+    }
 
     @Test
     fun returned_disposable_is_not_disposed() {
@@ -63,7 +84,6 @@ class SubscribeTest {
         assertTrue(disposable.isDisposed)
     }
 
-
     @Test
     fun calls_onError_WHEN_upstream_produced_an_error() {
         observer.onSubscribe(disposable())
@@ -82,5 +102,84 @@ class SubscribeTest {
         upstream.onError(Throwable())
 
         assertTrue(disposable.isDisposed)
+    }
+
+    @Test
+    fun calls_onError_WHEN_onSubscribe_thrown_exception() {
+        val exception = Exception()
+        val caughtException: AtomicReference<Throwable?> = AtomicReference(null, true)
+
+        upstream.subscribe(
+            onSubscribe = { throw exception },
+            onError = { caughtException.value = it }
+        )
+
+        assertSame(exception, caughtException.value)
+    }
+
+    @Test
+    fun returned_disposable_is_disposed_WHEN_onSubscribe_thrown_exception() {
+        val exception = Exception()
+
+        val disposable =
+            upstream.subscribe(
+                onSubscribe = { throw exception },
+                onError = {}
+            )
+
+        assertTrue(disposable.isDisposed)
+    }
+
+    @Test
+    fun does_not_subscribe_to_upstream_WHEN_onSubscribe_thrown_exception() {
+        upstream.subscribe(
+            onSubscribe = { throw Exception() },
+            onError = {}
+        )
+
+        assertFalse(upstream.hasSubscribers)
+    }
+
+    @Test
+    fun calls_uncaught_exception_handler_WHEN_onSuccess_thrown_exception() {
+        val exception = Exception()
+        val caughtException: AtomicReference<Throwable?> = AtomicReference(null, true)
+        reaktiveUncaughtErrorHandler = { caughtException.value = it }
+
+        upstream.subscribe(onSuccess = { throw exception })
+        upstream.onSuccess(0)
+
+        assertSame(exception, caughtException.value)
+    }
+
+    @Test
+    fun does_not_call_onError_WHEN_onSuccess_thrown_exception() {
+        val exception = Exception()
+        reaktiveUncaughtErrorHandler = {}
+        val isOnErrorCalled = AtomicBoolean()
+
+        upstream.subscribe(
+            onError = { isOnErrorCalled.value = true },
+            onSuccess = { throw exception }
+        )
+        upstream.onSuccess(0)
+
+        assertFalse(isOnErrorCalled.value)
+    }
+
+    @Test
+    fun calls_uncaught_exception_handler_with_CompositeException_WHEN_onError_thrown_exception() {
+        val exception1 = Exception()
+        val exception2 = Exception()
+        val caughtException: AtomicReference<Throwable?> = AtomicReference(null, true)
+        reaktiveUncaughtErrorHandler = { caughtException.value = it }
+
+        upstream.subscribe(onError = { throw exception2 })
+        upstream.onError(exception1)
+
+        assertTrue(caughtException.value is CompositeException)
+        val compositeException = caughtException.value as CompositeException
+        assertSame(exception1, compositeException.cause1)
+        assertSame(exception2, compositeException.cause2)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/test/Utils.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/test/Utils.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.test
 
-import com.badoo.reaktive.scheduler.computationScheduler
 import com.badoo.reaktive.utils.Condition
 import com.badoo.reaktive.utils.uptimeMillis
 import kotlin.test.fail
@@ -28,8 +27,4 @@ internal fun Condition.waitForOrFail(timeoutNanos: Long, predicate: () -> Boolea
     if (!waitFor(timeoutNanos, predicate)) {
         fail("Timeout waiting for condition")
     }
-}
-
-internal fun doInBackground(block: () -> Unit) {
-    computationScheduler.newExecutor().submit(task = block)
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/test/Utils.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/test/Utils.kt
@@ -1,5 +1,6 @@
 package com.badoo.reaktive.test
 
+import com.badoo.reaktive.scheduler.computationScheduler
 import com.badoo.reaktive.utils.Condition
 import com.badoo.reaktive.utils.uptimeMillis
 import kotlin.test.fail
@@ -27,4 +28,8 @@ internal fun Condition.waitForOrFail(timeoutNanos: Long, predicate: () -> Boolea
     if (!waitFor(timeoutNanos, predicate)) {
         fail("Timeout waiting for condition")
     }
+}
+
+internal fun doInBackground(block: () -> Unit) {
+    computationScheduler.newExecutor().submit(task = block)
 }

--- a/reaktive/src/iosCommonMain/kotlin/com/badoo/reaktive/utils/CurrentThread.kt
+++ b/reaktive/src/iosCommonMain/kotlin/com/badoo/reaktive/utils/CurrentThread.kt
@@ -1,11 +1,8 @@
 package com.badoo.reaktive.utils
 
-import kotlinx.cinterop.pointed
 import platform.Foundation.NSThread
-import platform.posix.pthread_self
 
-internal actual val currentThreadId: Long
-    get() = pthread_self()?.pointed?.__sig?.toLong() ?: NSThread.currentThread.name?.hashCode()?.toLong() ?: 0L
+// pthread_t.__sig returns same value for all threads, pthread_mach_thread_np() is not available in Kotlin/Native
+internal actual val currentThreadId: Long get() = NSThread.currentThread.hashCode().toLong()
 
-internal actual val currentThreadName: String
-    get() = NSThread.currentThread.name ?: pthread_self()?.pointed?.__sig?.toString() ?: "unnamed"
+internal actual val currentThreadName: String get() = NSThread.currentThread.name ?: "thread_$currentThreadId"

--- a/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/PrintError.kt
+++ b/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/PrintError.kt
@@ -1,5 +1,7 @@
 package com.badoo.reaktive.utils
 
 internal actual fun printError(error: Any?) {
-    console.error(error)
+    if (isPrintErrorEnabled) {
+        console.error(error)
+    }
 }

--- a/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/base/exceptions/CompositeException.kt
+++ b/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/base/exceptions/CompositeException.kt
@@ -1,19 +1,37 @@
 package com.badoo.reaktive.base.exceptions
 
-import java.io.PrintWriter
-
 actual class CompositeException actual constructor(
     actual val cause1: Throwable,
     actual val cause2: Throwable
 ) : RuntimeException() {
 
-    override fun printStackTrace(writer: PrintWriter) {
-        super.printStackTrace(writer)
+    init {
+        initCause(cause1)
 
-        writer.print("Caused by 1: ")
-        cause1.printStackTrace(writer)
+        if (!cause1.hasCause(cause2)) {
+            cause1.rootCause.initCause(cause2)
+        }
+    }
 
-        writer.print("Caused by 2: ")
-        cause2.printStackTrace(writer)
+    private companion object {
+        private fun Throwable.hasCause(throwable: Throwable): Boolean {
+            var cause: Throwable? = this
+            while (cause != null) {
+                if (cause === throwable) {
+                    return true
+                }
+                cause = cause.cause
+            }
+
+            return false
+        }
+
+        private val Throwable.rootCause: Throwable
+            get() {
+                var cause: Throwable = this
+                while (true) {
+                    cause = cause.cause ?: return cause
+                }
+            }
     }
 }

--- a/reaktive/src/jvmCommonTest/kotlin/com/badoo/reaktive/test/DoInBackground.kt
+++ b/reaktive/src/jvmCommonTest/kotlin/com/badoo/reaktive/test/DoInBackground.kt
@@ -1,0 +1,9 @@
+@file:JvmName("DoInBackgroundJvm")
+
+package com.badoo.reaktive.test
+
+import kotlin.jvm.JvmName
+
+internal actual fun doInBackground(block: () -> Unit) {
+    Thread(block).start()
+}

--- a/reaktive/src/jvmMain/kotlin/com/badoo/reaktive/utils/PrintError.kt
+++ b/reaktive/src/jvmMain/kotlin/com/badoo/reaktive/utils/PrintError.kt
@@ -1,5 +1,9 @@
+@file:JvmName("PrintError")
+
 package com.badoo.reaktive.utils
 
 internal actual fun printError(error: Any?) {
-    System.err.println(error)
+    if (isPrintErrorEnabled) {
+        System.err.println(error)
+    }
 }

--- a/reaktive/src/jvmNativeCommonTest/kotlin/com/badoo/reaktive/test/DoInBackground.kt
+++ b/reaktive/src/jvmNativeCommonTest/kotlin/com/badoo/reaktive/test/DoInBackground.kt
@@ -1,0 +1,25 @@
+package com.badoo.reaktive.test
+
+import com.badoo.reaktive.utils.Lock
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
+import com.badoo.reaktive.utils.synchronized
+
+internal expect fun doInBackground(block: () -> Unit)
+
+fun doInBackgroundBlocking(timeoutNanos: Long = 5_000_000_000L, block: () -> Unit) {
+    val lock = Lock()
+    val condition = lock.newCondition()
+    val isFinished = AtomicBoolean(false)
+
+    doInBackground {
+        block()
+        lock.synchronized {
+            isFinished.value = true
+            condition.signal()
+        }
+    }
+
+    lock.synchronized {
+        condition.waitForOrFail(timeoutNanos, isFinished::value)
+    }
+}

--- a/reaktive/src/jvmNativeCommonTest/kotlin/com/badoo/reaktive/utils/ThreadLocalStorageThreadingTest.kt
+++ b/reaktive/src/jvmNativeCommonTest/kotlin/com/badoo/reaktive/utils/ThreadLocalStorageThreadingTest.kt
@@ -1,6 +1,7 @@
 package com.badoo.reaktive.utils
 
 import com.badoo.reaktive.scheduler.computationScheduler
+import com.badoo.reaktive.test.doInBackground
 import com.badoo.reaktive.test.waitForOrFail
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import kotlin.test.Test
@@ -34,7 +35,7 @@ class ThreadLocalStorageThreadingTest {
         val lock = Lock()
         val condition = lock.newCondition()
 
-        computationScheduler.newExecutor().submit {
+        doInBackground {
             val isFailed =
                 try {
                     block(storage)

--- a/reaktive/src/jvmNativeCommonTest/kotlin/com/badoo/reaktive/utils/ThreadLocalStorageThreadingTest.kt
+++ b/reaktive/src/jvmNativeCommonTest/kotlin/com/badoo/reaktive/utils/ThreadLocalStorageThreadingTest.kt
@@ -1,11 +1,9 @@
 package com.badoo.reaktive.utils
 
-import com.badoo.reaktive.scheduler.computationScheduler
-import com.badoo.reaktive.test.doInBackground
-import com.badoo.reaktive.test.waitForOrFail
+import com.badoo.reaktive.test.doInBackgroundBlocking
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertEquals
 
 class ThreadLocalStorageThreadingTest {
 
@@ -31,31 +29,18 @@ class ThreadLocalStorageThreadingTest {
 
     private fun testThrowsRuntimeExceptionFromAnotherThread(block: (ThreadLocalStorage<Unit>) -> Unit) {
         val storage = ThreadLocalStorage(Unit)
-        val isFailedRef = AtomicReference<Boolean?>(null)
-        val lock = Lock()
-        val condition = lock.newCondition()
+        val isFailed = AtomicReference<Boolean?>(null)
 
-        doInBackground {
-            val isFailed =
+        doInBackgroundBlocking {
+            isFailed.value =
                 try {
                     block(storage)
                     false
                 } catch (e: RuntimeException) {
                     true
                 }
-
-            lock.synchronized {
-                isFailedRef.value = isFailed
-                condition.signal()
-            }
         }
 
-        lock.synchronized {
-            condition.waitForOrFail(5_000_000_000L) {
-                isFailedRef.value != null
-            }
-        }
-
-        assertTrue(isFailedRef.value!!)
+        assertEquals(true, isFailed.value)
     }
 }

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/PrintError.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/PrintError.kt
@@ -4,5 +4,7 @@ import platform.posix.fprintf
 import platform.posix.stderr
 
 internal actual fun printError(error: Any?) {
-    fprintf(stderr, error.toString())
+    if (isPrintErrorEnabled) {
+        fprintf(stderr, error.toString())
+    }
 }

--- a/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/completable/SubscribeTestNative.kt
+++ b/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/completable/SubscribeTestNative.kt
@@ -2,17 +2,15 @@ package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.test.completable.TestCompletable
-import com.badoo.reaktive.test.doInBackground
-import com.badoo.reaktive.test.waitForOrFail
-import com.badoo.reaktive.utils.Lock
+import com.badoo.reaktive.test.doInBackgroundBlocking
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import com.badoo.reaktive.utils.reaktiveUncaughtErrorHandler
 import com.badoo.reaktive.utils.resetReaktiveUncaughtErrorHandler
-import com.badoo.reaktive.utils.synchronized
 import kotlin.native.concurrent.ensureNeverFrozen
 import kotlin.native.concurrent.freeze
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 
 class SubscribeTestNative {
 
@@ -56,22 +54,13 @@ class SubscribeTestNative {
     private fun testCallsUncaughtExceptionWhenThreadLocalAndEventOccurred(block: (CompletableCallbacks) -> Unit) {
         val caughtException: AtomicReference<Throwable?> = AtomicReference(null, true)
         reaktiveUncaughtErrorHandler = { caughtException.value = it }
-        val lock = Lock()
-        val condition = lock.newCondition()
         val upstream = TestCompletable()
         upstream.subscribe(isThreadLocal = true)
 
-        doInBackground {
-            lock.synchronized {
-                block(upstream)
-                condition.signal()
-            }
+        doInBackgroundBlocking {
+            block(upstream)
         }
 
-        lock.synchronized {
-            condition.waitForOrFail(5_000_000_000L) {
-                caughtException.value != null
-            }
-        }
+        assertNotNull(caughtException.value)
     }
 }

--- a/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/completable/SubscribeTestNative.kt
+++ b/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/completable/SubscribeTestNative.kt
@@ -2,35 +2,76 @@ package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.test.completable.TestCompletable
+import com.badoo.reaktive.test.doInBackground
+import com.badoo.reaktive.test.waitForOrFail
+import com.badoo.reaktive.utils.Lock
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.reaktiveUncaughtErrorHandler
+import com.badoo.reaktive.utils.resetReaktiveUncaughtErrorHandler
+import com.badoo.reaktive.utils.synchronized
 import kotlin.native.concurrent.ensureNeverFrozen
 import kotlin.native.concurrent.freeze
+import kotlin.test.AfterTest
 import kotlin.test.Test
 
 class SubscribeTestNative {
 
-    @Test
-    fun does_not_freeze_callbacks_WHEN_subscribed_without_isThreadLocal() {
-        val onSubscribe: (Disposable) -> Unit = {}
-        val onError: (Throwable) -> Unit = {}
-        val onComplete: () -> Unit = {}
-        onSubscribe.ensureNeverFrozen()
-        onError.ensureNeverFrozen()
-        onComplete.ensureNeverFrozen()
-
-        TestCompletable()
-            .subscribe(isThreadLocal = false, onError = onError, onComplete = onComplete)
+    @AfterTest
+    fun after() {
+        resetReaktiveUncaughtErrorHandler()
     }
 
     @Test
-    fun does_not_freeze_callbacks_WHEN_subscribed_with_isThreadLocal() {
+    fun does_not_freeze_callbacks_WHEN_subscribed_without_isThreadLocal() {
         val onSubscribe: (Disposable) -> Unit = {}
-        val onError: (Throwable) -> Unit = {}
         val onComplete: () -> Unit = {}
         onSubscribe.ensureNeverFrozen()
-        onError.ensureNeverFrozen()
+        onComplete.ensureNeverFrozen()
+
+        completableUnsafe { }
+            .subscribe(isThreadLocal = false, onComplete = onComplete)
+    }
+
+    @Test
+    fun does_not_freeze_callbacks_WHEN_subscribed_with_isThreadLocal_and_observer_is_frozen() {
+        val onSubscribe: (Disposable) -> Unit = {}
+        val onComplete: () -> Unit = {}
+        onSubscribe.ensureNeverFrozen()
         onComplete.ensureNeverFrozen()
 
         completableUnsafe { it.freeze() }
-            .subscribe(isThreadLocal = true, onError = onError, onComplete = onComplete)
+            .subscribe(isThreadLocal = true, onComplete = onComplete)
+    }
+
+    @Test
+    fun calls_uncaught_exception_WHEN_thread_local_and_completed_from_another_thread() {
+        testCallsUncaughtExceptionWhenThreadLocalAndEventOccurred(CompletableCallbacks::onComplete)
+    }
+
+    @Test
+    fun calls_uncaught_exception_WHEN_thread_local_and_error_produced_from_another_thread() {
+        testCallsUncaughtExceptionWhenThreadLocalAndEventOccurred { it.onError(Exception()) }
+    }
+
+    private fun testCallsUncaughtExceptionWhenThreadLocalAndEventOccurred(block: (CompletableCallbacks) -> Unit) {
+        val caughtException: AtomicReference<Throwable?> = AtomicReference(null, true)
+        reaktiveUncaughtErrorHandler = { caughtException.value = it }
+        val lock = Lock()
+        val condition = lock.newCondition()
+        val upstream = TestCompletable()
+        upstream.subscribe(isThreadLocal = true)
+
+        doInBackground {
+            lock.synchronized {
+                block(upstream)
+                condition.signal()
+            }
+        }
+
+        lock.synchronized {
+            condition.waitForOrFail(5_000_000_000L) {
+                caughtException.value != null
+            }
+        }
     }
 }

--- a/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/maybe/SubscribeTestNative.kt
+++ b/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/maybe/SubscribeTestNative.kt
@@ -1,18 +1,16 @@
 package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.test.doInBackground
+import com.badoo.reaktive.test.doInBackgroundBlocking
 import com.badoo.reaktive.test.maybe.TestMaybe
-import com.badoo.reaktive.test.waitForOrFail
-import com.badoo.reaktive.utils.Lock
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import com.badoo.reaktive.utils.reaktiveUncaughtErrorHandler
 import com.badoo.reaktive.utils.resetReaktiveUncaughtErrorHandler
-import com.badoo.reaktive.utils.synchronized
 import kotlin.native.concurrent.ensureNeverFrozen
 import kotlin.native.concurrent.freeze
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 
 class SubscribeTestNative {
 
@@ -65,22 +63,13 @@ class SubscribeTestNative {
     private fun testCallsUncaughtExceptionWhenThreadLocalAndEventOccurred(block: (MaybeCallbacks<Unit>) -> Unit) {
         val caughtException: AtomicReference<Throwable?> = AtomicReference(null, true)
         reaktiveUncaughtErrorHandler = { caughtException.value = it }
-        val lock = Lock()
-        val condition = lock.newCondition()
         val upstream = TestMaybe<Unit>()
         upstream.subscribe(isThreadLocal = true)
 
-        doInBackground {
-            lock.synchronized {
-                block(upstream)
-                condition.signal()
-            }
+        doInBackgroundBlocking {
+            block(upstream)
         }
 
-        lock.synchronized {
-            condition.waitForOrFail(5_000_000_000L) {
-                caughtException.value != null
-            }
-        }
+        assertNotNull(caughtException.value)
     }
 }

--- a/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/maybe/SubscribeTestNative.kt
+++ b/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/maybe/SubscribeTestNative.kt
@@ -1,40 +1,86 @@
 package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.test.doInBackground
 import com.badoo.reaktive.test.maybe.TestMaybe
+import com.badoo.reaktive.test.waitForOrFail
+import com.badoo.reaktive.utils.Lock
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.reaktiveUncaughtErrorHandler
+import com.badoo.reaktive.utils.resetReaktiveUncaughtErrorHandler
+import com.badoo.reaktive.utils.synchronized
 import kotlin.native.concurrent.ensureNeverFrozen
 import kotlin.native.concurrent.freeze
+import kotlin.test.AfterTest
 import kotlin.test.Test
 
 class SubscribeTestNative {
 
-    @Test
-    fun does_not_freeze_callbacks_WHEN_subscribed_without_isThreadLocal() {
-        val onSubscribe: (Disposable) -> Unit = {}
-        val onError: (Throwable) -> Unit = {}
-        val onComplete: () -> Unit = {}
-        val onSuccess: (Nothing) -> Unit = {}
-        onSubscribe.ensureNeverFrozen()
-        onError.ensureNeverFrozen()
-        onComplete.ensureNeverFrozen()
-        onSuccess.ensureNeverFrozen()
-
-        TestMaybe<Nothing>()
-            .subscribe(isThreadLocal = false, onError = onError, onComplete = onComplete, onSuccess = onSuccess)
+    @AfterTest
+    fun after() {
+        resetReaktiveUncaughtErrorHandler()
     }
 
     @Test
-    fun does_not_freeze_callbacks_WHEN_subscribed_with_isThreadLocal() {
+    fun does_not_freeze_callbacks_WHEN_subscribed_without_isThreadLocal() {
         val onSubscribe: (Disposable) -> Unit = {}
-        val onError: (Throwable) -> Unit = {}
         val onComplete: () -> Unit = {}
         val onSuccess: (Nothing) -> Unit = {}
         onSubscribe.ensureNeverFrozen()
-        onError.ensureNeverFrozen()
+        onComplete.ensureNeverFrozen()
+        onSuccess.ensureNeverFrozen()
+
+        maybeUnsafe<Nothing> { }
+            .subscribe(isThreadLocal = false, onComplete = onComplete, onSuccess = onSuccess)
+    }
+
+    @Test
+    fun does_not_freeze_callbacks_WHEN_subscribed_with_isThreadLocal_and_observer_is_frozen() {
+        val onSubscribe: (Disposable) -> Unit = {}
+        val onComplete: () -> Unit = {}
+        val onSuccess: (Nothing) -> Unit = {}
+        onSubscribe.ensureNeverFrozen()
         onComplete.ensureNeverFrozen()
         onSuccess.ensureNeverFrozen()
 
         maybeUnsafe<Nothing> { it.freeze() }
-            .subscribe(isThreadLocal = true, onError = onError, onComplete = onComplete, onSuccess = onSuccess)
+            .subscribe(isThreadLocal = true, onComplete = onComplete, onSuccess = onSuccess)
+    }
+
+    @Test
+    fun calls_uncaught_exception_WHEN_thread_local_and_succeeded_from_another_thread() {
+        testCallsUncaughtExceptionWhenThreadLocalAndEventOccurred { it.onSuccess(Unit) }
+    }
+
+    @Test
+    fun calls_uncaught_exception_WHEN_thread_local_and_completed_from_another_thread() {
+        testCallsUncaughtExceptionWhenThreadLocalAndEventOccurred(MaybeCallbacks<*>::onComplete)
+    }
+
+    @Test
+    fun calls_uncaught_exception_WHEN_thread_local_and_error_produced_from_another_thread() {
+        testCallsUncaughtExceptionWhenThreadLocalAndEventOccurred { it.onError(Exception()) }
+    }
+
+    private fun testCallsUncaughtExceptionWhenThreadLocalAndEventOccurred(block: (MaybeCallbacks<Unit>) -> Unit) {
+        val caughtException: AtomicReference<Throwable?> = AtomicReference(null, true)
+        reaktiveUncaughtErrorHandler = { caughtException.value = it }
+        val lock = Lock()
+        val condition = lock.newCondition()
+        val upstream = TestMaybe<Unit>()
+        upstream.subscribe(isThreadLocal = true)
+
+        doInBackground {
+            lock.synchronized {
+                block(upstream)
+                condition.signal()
+            }
+        }
+
+        lock.synchronized {
+            condition.waitForOrFail(5_000_000_000L) {
+                caughtException.value != null
+            }
+        }
     }
 }

--- a/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/observable/SubscribeTestNative.kt
+++ b/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/observable/SubscribeTestNative.kt
@@ -1,20 +1,18 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.test.doInBackground
+import com.badoo.reaktive.test.doInBackgroundBlocking
 import com.badoo.reaktive.test.observable.TestObservable
-import com.badoo.reaktive.test.waitForOrFail
-import com.badoo.reaktive.utils.Lock
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import com.badoo.reaktive.utils.reaktiveUncaughtErrorHandler
 import com.badoo.reaktive.utils.resetReaktiveUncaughtErrorHandler
-import com.badoo.reaktive.utils.synchronized
 import kotlin.native.concurrent.TransferMode
 import kotlin.native.concurrent.Worker
 import kotlin.native.concurrent.ensureNeverFrozen
 import kotlin.native.concurrent.freeze
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 
 class SubscribeTestNative {
 
@@ -67,22 +65,13 @@ class SubscribeTestNative {
     private fun testCallsUncaughtExceptionWhenThreadLocalAndEventOccurred(block: (ObservableCallbacks<Unit>) -> Unit) {
         val caughtException: AtomicReference<Throwable?> = AtomicReference(null, true)
         reaktiveUncaughtErrorHandler = { caughtException.value = it }
-        val lock = Lock()
-        val condition = lock.newCondition()
         val upstream = TestObservable<Unit>()
         upstream.subscribe(isThreadLocal = true)
 
-        doInBackground {
-            lock.synchronized {
-                block(upstream)
-                condition.signal()
-            }
+        doInBackgroundBlocking {
+            block(upstream)
         }
 
-        lock.synchronized {
-            condition.waitForOrFail(5_000_000_000L) {
-                caughtException.value != null
-            }
-        }
+        assertNotNull(caughtException.value)
     }
 }

--- a/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/observable/SubscribeTestNative.kt
+++ b/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/observable/SubscribeTestNative.kt
@@ -1,40 +1,88 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.test.doInBackground
 import com.badoo.reaktive.test.observable.TestObservable
+import com.badoo.reaktive.test.waitForOrFail
+import com.badoo.reaktive.utils.Lock
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.reaktiveUncaughtErrorHandler
+import com.badoo.reaktive.utils.resetReaktiveUncaughtErrorHandler
+import com.badoo.reaktive.utils.synchronized
+import kotlin.native.concurrent.TransferMode
+import kotlin.native.concurrent.Worker
 import kotlin.native.concurrent.ensureNeverFrozen
 import kotlin.native.concurrent.freeze
+import kotlin.test.AfterTest
 import kotlin.test.Test
 
 class SubscribeTestNative {
 
-    @Test
-    fun does_not_freeze_callbacks_WHEN_subscribed_without_isThreadLocal() {
-        val onSubscribe: (Disposable) -> Unit = {}
-        val onError: (Throwable) -> Unit = {}
-        val onComplete: () -> Unit = {}
-        val onNext: (Nothing) -> Unit = {}
-        onSubscribe.ensureNeverFrozen()
-        onError.ensureNeverFrozen()
-        onComplete.ensureNeverFrozen()
-        onNext.ensureNeverFrozen()
-
-        TestObservable<Nothing>()
-            .subscribe(isThreadLocal = false, onError = onError, onComplete = onComplete, onNext = onNext)
+    @AfterTest
+    fun after() {
+        resetReaktiveUncaughtErrorHandler()
     }
 
     @Test
-    fun does_not_freeze_callbacks_WHEN_subscribed_with_isThreadLocal() {
+    fun does_not_freeze_callbacks_WHEN_subscribed_without_isThreadLocal() {
         val onSubscribe: (Disposable) -> Unit = {}
-        val onError: (Throwable) -> Unit = {}
         val onComplete: () -> Unit = {}
         val onNext: (Nothing) -> Unit = {}
         onSubscribe.ensureNeverFrozen()
-        onError.ensureNeverFrozen()
+        onComplete.ensureNeverFrozen()
+        onNext.ensureNeverFrozen()
+
+        observableUnsafe<Nothing> { }
+            .subscribe(isThreadLocal = false, onComplete = onComplete, onNext = onNext)
+    }
+
+    @Test
+    fun does_not_freeze_callbacks_WHEN_subscribed_with_isThreadLocal_and_observer_is_frozen() {
+        val onSubscribe: (Disposable) -> Unit = {}
+        val onComplete: () -> Unit = {}
+        val onNext: (Nothing) -> Unit = {}
+        onSubscribe.ensureNeverFrozen()
         onComplete.ensureNeverFrozen()
         onNext.ensureNeverFrozen()
 
         observableUnsafe<Nothing> { it.freeze() }
-            .subscribe(isThreadLocal = true, onError = onError, onComplete = onComplete, onNext = onNext)
+            .subscribe(isThreadLocal = true, onComplete = onComplete, onNext = onNext)
+    }
+
+    @Test
+    fun calls_uncaught_exception_WHEN_thread_local_and_value_produced_from_another_thread() {
+        testCallsUncaughtExceptionWhenThreadLocalAndEventOccurred { it.onNext(Unit) }
+    }
+
+    @Test
+    fun calls_uncaught_exception_WHEN_thread_local_and_completed_from_another_thread() {
+        testCallsUncaughtExceptionWhenThreadLocalAndEventOccurred(ObservableCallbacks<*>::onComplete)
+    }
+
+    @Test
+    fun calls_uncaught_exception_WHEN_thread_local_and_error_produced_from_another_thread() {
+        testCallsUncaughtExceptionWhenThreadLocalAndEventOccurred { it.onError(Exception()) }
+    }
+
+    private fun testCallsUncaughtExceptionWhenThreadLocalAndEventOccurred(block: (ObservableCallbacks<Unit>) -> Unit) {
+        val caughtException: AtomicReference<Throwable?> = AtomicReference(null, true)
+        reaktiveUncaughtErrorHandler = { caughtException.value = it }
+        val lock = Lock()
+        val condition = lock.newCondition()
+        val upstream = TestObservable<Unit>()
+        upstream.subscribe(isThreadLocal = true)
+
+        doInBackground {
+            lock.synchronized {
+                block(upstream)
+                condition.signal()
+            }
+        }
+
+        lock.synchronized {
+            condition.waitForOrFail(5_000_000_000L) {
+                caughtException.value != null
+            }
+        }
     }
 }

--- a/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/single/SubscribeTestNative.kt
+++ b/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/single/SubscribeTestNative.kt
@@ -1,28 +1,40 @@
 package com.badoo.reaktive.single
 
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.test.doInBackground
 import com.badoo.reaktive.test.single.TestSingle
+import com.badoo.reaktive.test.waitForOrFail
+import com.badoo.reaktive.utils.Lock
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.printStack
+import com.badoo.reaktive.utils.reaktiveUncaughtErrorHandler
+import com.badoo.reaktive.utils.resetReaktiveUncaughtErrorHandler
+import com.badoo.reaktive.utils.synchronized
 import kotlin.native.concurrent.ensureNeverFrozen
 import kotlin.native.concurrent.freeze
+import kotlin.test.AfterTest
 import kotlin.test.Test
 
 class SubscribeTestNative {
 
-    @Test
-    fun does_not_freeze_callbacks_WHEN_subscribed_without_isThreadLocal() {
-        val onSubscribe: (Disposable) -> Unit = {}
-        val onError: (Throwable) -> Unit = {}
-        val onSuccess: (Nothing) -> Unit = {}
-        onSubscribe.ensureNeverFrozen()
-        onError.ensureNeverFrozen()
-        onSuccess.ensureNeverFrozen()
-
-        TestSingle<Nothing>()
-            .subscribe(isThreadLocal = false, onError = onError, onSuccess = onSuccess)
+    @AfterTest
+    fun after() {
+        resetReaktiveUncaughtErrorHandler()
     }
 
     @Test
-    fun does_not_freeze_callbacks_WHEN_subscribed_with_isThreadLocal() {
+    fun does_not_freeze_callbacks_WHEN_subscribed_without_isThreadLocal() {
+        val onSubscribe: (Disposable) -> Unit = {}
+        val onSuccess: (Nothing) -> Unit = {}
+        onSubscribe.ensureNeverFrozen()
+        onSuccess.ensureNeverFrozen()
+
+        singleUnsafe<Nothing> { }
+            .subscribe(isThreadLocal = false, onSuccess = onSuccess)
+    }
+
+    @Test
+    fun does_not_freeze_callbacks_WHEN_subscribed_with_isThreadLocal_and_observer_is_frozen() {
         val onSubscribe: (Disposable) -> Unit = {}
         val onError: (Throwable) -> Unit = {}
         val onSuccess: (Nothing) -> Unit = {}
@@ -30,7 +42,46 @@ class SubscribeTestNative {
         onError.ensureNeverFrozen()
         onSuccess.ensureNeverFrozen()
 
-        singleUnsafe<Nothing> { it.freeze() }
-            .subscribe(isThreadLocal = true, onError = onError, onSuccess = onSuccess)
+        singleUnsafe<Nothing> {
+            try {
+                it.freeze()
+            } catch (e: Throwable) {
+                e.printStack()
+                throw e
+            }
+        }
+            .subscribe(isThreadLocal = true, onSuccess = onSuccess)
+    }
+
+    @Test
+    fun calls_uncaught_exception_WHEN_thread_local_and_succeeded_from_another_thread() {
+        testCallsUncaughtExceptionWhenThreadLocalAndEventOccurred { it.onSuccess(Unit) }
+    }
+
+    @Test
+    fun calls_uncaught_exception_WHEN_thread_local_and_error_produced_from_another_thread() {
+        testCallsUncaughtExceptionWhenThreadLocalAndEventOccurred { it.onError(Exception()) }
+    }
+
+    private fun testCallsUncaughtExceptionWhenThreadLocalAndEventOccurred(block: (SingleCallbacks<Unit>) -> Unit) {
+        val caughtException: AtomicReference<Throwable?> = AtomicReference(null, true)
+        reaktiveUncaughtErrorHandler = { caughtException.value = it }
+        val lock = Lock()
+        val condition = lock.newCondition()
+        val upstream = TestSingle<Unit>()
+        upstream.subscribe(isThreadLocal = true)
+
+        doInBackground {
+            lock.synchronized {
+                block(upstream)
+                condition.signal()
+            }
+        }
+
+        lock.synchronized {
+            condition.waitForOrFail(5_000_000_000L) {
+                caughtException.value != null
+            }
+        }
     }
 }

--- a/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/test/DoInBackground.kt
+++ b/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/test/DoInBackground.kt
@@ -1,0 +1,9 @@
+package com.badoo.reaktive.test
+
+import kotlin.native.concurrent.TransferMode
+import kotlin.native.concurrent.Worker
+import kotlin.native.concurrent.freeze
+
+internal actual fun doInBackground(block: () -> Unit) {
+    Worker.start(errorReporting = true).execute(TransferMode.SAFE, { block.freeze() }) { it() }
+}

--- a/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/utils/CurrentThreadTest.kt
+++ b/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/utils/CurrentThreadTest.kt
@@ -1,0 +1,66 @@
+package com.badoo.reaktive.utils
+
+import com.badoo.reaktive.test.doInBackgroundBlocking
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+
+class CurrentThreadTest {
+
+    @Test
+    fun currentThreadId_returns_same_value_for_main_thread() {
+        val id1 = currentThreadId
+        val id2 = currentThreadId
+        val id3 = currentThreadId
+
+        assertEquals(id1, id2)
+        assertEquals(id2, id3)
+    }
+
+    @Test
+    fun currentThreadId_returns_same_value_for_worker_thread() {
+        val ids = AtomicReference<Array<Long>?>(null, true)
+
+        doInBackgroundBlocking {
+            ids.value = Array(3) { currentThreadId }
+        }
+
+        assertNotNull(ids.value)
+        val (id1, id2, id3) = ids.value!!
+        assertEquals(id1, id2)
+        assertEquals(id2, id3)
+    }
+
+    @Test
+    fun currentThreadId_returns_different_values_for_main_and_worker_thread() {
+        val mainThreadId = currentThreadId
+        val workerThreadId = AtomicReference<Long?>(null)
+
+        doInBackgroundBlocking {
+            workerThreadId.value = currentThreadId
+        }
+
+        assertNotNull(workerThreadId.value)
+        assertNotEquals(mainThreadId, workerThreadId.value)
+    }
+
+    @Test
+    fun currentThreadId_returns_different_values_for_different_worker_threads() {
+        val workerThreadId1 = AtomicReference<Long?>(null)
+        val workerThreadId2 = AtomicReference<Long?>(null)
+
+        doInBackgroundBlocking {
+            workerThreadId1.value = currentThreadId
+        }
+
+        doInBackgroundBlocking {
+            workerThreadId2.value = currentThreadId
+        }
+
+        assertNotNull(workerThreadId1.value)
+        assertNotNull(workerThreadId2.value)
+        assertNotEquals(workerThreadId1.value, workerThreadId2.value)
+    }
+}


### PR DESCRIPTION
Quite a big change, extracted boilerplate to a separate file.
Fixes #176 
