### PR TITLE
Make publication name match MPP naming model

### DIFF
--- a/rxjava2-interop/build.gradle
+++ b/rxjava2-interop/build.gradle
@@ -8,7 +8,7 @@ version = reaktive_version
 
 publishing {
     publications {
-        maven(MavenPublication) {
+        jvm(MavenPublication) {
             from components.java
         }
     }


### PR DESCRIPTION
It is much easier just to rename publication name (that is used only in Gradle) than to do fixes inside plugin.