### PR TITLE
User synchronized instead of Lock in SerializerImpl in JVM and JS

### DIFF
--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/serializer/SerializerTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/serializer/SerializerTest.kt
@@ -73,12 +73,13 @@ class SerializerTest {
     }
 
     @Test
-    fun both_values_are_emitted_WHEN_second_value_sent_from_callback() {
-        lateinit var serializer: Serializer<Int>
+    fun all_values_are_emitted_WHEN_some_are_sent_from_callback() {
+        lateinit var serializer: Serializer<Int?>
         serializer =
             serializer {
                 values += it
                 if (it == 1) {
+                    serializer.accept(null)
                     serializer.accept(2)
                 }
                 true
@@ -86,7 +87,7 @@ class SerializerTest {
 
         serializer.accept(1)
 
-        assertValues(1, 2)
+        assertValues(1, null, 2)
     }
 
     @Test

--- a/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/scheduler/BufferedExecutor.kt
+++ b/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/scheduler/BufferedExecutor.kt
@@ -2,8 +2,7 @@ package com.badoo.reaktive.scheduler
 
 import com.badoo.reaktive.utils.queue.ArrayQueue
 import com.badoo.reaktive.utils.queue.Queue
-import com.badoo.reaktive.utils.queue.isNotEmpty
-import com.badoo.reaktive.utils.queue.take
+import com.badoo.reaktive.utils.queue.isEmpty
 
 internal actual class BufferedExecutor<in T> actual constructor(
     private val executor: Scheduler.Executor,
@@ -28,12 +27,13 @@ internal actual class BufferedExecutor<in T> actual constructor(
     private fun drain() {
         while (!executor.isDisposed) {
             synchronized(monitor) {
-                if (queue.isNotEmpty) {
-                    queue.take()
-                } else {
+                if (queue.isEmpty) {
                     isDraining = false
                     return
                 }
+
+                @Suppress("UNCHECKED_CAST")
+                queue.poll() as T
             }
                 .also(onNext)
         }

--- a/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/scheduler/BufferedExecutor.kt
+++ b/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/scheduler/BufferedExecutor.kt
@@ -1,24 +1,22 @@
 package com.badoo.reaktive.scheduler
 
-import com.badoo.reaktive.utils.Lock
 import com.badoo.reaktive.utils.queue.ArrayQueue
 import com.badoo.reaktive.utils.queue.Queue
 import com.badoo.reaktive.utils.queue.isNotEmpty
 import com.badoo.reaktive.utils.queue.take
-import com.badoo.reaktive.utils.synchronized
 
 internal actual class BufferedExecutor<in T> actual constructor(
     private val executor: Scheduler.Executor,
     private val onNext: (T) -> Unit
 ) {
 
-    private val lock = Lock()
+    private val monitor = Any()
     private val queue: Queue<T> = ArrayQueue()
     private var isDraining = false
     private val drainFunction = ::drain
 
     actual fun submit(value: T) {
-        lock.synchronized {
+        synchronized(monitor) {
             queue.offer(value)
             if (!isDraining) {
                 isDraining = true
@@ -29,15 +27,14 @@ internal actual class BufferedExecutor<in T> actual constructor(
 
     private fun drain() {
         while (!executor.isDisposed) {
-            lock
-                .synchronized {
-                    if (queue.isNotEmpty) {
-                        queue.take()
-                    } else {
-                        isDraining = false
-                        return
-                    }
+            synchronized(monitor) {
+                if (queue.isNotEmpty) {
+                    queue.take()
+                } else {
+                    isDraining = false
+                    return
                 }
+            }
                 .also(onNext)
         }
     }

--- a/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/utils/queue/QueueExt.kt
+++ b/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/utils/queue/QueueExt.kt
@@ -3,11 +3,3 @@ package com.badoo.reaktive.utils.queue
 internal val Queue<*>.isEmpty: Boolean get() = size == 0
 
 internal val Queue<*>.isNotEmpty: Boolean get() = size > 0
-
-internal fun <T> Queue<T>.take(): T =
-    if (isEmpty) {
-        throw NoSuchElementException("Queue is empty")
-    } else {
-        @Suppress("UNCHECKED_CAST")
-        poll() as T
-    }

--- a/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/utils/serializer/SerializerImpl.kt
+++ b/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/utils/serializer/SerializerImpl.kt
@@ -10,24 +10,24 @@ internal abstract class SerializerImpl<in T>(queue: Queue<T>) : Serializer<T> {
     private var isDraining = false
 
     override fun accept(value: T) {
-        val q =
+        val queueToDrain =
             synchronized(monitor) {
-                val q = queue ?: return
+                val queue = queue ?: return
 
                 if (isDraining) {
-                    q.offer(value)
+                    queue.offer(value)
                     return
                 }
 
                 isDraining = true
-                q
+                queue
             }
 
         if (!processValue(value)) {
             return
         }
 
-        q.drain()
+        queueToDrain.drain()
     }
 
     override fun clear() {

--- a/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/utils/serializer/SerializerImpl.kt
+++ b/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/utils/serializer/SerializerImpl.kt
@@ -45,7 +45,8 @@ internal abstract class SerializerImpl<in T>(queue: Queue<T>) : Serializer<T> {
                         return
                     }
 
-                    poll()!!
+                    @Suppress("UNCHECKED_CAST")
+                    poll() as T
                 }
 
             if (!processValue(value)) {


### PR DESCRIPTION
This PR addresses performance of `Serializer` and `BufferedExecutor` in JVM. As per JMH [benchmarks](https://github.com/ShikaSD/multiK/tree/master/bench/src) some operators are slower than RxJava2 (e.g. `flatMap`). This PR improves performance of `Serializer` and `BufferedExecutor` in JVM, so e.g. `flatMap` is now around ~3x faster.