### PR TITLE
Fix maybeOf nullability

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Vairous.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Vairous.kt
@@ -7,12 +7,16 @@ inline fun <T> maybeUnsafe(crossinline onSubscribe: (observer: MaybeObserver<T>)
         }
     }
 
-fun <T> maybeOf(value: T): Maybe<T> =
+fun <T : Any> maybeOf(value: T?): Maybe<T> =
     maybe { emitter ->
-        emitter.onSuccess(value)
+        if (value == null) {
+            emitter.onComplete()
+        } else {
+            emitter.onSuccess(value)
+        }
     }
 
-fun <T> T.toMaybe(): Maybe<T> = maybeOf(this)
+fun <T : Any> T?.toMaybe(): Maybe<T> = maybeOf(this)
 
 fun <T> maybeOfError(error: Throwable): Maybe<T> =
     maybe { emitter ->


### PR DESCRIPTION
Perhaps `maybeOf(value)` should work as in RxJava2, if value is `null` then `Maybe` should just complete, otherwise emit the value. Not sure though.