### PR TITLE
Skip Jitpack builds

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,3 @@
 jdk: openjdk8
-install: ./gradlew reaktive:publishToMavenLocal rxjava2-interop:publishToMavenLocal
+before_install: true
+install: true


### PR DESCRIPTION
Not sure if Jitpack still tries to build us or not, but now it will be disabled by overriding build steps.