### PR TITLE
Update README with the correct module name for reaktive-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ repositories {
 There are four modules published:
 - `reaktive` - the main Reaktive library (multiplatform)
 - `reaktive-annotations` - collection of annotations (mutiplatform)
-- `reaktive-testing` - testing utilities (multiplatform)
+- `reaktive-test` - testing utilities (multiplatform)
 - `rxjava2-interop` - RxJava2 interoperability helpers (JVM and Android)
 
 Each multiplatform module is compiled against each target and published in


### PR DESCRIPTION
The `reaktive-testing` module is published as `reaktive-test` on maven, which wasn't clear in the README. 