### PR TITLE
Remove Disposable interface from TestSource

### DIFF
--- a/coroutines-interop/src/commonTest/kotlin/com/badoo/reaktive/coroutinesinterop/ObservableAsFlowTest.kt
+++ b/coroutines-interop/src/commonTest/kotlin/com/badoo/reaktive/coroutinesinterop/ObservableAsFlowTest.kt
@@ -1,5 +1,6 @@
 package com.badoo.reaktive.coroutinesinterop
 
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.onNext
 import kotlinx.coroutines.CoroutineScope
@@ -10,6 +11,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
@@ -64,7 +66,7 @@ class ObservableAsFlowTest {
     }
 
     @Test
-    fun disposes_upstream_WHEN_flow_is_cancelled() {
+    fun unsubscribes_from_upstream_WHEN_flow_is_cancelled() {
         val scope = CoroutineScope(Dispatchers.Unconfined)
 
         scope.launch(Dispatchers.Unconfined) {
@@ -73,6 +75,6 @@ class ObservableAsFlowTest {
 
         scope.cancel()
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 }

--- a/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/base/TestSource.kt
+++ b/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/base/TestSource.kt
@@ -3,27 +3,19 @@ package com.badoo.reaktive.test.base
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.base.Source
-import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.AtomicReference
-import com.badoo.reaktive.utils.atomic.update
+import com.badoo.reaktive.disposable.disposable
+import com.badoo.reaktive.utils.atomic.AtomicList
+import com.badoo.reaktive.utils.atomic.minusAssign
+import com.badoo.reaktive.utils.atomic.plusAssign
 
-open class TestSource<O> : Source<O>, Disposable, ErrorCallback where O : Observer, O : ErrorCallback {
+open class TestSource<O> : Source<O>, ErrorCallback where O : Observer, O : ErrorCallback {
 
-    private val _observers: AtomicReference<List<O>> = AtomicReference(emptyList())
+    private val _observers: AtomicList<O> = AtomicList(emptyList())
     val observers get() = _observers.value
 
-    private val _isDisposed = AtomicBoolean()
-    override val isDisposed: Boolean get() = _isDisposed.value
-
     override fun subscribe(observer: O) {
-        _observers.update { it + observer }
-        observer.onSubscribe(this)
-    }
-
-    override fun dispose() {
-        _isDisposed.value = true
-        _observers.value = emptyList()
+        _observers += observer
+        observer.onSubscribe(disposable { _observers -= observer })
     }
 
     override fun onError(error: Throwable) {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AndThenTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AndThenTest.kt
@@ -67,12 +67,11 @@ class AndThenTest : CompletableToCompletableTests by CompletableToCompletableTes
     }
 
     @Test
-    fun disposes_inner_source_WHEN_disposed() {
+    fun unsubscribes_from_inner_source_WHEN_disposed() {
         upstream.onComplete()
 
         observer.dispose()
 
-        assertTrue(upstream.isDisposed)
-        assertTrue(inner.isDisposed)
+        assertFalse(inner.hasSubscribers)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToCompletableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToCompletableTests.kt
@@ -2,11 +2,12 @@ package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertSubscribed
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.assertComplete
 import com.badoo.reaktive.test.completable.test
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 interface CompletableToCompletableTests {
 
@@ -20,7 +21,7 @@ interface CompletableToCompletableTests {
     fun produces_error_WHEN_upstream_produced_error()
 
     @Test
-    fun disposes_upstream_WHEN_disposed()
+    fun unsubscribes_from_upstream_WHEN_disposed()
 
     companion object {
         operator fun invoke(transform: Completable.() -> Completable): CompletableToCompletableTests =
@@ -46,10 +47,10 @@ interface CompletableToCompletableTests {
                     observer.assertError(error)
                 }
 
-                override fun disposes_upstream_WHEN_disposed() {
+                override fun unsubscribes_from_upstream_WHEN_disposed() {
                     observer.dispose()
 
-                    assertTrue(upstream.isDisposed)
+                    assertFalse(upstream.hasSubscribers)
                 }
             }
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToMaybeTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToMaybeTests.kt
@@ -3,11 +3,12 @@ package com.badoo.reaktive.completable
 import com.badoo.reaktive.maybe.Maybe
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertSubscribed
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.maybe.assertComplete
 import com.badoo.reaktive.test.maybe.test
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 interface CompletableToMaybeTests {
 
@@ -21,7 +22,7 @@ interface CompletableToMaybeTests {
     fun produces_error_WHEN_upstream_produced_error()
 
     @Test
-    fun disposes_upstream_WHEN_disposed()
+    fun unsubscribes_from_upstream_WHEN_disposed()
 
     companion object {
         operator fun invoke(transform: Completable.() -> Maybe<*>): CompletableToMaybeTests =
@@ -47,10 +48,10 @@ interface CompletableToMaybeTests {
                     observer.assertError(error)
                 }
 
-                override fun disposes_upstream_WHEN_disposed() {
+                override fun unsubscribes_from_upstream_WHEN_disposed() {
                     observer.dispose()
 
-                    assertTrue(upstream.isDisposed)
+                    assertFalse(upstream.hasSubscribers)
                 }
             }
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToObservableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToObservableTests.kt
@@ -3,11 +3,12 @@ package com.badoo.reaktive.completable
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertSubscribed
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.observable.assertComplete
 import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 interface CompletableToObservableTests {
 
@@ -21,7 +22,7 @@ interface CompletableToObservableTests {
     fun produces_error_WHEN_upstream_produced_error()
 
     @Test
-    fun disposes_upstream_WHEN_disposed()
+    fun unsubscribes_from_upstream_WHEN_disposed()
 
     companion object {
         operator fun invoke(transform: Completable.() -> Observable<*>): CompletableToObservableTests =
@@ -47,10 +48,10 @@ interface CompletableToObservableTests {
                     observer.assertError(error)
                 }
 
-                override fun disposes_upstream_WHEN_disposed() {
+                override fun unsubscribes_from_upstream_WHEN_disposed() {
                     observer.dispose()
 
-                    assertTrue(upstream.isDisposed)
+                    assertFalse(upstream.hasSubscribers)
                 }
             }
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToSingleTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToSingleTests.kt
@@ -3,10 +3,11 @@ package com.badoo.reaktive.completable
 import com.badoo.reaktive.single.Single
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertSubscribed
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 interface CompletableToSingleTests {
 
@@ -17,7 +18,7 @@ interface CompletableToSingleTests {
     fun produces_error_WHEN_upstream_produced_error()
 
     @Test
-    fun disposes_upstream_WHEN_disposed()
+    fun unsubscribes_from_upstream_WHEN_disposed()
 
     companion object {
         operator fun invoke(transform: Completable.() -> Single<*>): CompletableToSingleTests =
@@ -37,10 +38,10 @@ interface CompletableToSingleTests {
                     observer.assertError(error)
                 }
 
-                override fun disposes_upstream_WHEN_disposed() {
+                override fun unsubscribes_from_upstream_WHEN_disposed() {
                     observer.dispose()
 
-                    assertTrue(upstream.isDisposed)
+                    assertFalse(upstream.hasSubscribers)
                 }
             }
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/ConcatTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/ConcatTests.kt
@@ -65,11 +65,11 @@ class ConcatTests : CompletableToCompletableTests by CompletableToCompletableTes
     }
 
     @Test
-    fun disposes_second_upstream_WHEN_disposed() {
+    fun unsubscribes_from_second_upstream_WHEN_disposed() {
         upstream1.onComplete()
         inner.dispose()
 
-        assertTrue(upstream2.isDisposed)
+        assertFalse(upstream2.hasSubscribers)
     }
 
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/MergeTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/MergeTests.kt
@@ -7,6 +7,7 @@ import com.badoo.reaktive.test.completable.assertComplete
 import com.badoo.reaktive.test.completable.assertNotComplete
 import com.badoo.reaktive.test.completable.test
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class MergeTests : CompletableToCompletableTests by CompletableToCompletableTests({ merge(this) }) {
@@ -57,11 +58,11 @@ class MergeTests : CompletableToCompletableTests by CompletableToCompletableTest
     }
 
     @Test
-    fun disposes_both_upstreams_WHEN_disposed() {
+    fun unsubscribes_from_both_upstreams_WHEN_disposed() {
         inner.dispose()
 
-        assertTrue(upstream1.isDisposed)
-        assertTrue(upstream2.isDisposed)
+        assertFalse(upstream1.hasSubscribers)
+        assertFalse(upstream2.hasSubscribers)
     }
 
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/OnErrorResumeNextTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/OnErrorResumeNextTest.kt
@@ -40,22 +40,22 @@ class OnErrorResumeNextTest :
     }
 
     @Test
-    fun disposes_upstream_WHEN_upstream_produced_error() {
+    fun unsubscribes_from_upstream_WHEN_upstream_produced_error() {
         createTestWithCompletable()
 
         upstream.onError(Throwable())
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     @Test
-    fun disposes_resume_next_WHEN_disposed() {
+    fun unsubscribes_from_resume_next_WHEN_disposed() {
         val (errorResumeNext, observer) = createTestWithCompletable()
 
         upstream.onError(Throwable())
         observer.dispose()
 
-        assertTrue(errorResumeNext.isDisposed)
+        assertFalse(errorResumeNext.hasSubscribers)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/SubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/SubscribeTest.kt
@@ -42,10 +42,10 @@ class SubscribeTest {
     }
 
     @Test
-    fun disposes_upstream_WHEN_disposed() {
+    fun unsubscribes_from_upstream_WHEN_disposed() {
         upstream.subscribe().dispose()
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToCompletableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToCompletableTests.kt
@@ -3,11 +3,12 @@ package com.badoo.reaktive.maybe
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertSubscribed
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.completable.assertComplete
 import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.maybe.TestMaybe
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 interface MaybeToCompletableTests {
 
@@ -21,7 +22,7 @@ interface MaybeToCompletableTests {
     fun produces_error_WHEN_upstream_produced_error()
 
     @Test
-    fun disposes_upstream_WHEN_disposed()
+    fun unsubscribes_from_upstream_WHEN_disposed()
 
     companion object {
         operator fun invoke(transform: Maybe<*>.() -> Completable): MaybeToCompletableTests =
@@ -47,10 +48,10 @@ interface MaybeToCompletableTests {
                     observer.assertError(error)
                 }
 
-                override fun disposes_upstream_WHEN_disposed() {
+                override fun unsubscribes_from_upstream_WHEN_disposed() {
                     observer.dispose()
 
-                    assertTrue(upstream.isDisposed)
+                    assertFalse(upstream.hasSubscribers)
                 }
             }
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToMaybeTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToMaybeTests.kt
@@ -2,11 +2,12 @@ package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertSubscribed
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.assertComplete
 import com.badoo.reaktive.test.maybe.test
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 interface MaybeToMaybeTests {
 
@@ -20,7 +21,7 @@ interface MaybeToMaybeTests {
     fun produces_error_WHEN_upstream_produced_error()
 
     @Test
-    fun disposes_upstream_WHEN_disposed()
+    fun unsubscribes_from_upstream_WHEN_disposed()
 
     companion object {
         operator fun <T> invoke(transform: Maybe<T>.() -> Maybe<*>): MaybeToMaybeTests =
@@ -46,10 +47,10 @@ interface MaybeToMaybeTests {
                     observer.assertError(error)
                 }
 
-                override fun disposes_upstream_WHEN_disposed() {
+                override fun unsubscribes_from_upstream_WHEN_disposed() {
                     observer.dispose()
 
-                    assertTrue(upstream.isDisposed)
+                    assertFalse(upstream.hasSubscribers)
                 }
             }
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToObservableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToObservableTests.kt
@@ -3,11 +3,12 @@ package com.badoo.reaktive.maybe
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertSubscribed
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.observable.assertComplete
 import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 interface MaybeToObservableTests {
 
@@ -21,7 +22,7 @@ interface MaybeToObservableTests {
     fun produces_error_WHEN_upstream_produced_error()
 
     @Test
-    fun disposes_upstream_WHEN_disposed()
+    fun unsubscribes_from_upstream_WHEN_disposed()
 
     companion object {
         operator fun <T> invoke(transform: Maybe<T>.() -> Observable<*>): MaybeToObservableTests =
@@ -47,10 +48,10 @@ interface MaybeToObservableTests {
                     observer.assertError(error)
                 }
 
-                override fun disposes_upstream_WHEN_disposed() {
+                override fun unsubscribes_from_upstream_WHEN_disposed() {
                     observer.dispose()
 
-                    assertTrue(upstream.isDisposed)
+                    assertFalse(upstream.hasSubscribers)
                 }
             }
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToSingleTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToSingleTests.kt
@@ -3,10 +3,11 @@ package com.badoo.reaktive.maybe
 import com.badoo.reaktive.single.Single
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertSubscribed
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 interface MaybeToSingleTests {
 
@@ -17,7 +18,7 @@ interface MaybeToSingleTests {
     fun produces_error_WHEN_upstream_produced_error()
 
     @Test
-    fun disposes_upstream_WHEN_disposed()
+    fun unsubscribes_from_upstream_WHEN_disposed()
 
     companion object {
         operator fun <T> invoke(transform: Maybe<T>.() -> Single<*>): MaybeToSingleTests =
@@ -37,10 +38,10 @@ interface MaybeToSingleTests {
                     observer.assertError(error)
                 }
 
-                override fun disposes_upstream_WHEN_disposed() {
+                override fun unsubscribes_from_upstream_WHEN_disposed() {
                     observer.dispose()
 
-                    assertTrue(upstream.isDisposed)
+                    assertFalse(upstream.hasSubscribers)
                 }
             }
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/OnErrorResumeNextTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/OnErrorResumeNextTest.kt
@@ -51,22 +51,22 @@ class OnErrorResumeNextTest :
     }
 
     @Test
-    fun disposes_upstream_WHEN_upstream_produced_error() {
+    fun unsubscribes_from_upstream_WHEN_upstream_produced_error() {
         createTestWithMaybe()
 
         upstream.onError(Throwable())
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     @Test
-    fun disposes_resume_next_WHEN_disposed() {
+    fun unsubscribes_from_resume_next_WHEN_disposed() {
         val (errorResumeNext, observer) = createTestWithMaybe()
 
         upstream.onError(Throwable())
         observer.dispose()
 
-        assertTrue(errorResumeNext.isDisposed)
+        assertFalse(errorResumeNext.hasSubscribers)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/SubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/SubscribeTest.kt
@@ -43,10 +43,10 @@ class SubscribeTest {
     }
 
     @Test
-    fun disposes_upstream_WHEN_disposed() {
+    fun unsubscribes_from_upstream_WHEN_disposed() {
         upstream.subscribe().dispose()
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ConcatMapTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ConcatMapTest.kt
@@ -172,36 +172,36 @@ class ConcatMapTest
     }
 
     @Test
-    fun disposes_source_WHEN_disposed() {
+    fun unsubscribes_from_source_WHEN_disposed() {
         val inner = TestObservable<String>()
         val observer = concatMapUpstreamAndSubscribe { inner }
         upstream.onNext(0)
 
         observer.dispose()
 
-        assertTrue(inner.isDisposed)
+        assertFalse(inner.hasSubscribers)
     }
 
     @Test
-    fun disposes_source_WHEN_upstream_produced_error() {
+    fun unsubscribes_from_source_WHEN_upstream_produced_error() {
         val inner = TestObservable<String>()
         concatMapUpstreamAndSubscribe { inner }
         upstream.onNext(0)
 
         upstream.onError(Throwable())
 
-        assertTrue(inner.isDisposed)
+        assertFalse(inner.hasSubscribers)
     }
 
     @Test
-    fun disposes_upstream_WHEN_source_produced_error() {
+    fun unsubscribes_from_upstream_WHEN_source_produced_error() {
         val inner = TestObservable<String>()
         concatMapUpstreamAndSubscribe { inner }
         upstream.onNext(0)
 
         inner.onError(Throwable())
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     private fun concatMapUpstreamAndSubscribe(innerSources: List<Observable<String?>>): TestObservableObserver<String?> =

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DebounceWithSelectorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DebounceWithSelectorTest.kt
@@ -205,66 +205,66 @@ class DebounceWithSelectorTest :
     }
 
     @Test
-    fun disposes_previous_stream_WHEN_source_emits_next_value() {
+    fun unsubscribes_from_previous_stream_WHEN_source_emits_next_value() {
         val source = TestObservable<Int>()
         val inners = createInnerSources(2)
         source.debounce { inners[it] }.test()
 
         source.onNext(0)
-        assertFalse(inners[0].isDisposed)
+        assertTrue(inners[0].hasSubscribers)
 
         source.onNext(1)
-        assertFalse(source.isDisposed)
-        assertTrue(inners[0].isDisposed)
-        assertFalse(inners[1].isDisposed)
+        assertTrue(source.hasSubscribers)
+        assertFalse(inners[0].hasSubscribers)
+        assertTrue(inners[1].hasSubscribers)
     }
 
     @Test
-    fun disposes_latest_stream_WHEN_disposed() {
+    fun unsubscribes_from_latest_stream_WHEN_disposed() {
         val source = TestObservable<Int>()
         val inners = createInnerSources(2)
         val observer = source.debounce { inners[it] }.test()
 
         source.onNext(0)
         source.onNext(1)
-        assertTrue(inners[0].isDisposed)
+        assertFalse(inners[0].hasSubscribers)
 
         observer.dispose()
 
-        assertTrue(source.isDisposed)
-        assertTrue(inners[1].isDisposed)
+        assertFalse(source.hasSubscribers)
+        assertFalse(inners[1].hasSubscribers)
     }
 
     @Test
-    fun disposes_streams_WHEN_upstream_produced_error() {
+    fun unsubscribes_from_streams_WHEN_upstream_produced_error() {
         val source = TestObservable<Int>()
         val inners = createInnerSources(2)
         source.debounce { inners[it] }.test()
 
         source.onNext(0)
         source.onNext(1)
-        assertTrue(inners[0].isDisposed)
+        assertFalse(inners[0].hasSubscribers)
 
         source.onError(Throwable())
 
-        assertTrue(source.isDisposed)
-        assertTrue(inners[1].isDisposed)
+        assertFalse(source.hasSubscribers)
+        assertFalse(inners[1].hasSubscribers)
     }
 
     @Test
-    fun disposes_stream_WHEN_inner_source_produced_error() {
+    fun unsubscribes_from_stream_WHEN_inner_source_produced_error() {
         val source = TestObservable<Int>()
         val inners = createInnerSources(2)
         source.debounce { inners[it] }.test()
 
         source.onNext(0)
         source.onNext(1)
-        assertTrue(inners[0].isDisposed)
+        assertFalse(inners[0].hasSubscribers)
 
         inners[1].onError(Throwable())
 
-        assertTrue(source.isDisposed)
-        assertTrue(inners[1].isDisposed)
+        assertFalse(source.hasSubscribers)
+        assertFalse(inners[1].hasSubscribers)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrCompleteTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrCompleteTests.kt
@@ -1,5 +1,6 @@
 package com.badoo.reaktive.observable
 
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.maybe.assertComplete
 import com.badoo.reaktive.test.maybe.assertSuccess
 import com.badoo.reaktive.test.maybe.test
@@ -28,14 +29,14 @@ class FirstOrCompleteTests : ObservableToMaybeTests by ObservableToMaybeTests<No
     }
 
     @Test
-    fun disposes_upstream_WHEN_upstream_emitted_value() {
+    fun unsubscribes_from_upstream_WHEN_upstream_emitted_value() {
         upstream.onNext(0)
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     @Test
-    fun does_not_dispose_upstream_WHEN_upstream_did_not_emit_values() {
-        assertFalse(upstream.isDisposed)
+    fun does_not_unsubscribe_from_upstream_WHEN_upstream_did_not_emit_values() {
+        assertTrue(upstream.hasSubscribers)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrDefaultSupplierTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrDefaultSupplierTests.kt
@@ -1,6 +1,7 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.test.base.assertError
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.single.assertSuccess
 import com.badoo.reaktive.test.single.test
@@ -28,15 +29,15 @@ class FirstOrDefaultSupplierTests : ObservableToSingleTests by ObservableToSingl
     }
 
     @Test
-    fun disposes_upstream_WHEN_upstream_emitted_value() {
+    fun unsubscribes_from_upstream_WHEN_upstream_emitted_value() {
         upstream.onNext(0)
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     @Test
-    fun does_not_dispose_upstream_WHEN_upstream_did_not_emit_values() {
-        assertFalse(upstream.isDisposed)
+    fun does_not_unsubscribe_from_upstream_WHEN_upstream_did_not_emit_values() {
+        assertTrue(upstream.hasSubscribers)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrDefaultValueTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrDefaultValueTests.kt
@@ -1,5 +1,6 @@
 package com.badoo.reaktive.observable
 
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.single.assertSuccess
 import com.badoo.reaktive.test.single.test
@@ -27,14 +28,14 @@ class FirstOrDefaultValueTests : ObservableToSingleTests by ObservableToSingleTe
     }
 
     @Test
-    fun disposes_upstream_WHEN_upstream_emitted_value() {
+    fun unsubscribes_from_upstream_WHEN_upstream_emitted_value() {
         upstream.onNext(0)
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     @Test
-    fun does_not_dispose_upstream_WHEN_upstream_did_not_emit_values() {
-        assertFalse(upstream.isDisposed)
+    fun does_not_unsubscribe_from_upstream_WHEN_upstream_did_not_emit_values() {
+        assertTrue(upstream.hasSubscribers)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrErrorSupplierTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrErrorSupplierTests.kt
@@ -1,6 +1,7 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.test.base.assertError
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.single.TestSingleObserver
 import com.badoo.reaktive.test.single.assertSuccess
@@ -34,15 +35,15 @@ class FirstOrErrorSupplierTests : ObservableToSingleTests by ObservableToSingleT
     }
 
     @Test
-    fun disposes_upstream_WHEN_upstream_emitted_value() {
+    fun unsubscribes_from_upstream_WHEN_upstream_emitted_value() {
         upstream.onNext(0)
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     @Test
-    fun does_not_dispose_upstream_WHEN_upstream_did_not_emit_values() {
-        assertFalse(upstream.isDisposed)
+    fun does_not_unsubscribe_from_upstream_WHEN_upstream_did_not_emit_values() {
+        assertTrue(upstream.hasSubscribers)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrErrorValueTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrErrorValueTests.kt
@@ -1,6 +1,7 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.test.base.assertError
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.single.assertSuccess
 import com.badoo.reaktive.test.single.test
@@ -29,14 +30,14 @@ class FirstOrErrorValueTests : ObservableToSingleTests by ObservableToSingleTest
     }
 
     @Test
-    fun disposes_upstream_WHEN_upstream_emitted_value() {
+    fun unsubscribes_from_upstream_WHEN_upstream_emitted_value() {
         upstream.onNext(0)
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     @Test
-    fun does_not_dispose_upstream_WHEN_upstream_did_not_emit_values() {
-        assertFalse(upstream.isDisposed)
+    fun does_not_unsubscribe_from_upstream_WHEN_upstream_did_not_emit_values() {
+        assertTrue(upstream.hasSubscribers)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FlatMapTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FlatMapTest.kt
@@ -10,6 +10,7 @@ import com.badoo.reaktive.test.observable.assertNotComplete
 import com.badoo.reaktive.test.observable.assertValues
 import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class FlatMapTest
@@ -138,7 +139,7 @@ class FlatMapTest
     }
 
     @Test
-    fun disposes_streams_WHEN_disposed() {
+    fun unsubscribes_from_streams_WHEN_disposed() {
         val inners = createInnerSources(2)
         val observer = flatMapUpstreamAndSubscribe(inners)
         source.onNext(0)
@@ -146,13 +147,13 @@ class FlatMapTest
 
         observer.dispose()
 
-        assertTrue(source.isDisposed)
-        assertTrue(inners[0].isDisposed)
-        assertTrue(inners[1].isDisposed)
+        assertFalse(source.hasSubscribers)
+        assertFalse(inners[0].hasSubscribers)
+        assertFalse(inners[1].hasSubscribers)
     }
 
     @Test
-    fun disposes_streams_WHEN_upstream_produced_error() {
+    fun unsubscribes_from_streams_WHEN_upstream_produced_error() {
         val inners = createInnerSources(2)
         flatMapUpstreamAndSubscribe(inners)
         source.onNext(0)
@@ -160,13 +161,13 @@ class FlatMapTest
 
         source.onError(Throwable())
 
-        assertTrue(source.isDisposed)
-        assertTrue(inners[0].isDisposed)
-        assertTrue(inners[1].isDisposed)
+        assertFalse(source.hasSubscribers)
+        assertFalse(inners[0].hasSubscribers)
+        assertFalse(inners[1].hasSubscribers)
     }
 
     @Test
-    fun disposes_streams_WHEN_inner_source_produced_error() {
+    fun unsubscribes_from_streams_WHEN_inner_source_produced_error() {
         val inners = createInnerSources(2)
         flatMapUpstreamAndSubscribe(inners)
         source.onNext(0)
@@ -174,9 +175,9 @@ class FlatMapTest
 
         inners[1].onError(Throwable())
 
-        assertTrue(source.isDisposed)
-        assertTrue(inners[0].isDisposed)
-        assertTrue(inners[1].isDisposed)
+        assertFalse(source.hasSubscribers)
+        assertFalse(inners[0].hasSubscribers)
+        assertFalse(inners[1].hasSubscribers)
     }
 
     private fun flatMapUpstreamAndSubscribe(innerSources: List<Observable<String?>>): TestObservableObserver<String?> =

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableToCompletableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableToCompletableTests.kt
@@ -3,11 +3,12 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertSubscribed
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.completable.assertComplete
 import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.observable.TestObservable
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 interface ObservableToCompletableTests {
 
@@ -21,7 +22,7 @@ interface ObservableToCompletableTests {
     fun produces_error_WHEN_upstream_produced_error()
 
     @Test
-    fun disposes_upstream_WHEN_disposed()
+    fun unsubscribes_from_upstream_WHEN_disposed()
 
     companion object {
         operator fun invoke(transform: Observable<*>.() -> Completable): ObservableToCompletableTests =
@@ -47,10 +48,10 @@ interface ObservableToCompletableTests {
                     observer.assertError(error)
                 }
 
-                override fun disposes_upstream_WHEN_disposed() {
+                override fun unsubscribes_from_upstream_WHEN_disposed() {
                     observer.dispose()
 
-                    assertTrue(upstream.isDisposed)
+                    assertFalse(upstream.hasSubscribers)
                 }
             }
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableToMaybeTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableToMaybeTests.kt
@@ -3,11 +3,12 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.maybe.Maybe
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertSubscribed
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.maybe.assertComplete
 import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.observable.TestObservable
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 interface ObservableToMaybeTests {
 
@@ -21,7 +22,7 @@ interface ObservableToMaybeTests {
     fun produces_error_WHEN_upstream_produced_error()
 
     @Test
-    fun disposes_upstream_WHEN_disposed()
+    fun unsubscribes_from_upstream_WHEN_disposed()
 
     companion object {
         operator fun <T> invoke(transform: Observable<T>.() -> Maybe<*>): ObservableToMaybeTests =
@@ -47,10 +48,10 @@ interface ObservableToMaybeTests {
                     observer.assertError(error)
                 }
 
-                override fun disposes_upstream_WHEN_disposed() {
+                override fun unsubscribes_from_upstream_WHEN_disposed() {
                     observer.dispose()
 
-                    assertTrue(upstream.isDisposed)
+                    assertFalse(upstream.hasSubscribers)
                 }
             }
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableToObservableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableToObservableTests.kt
@@ -2,11 +2,12 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertSubscribed
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.assertComplete
 import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 interface ObservableToObservableTests {
 
@@ -20,7 +21,7 @@ interface ObservableToObservableTests {
     fun produces_error_WHEN_upstream_produced_error()
 
     @Test
-    fun disposes_upstream_WHEN_disposed()
+    fun unsubscribes_from_upstream_WHEN_disposed()
 
     companion object {
         operator fun <T> invoke(transform: Observable<T>.() -> Observable<*>): ObservableToObservableTests =
@@ -46,10 +47,10 @@ interface ObservableToObservableTests {
                     observer.assertError(error)
                 }
 
-                override fun disposes_upstream_WHEN_disposed() {
+                override fun unsubscribes_from_upstream_WHEN_disposed() {
                     observer.dispose()
 
-                    assertTrue(upstream.isDisposed)
+                    assertFalse(upstream.hasSubscribers)
                 }
             }
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableToSingleTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableToSingleTests.kt
@@ -3,10 +3,11 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.single.Single
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertSubscribed
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 interface ObservableToSingleTests {
 
@@ -17,7 +18,7 @@ interface ObservableToSingleTests {
     fun produces_error_WHEN_upstream_produced_error()
 
     @Test
-    fun disposes_upstream_WHEN_disposed()
+    fun unsubscribes_from_upstream_WHEN_disposed()
 
     companion object {
         operator fun <T> invoke(transform: Observable<T>.() -> Single<*>): ObservableToSingleTests =
@@ -37,10 +38,10 @@ interface ObservableToSingleTests {
                     observer.assertError(error)
                 }
 
-                override fun disposes_upstream_WHEN_disposed() {
+                override fun unsubscribes_from_upstream_WHEN_disposed() {
                     observer.dispose()
 
-                    assertTrue(upstream.isDisposed)
+                    assertFalse(upstream.hasSubscribers)
                 }
             }
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/OnErrorResumeNextTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/OnErrorResumeNextTest.kt
@@ -52,22 +52,22 @@ class OnErrorResumeNextTest :
     }
 
     @Test
-    fun disposes_upstream_WHEN_upstream_produced_error() {
+    fun unsubscribes_from_upstream_WHEN_upstream_produced_error() {
         createTestWithObservable()
 
         upstream.onError(Throwable())
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     @Test
-    fun disposes_resume_next_WHEN_disposed() {
+    fun unsubscribes_from_resume_next_WHEN_disposed() {
         val (errorResumeNext, observer) = createTestWithObservable()
 
         upstream.onError(Throwable())
         observer.dispose()
 
-        assertTrue(errorResumeNext.isDisposed)
+        assertFalse(errorResumeNext.hasSubscribers)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SubscribeTest.kt
@@ -43,10 +43,10 @@ class SubscribeTest {
     }
 
     @Test
-    fun disposes_upstream_WHEN_disposed() {
+    fun unsubscribes_from_upstream_WHEN_disposed() {
         upstream.subscribe().dispose()
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SwitchMapTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SwitchMapTest.kt
@@ -143,59 +143,59 @@ class SwitchMapTest :
     }
 
     @Test
-    fun disposes_previous_stream_WHEN_source_emits_next_value() {
+    fun unsubscribes_from_previous_stream_WHEN_source_emits_next_value() {
         val inners = createInnerSources(2)
         switchMapUpstreamAndSubscribe(inners)
 
         source.onNext(0)
-        assertFalse(inners[0].isDisposed)
+        assertTrue(inners[0].hasSubscribers)
 
         source.onNext(1)
-        assertFalse(source.isDisposed)
-        assertTrue(inners[0].isDisposed)
-        assertFalse(inners[1].isDisposed)
+        assertTrue(source.hasSubscribers)
+        assertFalse(inners[0].hasSubscribers)
+        assertTrue(inners[1].hasSubscribers)
     }
 
     @Test
-    fun disposes_latest_stream_WHEN_disposed() {
+    fun unsubscribes_from_latest_stream_WHEN_disposed() {
         val inners = createInnerSources(2)
         val observer = switchMapUpstreamAndSubscribe(inners)
         source.onNext(0)
         source.onNext(1)
-        assertTrue(inners[0].isDisposed)
+        assertFalse(inners[0].hasSubscribers)
 
         observer.dispose()
 
-        assertTrue(source.isDisposed)
-        assertTrue(inners[1].isDisposed)
+        assertFalse(source.hasSubscribers)
+        assertFalse(inners[1].hasSubscribers)
     }
 
     @Test
-    fun disposes_streams_WHEN_upstream_produced_error() {
+    fun unsubscribes_from_streams_WHEN_upstream_produced_error() {
         val inners = createInnerSources(2)
         switchMapUpstreamAndSubscribe(inners)
         source.onNext(0)
         source.onNext(1)
-        assertTrue(inners[0].isDisposed)
+        assertFalse(inners[0].hasSubscribers)
 
         source.onError(Throwable())
 
-        assertTrue(source.isDisposed)
-        assertTrue(inners[1].isDisposed)
+        assertFalse(source.hasSubscribers)
+        assertFalse(inners[1].hasSubscribers)
     }
 
     @Test
-    fun disposes_stream_WHEN_inner_source_produced_error() {
+    fun unsubscribes_from_stream_WHEN_inner_source_produced_error() {
         val inners = createInnerSources(2)
         switchMapUpstreamAndSubscribe(inners)
         source.onNext(0)
         source.onNext(1)
-        assertTrue(inners[0].isDisposed)
+        assertFalse(inners[0].hasSubscribers)
 
         inners[1].onError(Throwable())
 
-        assertTrue(source.isDisposed)
-        assertTrue(inners[1].isDisposed)
+        assertFalse(source.hasSubscribers)
+        assertFalse(inners[1].hasSubscribers)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/TakeUntilObservableTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/TakeUntilObservableTest.kt
@@ -1,13 +1,14 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.test.base.assertError
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.assertComplete
 import com.badoo.reaktive.test.observable.assertValues
 import com.badoo.reaktive.test.observable.onNext
 import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 class TakeUntilObservableTest :
     ObservableToObservableTests by ObservableToObservableTests<Unit>({ takeUntil(observableOfNever<Nothing>()) }) {
@@ -74,45 +75,45 @@ class TakeUntilObservableTest :
     }
 
     @Test
-    fun disposes_upstream_disposable_WHEN_other_produced_non_null_value() {
+    fun unsubscribes_from_upstream_WHEN_other_produced_non_null_value() {
         other.onNext(Unit)
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     @Test
-    fun disposes_upstream_disposable_WHEN_other_produced_null_value() {
+    fun unsubscribes_from_upstream_WHEN_other_produced_null_value() {
         other.onNext(null)
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     @Test
-    fun disposes_other_disposable_WHEN_other_produced_non_null_value() {
+    fun unsubscribes_from_other_WHEN_other_produced_non_null_value() {
         other.onNext(Unit)
 
-        assertTrue(other.isDisposed)
+        assertFalse(other.hasSubscribers)
     }
 
     @Test
-    fun disposes_other_disposable_WHEN_other_produced_null_value() {
+    fun unsubscribes_from_other_WHEN_other_produced_null_value() {
         other.onNext(null)
 
-        assertTrue(other.isDisposed)
+        assertFalse(other.hasSubscribers)
     }
 
     @Test
-    fun disposes_upstream_disposable_WHEN_other_completed() {
+    fun unsubscribes_from_upstream_WHEN_other_completed() {
         other.onComplete()
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     @Test
-    fun disposes_upstream_disposable_WHEN_other_produced_error() {
+    fun unsubscribes_from_upstream_WHEN_other_produced_error() {
         other.onError(Exception())
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     @Test
@@ -123,17 +124,17 @@ class TakeUntilObservableTest :
     }
 
     @Test
-    fun disposes_other_disposable_WHEN_upstream_completed() {
+    fun unsubscribes_from_other_WHEN_upstream_completed() {
         upstream.onComplete()
 
-        assertTrue(other.isDisposed)
+        assertFalse(other.hasSubscribers)
     }
 
     @Test
-    fun disposes_other_disposable_WHEN_upstream_produced_error() {
+    fun unsubscribes_from_other_WHEN_upstream_produced_error() {
         upstream.onError(Exception())
 
-        assertTrue(other.isDisposed)
+        assertFalse(other.hasSubscribers)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ZipTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ZipTest.kt
@@ -1,6 +1,7 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.test.base.assertError
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.assertComplete
 import com.badoo.reaktive.test.observable.assertNoValues
@@ -8,7 +9,7 @@ import com.badoo.reaktive.test.observable.assertNotComplete
 import com.badoo.reaktive.test.observable.assertValue
 import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 class ZipTest {
 
@@ -104,29 +105,29 @@ class ZipTest {
     }
 
     @Test
-    fun disposes_all_sources_WHEN_completed() {
+    fun unsubscribes_from_all_sources_WHEN_completed() {
         sources[0].onComplete()
 
-        assertTrue(sources[0].isDisposed)
-        assertTrue(sources[1].isDisposed)
-        assertTrue(sources[2].isDisposed)
+        sources.forEach {
+            assertFalse(it.hasSubscribers)
+        }
     }
 
     @Test
-    fun disposes_all_sources_WHEN_error() {
+    fun unsubscribes_from_all_sources_WHEN_error() {
         sources[0].onError(Throwable())
 
-        assertTrue(sources[0].isDisposed)
-        assertTrue(sources[1].isDisposed)
-        assertTrue(sources[2].isDisposed)
+        sources.forEach {
+            assertFalse(it.hasSubscribers)
+        }
     }
 
     @Test
-    fun disposes_all_sources_WHEN_disposed() {
+    fun unsubscribes_from_all_sources_WHEN_disposed() {
         observer.dispose()
 
-        assertTrue(sources[0].isDisposed)
-        assertTrue(sources[1].isDisposed)
-        assertTrue(sources[2].isDisposed)
+        sources.forEach {
+            assertFalse(it.hasSubscribers)
+        }
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/FlatMapTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/FlatMapTest.kt
@@ -8,6 +8,7 @@ import com.badoo.reaktive.test.single.assertNotSuccess
 import com.badoo.reaktive.test.single.assertSuccess
 import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class FlatMapTest : SingleToSingleTests by SingleToSingleTests<Unit>({ flatMap { TestSingle<Int>() } }) {
@@ -68,13 +69,12 @@ class FlatMapTest : SingleToSingleTests by SingleToSingleTests<Unit>({ flatMap {
     }
 
     @Test
-    fun disposes_inner_source_WHEN_disposed() {
+    fun unsubscribes_from_inner_source_WHEN_disposed() {
         upstream.onSuccess(0)
 
         observer.dispose()
 
-        assertTrue(upstream.isDisposed)
-        assertTrue(inner.isDisposed)
+        assertFalse(inner.hasSubscribers)
     }
 
     private fun flatMapUpstreamAndSubscribe(innerSources: List<Single<String?>>): TestSingleObserver<String?> =

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/FlattenTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/FlattenTest.kt
@@ -2,13 +2,14 @@ package com.badoo.reaktive.single
 
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertSubscribed
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.observable.assertComplete
 import com.badoo.reaktive.test.observable.assertNotComplete
 import com.badoo.reaktive.test.observable.assertValues
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.single.TestSingle
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 class FlattenTest {
 
@@ -55,9 +56,9 @@ class FlattenTest {
     }
 
     @Test
-    fun disposes_upstream_WHEN_disposed() {
+    fun unsubscribes_from_upstream_WHEN_disposed() {
         observer.dispose()
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/OnErrorResumeNextTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/OnErrorResumeNextTest.kt
@@ -41,22 +41,22 @@ class OnErrorResumeNextTest :
     }
 
     @Test
-    fun disposes_upstream_WHEN_upstream_produced_error() {
+    fun unsubscribes_from_upstream_WHEN_upstream_produced_error() {
         createTestWithSingle()
 
         upstream.onError(Throwable())
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     @Test
-    fun disposes_resume_next_WHEN_disposed() {
+    fun unsubscribes_from_resume_next_WHEN_disposed() {
         val (errorResumeNext, observer) = createTestWithSingle()
 
         upstream.onError(Throwable())
         observer.dispose()
 
-        assertTrue(errorResumeNext.isDisposed)
+        assertFalse(errorResumeNext.hasSubscribers)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/SingleToMaybeTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/SingleToMaybeTests.kt
@@ -3,10 +3,11 @@ package com.badoo.reaktive.single
 import com.badoo.reaktive.maybe.Maybe
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertSubscribed
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.single.TestSingle
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 interface SingleToMaybeTests {
 
@@ -17,7 +18,7 @@ interface SingleToMaybeTests {
     fun produces_error_WHEN_upstream_produced_error()
 
     @Test
-    fun disposes_upstream_WHEN_disposed()
+    fun unsubscribes_from_upstream_WHEN_disposed()
 
     companion object {
         operator fun <T> invoke(transform: Single<T>.() -> Maybe<*>): SingleToMaybeTests =
@@ -37,10 +38,10 @@ interface SingleToMaybeTests {
                     observer.assertError(error)
                 }
 
-                override fun disposes_upstream_WHEN_disposed() {
+                override fun unsubscribes_from_upstream_WHEN_disposed() {
                     observer.dispose()
 
-                    assertTrue(upstream.isDisposed)
+                    assertFalse(upstream.hasSubscribers)
                 }
             }
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/SingleToSingleTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/SingleToSingleTests.kt
@@ -2,10 +2,11 @@ package com.badoo.reaktive.single
 
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertSubscribed
+import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 interface SingleToSingleTests {
 
@@ -16,7 +17,7 @@ interface SingleToSingleTests {
     fun produces_error_WHEN_upstream_produced_error()
 
     @Test
-    fun disposes_upstream_WHEN_disposed()
+    fun unsubscribes_from_upstream_WHEN_disposed()
 
     companion object {
         operator fun <T> invoke(transform: Single<T>.() -> Single<*>): SingleToSingleTests =
@@ -36,10 +37,10 @@ interface SingleToSingleTests {
                     observer.assertError(error)
                 }
 
-                override fun disposes_upstream_WHEN_disposed() {
+                override fun unsubscribes_from_upstream_WHEN_disposed() {
                     observer.dispose()
 
-                    assertTrue(upstream.isDisposed)
+                    assertFalse(upstream.hasSubscribers)
                 }
             }
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/SubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/SubscribeTest.kt
@@ -42,10 +42,10 @@ class SubscribeTest {
     }
 
     @Test
-    fun disposes_upstream_WHEN_disposed() {
+    fun unsubscribes_from_upstream_WHEN_disposed() {
         upstream.subscribe().dispose()
 
-        assertTrue(upstream.isDisposed)
+        assertFalse(upstream.hasSubscribers)
     }
 
     @Test


### PR DESCRIPTION
There are two commits:
1. Removed Disposable interface from `TestSource`
2. Updated all the tests

Reason: can't use `TestObservable` for `Observable.publish()` testing because the last one can resubscribe to the upstream.