### PR TITLE
Introduce SharedList

### DIFF
--- a/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/base/TestSource.kt
+++ b/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/base/TestSource.kt
@@ -4,18 +4,17 @@ import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.base.Source
 import com.badoo.reaktive.disposable.disposable
-import com.badoo.reaktive.utils.atomic.AtomicList
-import com.badoo.reaktive.utils.atomic.minusAssign
-import com.badoo.reaktive.utils.atomic.plusAssign
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.update
 
 open class TestSource<O> : Source<O>, ErrorCallback where O : Observer, O : ErrorCallback {
 
-    private val _observers: AtomicList<O> = AtomicList(emptyList())
+    private val _observers = AtomicReference<List<O>>(emptyList())
     val observers get() = _observers.value
 
     override fun subscribe(observer: O) {
-        _observers += observer
-        observer.onSubscribe(disposable { _observers -= observer })
+        _observers.update { it + observer }
+        observer.onSubscribe(disposable { _observers.update { it - observer } })
     }
 
     override fun onError(error: Throwable) {

--- a/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/observable/TestObservableObserver.kt
+++ b/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/observable/TestObservableObserver.kt
@@ -3,13 +3,12 @@ package com.badoo.reaktive.test.observable
 import com.badoo.reaktive.observable.ObservableObserver
 import com.badoo.reaktive.test.base.TestObserver
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.clear
-import com.badoo.reaktive.utils.atomic.plusAssign
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.update
 
 class TestObservableObserver<T> : TestObserver(), ObservableObserver<T> {
 
-    private val _values = atomicList<T>()
+    private val _values = AtomicReference<List<T>>(emptyList())
     val values: List<T> get() = _values.value
     private val _isComplete = AtomicBoolean()
     val isComplete: Boolean get() = _isComplete.value
@@ -17,7 +16,7 @@ class TestObservableObserver<T> : TestObserver(), ObservableObserver<T> {
     override fun onNext(value: T) {
         checkActive()
 
-        _values += value
+        _values.update { it + value }
     }
 
     override fun onComplete() {
@@ -29,7 +28,7 @@ class TestObservableObserver<T> : TestObserver(), ObservableObserver<T> {
     override fun reset() {
         super.reset()
 
-        _values.clear()
+        _values.update { emptyList() }
         _isComplete.value = false
     }
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/SharedList.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/SharedList.kt
@@ -1,0 +1,3 @@
+package com.badoo.reaktive.utils
+
+internal expect class SharedList<T>(initialCapacity: Int = 8) : MutableList<T>

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/SharedListExt.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/SharedListExt.kt
@@ -1,0 +1,6 @@
+package com.badoo.reaktive.utils
+
+internal inline fun <T> SharedList(size: Int, init: (Int) -> T): SharedList<T> =
+    SharedList<T>(size).apply {
+        repeat(size) { add(init(it)) }
+    }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicList.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicList.kt
@@ -3,28 +3,28 @@ package com.badoo.reaktive.utils.atomic
 import com.badoo.reaktive.utils.insert
 import com.badoo.reaktive.utils.replace
 
-typealias AtomicList<T> = AtomicReference<List<T>>
+internal typealias AtomicList<T> = AtomicReference<List<T>>
 
-fun <T> atomicList(initialList: List<T> = emptyList()): AtomicList<T> = AtomicList(initialList)
+internal fun <T> atomicList(initialList: List<T> = emptyList()): AtomicList<T> = AtomicList(initialList)
 
-fun <T> AtomicList<T>.add(element: T) {
+internal fun <T> AtomicList<T>.add(element: T) {
     update { it + element }
 }
 
-operator fun <T> AtomicList<T>.plusAssign(element: T) {
+internal operator fun <T> AtomicList<T>.plusAssign(element: T) {
     add(element)
 }
 
-fun <T> AtomicList<T>.add(index: Int, element: T) {
+internal fun <T> AtomicList<T>.add(index: Int, element: T) {
     update { it.insert(index, element) }
 }
 
-fun <T> AtomicList<T>.removeAt(index: Int): T =
+internal fun <T> AtomicList<T>.removeAt(index: Int): T =
     getAndUpdate {
         it.filterIndexed { i, _ -> i != index }
     }[index]
 
-fun <T> AtomicList<T>.remove(element: T): Boolean {
+internal fun <T> AtomicList<T>.remove(element: T): Boolean {
     var removed = false
 
     update {
@@ -36,25 +36,27 @@ fun <T> AtomicList<T>.remove(element: T): Boolean {
     return removed
 }
 
-operator fun <T> AtomicList<T>.minusAssign(element: T) {
+internal operator fun <T> AtomicList<T>.minusAssign(element: T) {
     remove(element)
 }
 
-fun <T> AtomicList<T>.clear() {
+internal fun <T> AtomicList<T>.clear() {
     update { emptyList() }
 }
 
-operator fun <T> AtomicList<T>.get(index: Int): T = value[index]
+internal operator fun <T> AtomicList<T>.get(index: Int): T = value[index]
 
-operator fun <T> AtomicList<T>.set(index: Int, element: T): T =
+internal operator fun <T> AtomicList<T>.set(index: Int, element: T): T =
     getAndUpdate {
         it.replace(index, element)
     }[index]
 
-fun <T> AtomicList<T>.firstOrNull(): T? = value.firstOrNull()
+internal fun <T> AtomicList<T>.firstOrNull(): T? = value.firstOrNull()
 
-val AtomicReference<out Collection<*>>.isEmpty: Boolean get() = value.isEmpty()
+internal val AtomicReference<out Collection<*>>.size: Int get() = value.size
 
-val AtomicReference<out Collection<*>>.isNotEmpty: Boolean get() = value.isNotEmpty()
+internal val AtomicReference<out Collection<*>>.isEmpty: Boolean get() = value.isEmpty()
 
-operator fun <T> AtomicReference<out Iterable<T>>.iterator(): Iterator<T> = value.iterator()
+internal val AtomicReference<out Collection<*>>.isNotEmpty: Boolean get() = value.isNotEmpty()
+
+internal operator fun <T> AtomicReference<out Iterable<T>>.iterator(): Iterator<T> = value.iterator()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeCompleteTest.kt
@@ -5,8 +5,7 @@ import com.badoo.reaktive.test.completable.DefaultCompletableObserver
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
+import com.badoo.reaktive.utils.SharedList
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -18,7 +17,7 @@ class DoOnBeforeCompleteTest
 
     @Test
     fun calls_action_before_completion() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         upstream
             .doOnBeforeComplete {
@@ -34,7 +33,7 @@ class DoOnBeforeCompleteTest
 
         upstream.onComplete()
 
-        assertEquals(listOf("action", "onComplete"), callOrder.value)
+        assertEquals(listOf("action", "onComplete"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeDisposeTest.kt
@@ -6,8 +6,7 @@ import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
+import com.badoo.reaktive.utils.SharedList
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -19,7 +18,7 @@ class DoOnBeforeDisposeTest
 
     @Test
     fun calls_action_before_disposing_upstream() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         completableUnsafe { observer ->
             observer.onSubscribe(
@@ -34,7 +33,7 @@ class DoOnBeforeDisposeTest
             .test()
             .dispose()
 
-        assertEquals(listOf("action", "dispose"), callOrder.value)
+        assertEquals(listOf("action", "dispose"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeErrorTest.kt
@@ -5,8 +5,7 @@ import com.badoo.reaktive.test.completable.DefaultCompletableObserver
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
+import com.badoo.reaktive.utils.SharedList
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -20,8 +19,8 @@ class DoOnBeforeErrorTest
 
     @Test
     fun calls_action_before_failing() {
-        val callOrder = atomicList<Pair<String, Throwable>>()
-        val exception = Exception()
+        val callOrder = SharedList<Pair<String, Throwable>>()
+        val exception = Throwable()
 
         upstream
             .doOnBeforeError { error ->
@@ -37,7 +36,7 @@ class DoOnBeforeErrorTest
 
         upstream.onError(exception)
 
-        assertEquals(listOf("action" to exception, "onError" to exception), callOrder.value)
+        assertEquals(listOf("action" to exception, "onError" to exception), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeFinallyTest.kt
@@ -7,9 +7,8 @@ import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.completable.DefaultCompletableObserver
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicInt
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
@@ -22,7 +21,7 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun calls_action_before_completion() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         upstream
             .doOnBeforeFinally {
@@ -38,12 +37,12 @@ class DoOnBeforeFinallyTest
 
         upstream.onComplete()
 
-        assertEquals(listOf("action", "onComplete"), callOrder.value)
+        assertEquals(listOf("action", "onComplete"), callOrder)
     }
 
     @Test
     fun calls_action_before_failing() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
         val exception = Exception()
 
         upstream
@@ -60,12 +59,12 @@ class DoOnBeforeFinallyTest
 
         upstream.onError(exception)
 
-        assertEquals(listOf("action", "onError"), callOrder.value)
+        assertEquals(listOf("action", "onError"), callOrder)
     }
 
     @Test
     fun calls_action_before_disposing_upstream() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         completableUnsafe { observer ->
             observer.onSubscribe(
@@ -80,7 +79,7 @@ class DoOnBeforeFinallyTest
             .test()
             .dispose()
 
-        assertEquals(listOf("action", "dispose"), callOrder.value)
+        assertEquals(listOf("action", "dispose"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeSubscribeTest.kt
@@ -5,9 +5,8 @@ import com.badoo.reaktive.disposable.disposable
 import com.badoo.reaktive.test.completable.DefaultCompletableObserver
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -17,7 +16,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun calls_action_before_downstream_onSubscribe_WHEN_action_does_not_throw_exception() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         completableUnsafe {}
             .doOnBeforeSubscribe {
@@ -31,12 +30,12 @@ class DoOnBeforeSubscribeTest
                 }
             )
 
-        assertEquals(listOf("action", "onSubscribe"), callOrder.value)
+        assertEquals(listOf("action", "onSubscribe"), callOrder)
     }
 
     @Test
     fun delegates_error_to_downstream_after_downstream_onSubscribe_WHEN_action_throws_exception() {
-        val callOrder = atomicList<Any>()
+        val callOrder = SharedList<Any>()
         val exception = Exception()
 
         completableUnsafe {}
@@ -55,7 +54,7 @@ class DoOnBeforeSubscribeTest
                 }
             )
 
-        assertEquals(listOf("onSubscribe", exception), callOrder.value)
+        assertEquals(listOf<Any>("onSubscribe", exception), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeTerminateTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeTerminateTest.kt
@@ -5,8 +5,7 @@ import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.completable.DefaultCompletableObserver
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.test
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
+import com.badoo.reaktive.utils.SharedList
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
@@ -16,7 +15,7 @@ class DoOnBeforeTerminateTest
     : CompletableToCompletableTests by CompletableToCompletableTests({ doOnBeforeTerminate {} }) {
 
     private val upstream = TestCompletable()
-    private val callOrder = atomicList<String>()
+    private val callOrder = SharedList<String>()
 
     @Test
     fun calls_action_before_completion() {
@@ -35,12 +34,12 @@ class DoOnBeforeTerminateTest
 
         upstream.onComplete()
 
-        assertEquals(listOf("action", "onComplete"), callOrder.value)
+        assertEquals(listOf("action", "onComplete"), callOrder)
     }
 
     @Test
     fun calls_action_before_failing() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
         val exception = Exception()
 
         upstream
@@ -57,7 +56,7 @@ class DoOnBeforeTerminateTest
 
         upstream.onError(exception)
 
-        assertEquals(listOf("action", "onError"), callOrder.value)
+        assertEquals(listOf("action", "onError"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeCompleteTest.kt
@@ -4,9 +4,8 @@ import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -18,7 +17,7 @@ class DoOnBeforeCompleteTest
 
     @Test
     fun calls_action_before_completion() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         upstream
             .doOnBeforeComplete {
@@ -34,7 +33,7 @@ class DoOnBeforeCompleteTest
 
         upstream.onComplete()
 
-        assertEquals(listOf("action", "onComplete"), callOrder.value)
+        assertEquals(listOf("action", "onComplete"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeDisposeTest.kt
@@ -5,9 +5,8 @@ import com.badoo.reaktive.test.base.assertDisposed
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -19,7 +18,7 @@ class DoOnBeforeDisposeTest
 
     @Test
     fun calls_action_before_disposing_upstream() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         maybeUnsafe<Nothing> { observer ->
             observer.onSubscribe(
@@ -34,7 +33,7 @@ class DoOnBeforeDisposeTest
             .test()
             .dispose()
 
-        assertEquals(listOf("action", "dispose"), callOrder.value)
+        assertEquals(listOf("action", "dispose"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeErrorTest.kt
@@ -4,9 +4,8 @@ import com.badoo.reaktive.base.exceptions.CompositeException
 import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -20,8 +19,8 @@ class DoOnBeforeErrorTest
 
     @Test
     fun calls_action_before_failing() {
-        val callOrder = atomicList<Pair<String, Throwable>>()
-        val exception = Exception()
+        val callOrder = SharedList<Pair<String, Throwable>>()
+        val exception = Throwable()
 
         upstream
             .doOnBeforeError { error ->
@@ -37,7 +36,7 @@ class DoOnBeforeErrorTest
 
         upstream.onError(exception)
 
-        assertEquals(listOf("action" to exception, "onError" to exception), callOrder.value)
+        assertEquals(listOf("action" to exception, "onError" to exception), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeFinallyTest.kt
@@ -7,9 +7,8 @@ import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicInt
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
@@ -22,7 +21,7 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun calls_action_before_completion() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         upstream
             .doOnBeforeFinally {
@@ -38,12 +37,12 @@ class DoOnBeforeFinallyTest
 
         upstream.onComplete()
 
-        assertEquals(listOf("action", "onComplete"), callOrder.value)
+        assertEquals(listOf("action", "onComplete"), callOrder)
     }
 
     @Test
     fun calls_action_before_success() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         upstream
             .doOnBeforeFinally {
@@ -59,12 +58,12 @@ class DoOnBeforeFinallyTest
 
         upstream.onSuccess(0)
 
-        assertEquals(listOf("action", "onSuccess"), callOrder.value)
+        assertEquals(listOf("action", "onSuccess"), callOrder)
     }
 
     @Test
     fun calls_action_before_failing() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
         val exception = Exception()
 
         upstream
@@ -81,12 +80,12 @@ class DoOnBeforeFinallyTest
 
         upstream.onError(exception)
 
-        assertEquals(listOf("action", "onError"), callOrder.value)
+        assertEquals(listOf("action", "onError"), callOrder)
     }
 
     @Test
     fun calls_action_before_disposing_upstream() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         maybeUnsafe<Unit> { observer ->
             observer.onSubscribe(
@@ -101,7 +100,7 @@ class DoOnBeforeFinallyTest
             .test()
             .dispose()
 
-        assertEquals(listOf("action", "dispose"), callOrder.value)
+        assertEquals(listOf("action", "dispose"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSubscribeTest.kt
@@ -5,9 +5,8 @@ import com.badoo.reaktive.disposable.disposable
 import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -17,7 +16,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun calls_action_before_downstream_onSubscribe_WHEN_action_does_not_throw_exception() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         maybeUnsafe<Nothing> {}
             .doOnBeforeSubscribe {
@@ -31,12 +30,12 @@ class DoOnBeforeSubscribeTest
                 }
             )
 
-        assertEquals(listOf("action", "onSubscribe"), callOrder.value)
+        assertEquals(listOf("action", "onSubscribe"), callOrder)
     }
 
     @Test
     fun delegates_error_to_downstream_after_downstream_onSubscribe_WHEN_action_throws_exception() {
-        val callOrder = atomicList<Any>()
+        val callOrder = SharedList<Any>()
         val exception = Exception()
 
         maybeUnsafe<Nothing> {}
@@ -55,7 +54,7 @@ class DoOnBeforeSubscribeTest
                 }
             )
 
-        assertEquals(listOf("onSubscribe", exception), callOrder.value)
+        assertEquals(listOf<Any>("onSubscribe", exception), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSuccessTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSuccessTest.kt
@@ -4,9 +4,8 @@ import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -18,7 +17,7 @@ class DoOnBeforeSuccessTest
 
     @Test
     fun calls_action_before_emitting() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         upstream
             .doOnBeforeSuccess { value ->
@@ -34,7 +33,7 @@ class DoOnBeforeSuccessTest
 
         upstream.onSuccess(0)
 
-        assertEquals(listOf("action 0", "onNext 0"), callOrder.value)
+        assertEquals(listOf("action 0", "onNext 0"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeTerminateTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeTerminateTest.kt
@@ -5,8 +5,7 @@ import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.maybe.DefaultMaybeObserver
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.test
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
+import com.badoo.reaktive.utils.SharedList
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
@@ -16,7 +15,7 @@ class DoOnBeforeTerminateTest
     : MaybeToMaybeTests by MaybeToMaybeTests<Unit>({ doOnBeforeTerminate {} }) {
 
     private val upstream = TestMaybe<Int>()
-    private val callOrder = atomicList<String>()
+    private val callOrder = SharedList<String>()
 
     @Test
     fun calls_action_before_completion() {
@@ -35,12 +34,12 @@ class DoOnBeforeTerminateTest
 
         upstream.onComplete()
 
-        assertEquals(listOf("action", "onComplete"), callOrder.value)
+        assertEquals(listOf("action", "onComplete"), callOrder)
     }
 
     @Test
     fun calls_action_before_success() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         upstream
             .doOnBeforeTerminate {
@@ -56,12 +55,12 @@ class DoOnBeforeTerminateTest
 
         upstream.onSuccess(0)
 
-        assertEquals(listOf("action", "onSuccess"), callOrder.value)
+        assertEquals(listOf("action", "onSuccess"), callOrder)
     }
 
     @Test
     fun calls_action_before_failing() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
         val exception = Exception()
 
         upstream
@@ -78,7 +77,7 @@ class DoOnBeforeTerminateTest
 
         upstream.onError(exception)
 
-        assertEquals(listOf("action", "onError"), callOrder.value)
+        assertEquals(listOf("action", "onError"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeCompleteTest.kt
@@ -4,9 +4,8 @@ import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.observable.DefaultObservableObserver
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -18,7 +17,7 @@ class DoOnBeforeCompleteTest
 
     @Test
     fun calls_action_before_completion() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         upstream
             .doOnBeforeComplete {
@@ -34,7 +33,7 @@ class DoOnBeforeCompleteTest
 
         upstream.onComplete()
 
-        assertEquals(listOf("action", "onComplete"), callOrder.value)
+        assertEquals(listOf("action", "onComplete"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeDisposeTest.kt
@@ -5,9 +5,8 @@ import com.badoo.reaktive.test.base.assertDisposed
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -19,7 +18,7 @@ class DoOnBeforeDisposeTest
 
     @Test
     fun calls_action_before_disposing_upstream() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         observableUnsafe<Nothing> { observer ->
             observer.onSubscribe(
@@ -34,7 +33,7 @@ class DoOnBeforeDisposeTest
             .test()
             .dispose()
 
-        assertEquals(listOf("action", "dispose"), callOrder.value)
+        assertEquals(listOf("action", "dispose"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeErrorTest.kt
@@ -4,9 +4,8 @@ import com.badoo.reaktive.base.exceptions.CompositeException
 import com.badoo.reaktive.test.observable.DefaultObservableObserver
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -20,8 +19,8 @@ class DoOnBeforeErrorTest
 
     @Test
     fun calls_action_before_failing() {
-        val callOrder = atomicList<Pair<String, Throwable>>()
-        val exception = Exception()
+        val callOrder = SharedList<Pair<String, Throwable>>()
+        val exception = Throwable()
 
         upstream
             .doOnBeforeError { error ->
@@ -37,7 +36,7 @@ class DoOnBeforeErrorTest
 
         upstream.onError(exception)
 
-        assertEquals(listOf("action" to exception, "onError" to exception), callOrder.value)
+        assertEquals(listOf("action" to exception, "onError" to exception), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeFinallyTest.kt
@@ -7,10 +7,9 @@ import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.observable.DefaultObservableObserver
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import com.badoo.reaktive.utils.atomic.AtomicInt
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -24,7 +23,7 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun calls_action_before_completion() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         upstream
             .doOnBeforeFinally {
@@ -40,12 +39,12 @@ class DoOnBeforeFinallyTest
 
         upstream.onComplete()
 
-        assertEquals(listOf("action", "onComplete"), callOrder.value)
+        assertEquals(listOf("action", "onComplete"), callOrder)
     }
 
     @Test
     fun calls_action_before_failing() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
         val exception = Exception()
 
         upstream
@@ -62,12 +61,12 @@ class DoOnBeforeFinallyTest
 
         upstream.onError(exception)
 
-        assertEquals(listOf("action", "onError"), callOrder.value)
+        assertEquals(listOf("action", "onError"), callOrder)
     }
 
     @Test
     fun calls_action_before_disposing_upstream() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         observableUnsafe<Unit> { observer ->
             observer.onSubscribe(
@@ -82,7 +81,7 @@ class DoOnBeforeFinallyTest
             .test()
             .dispose()
 
-        assertEquals(listOf("action", "dispose"), callOrder.value)
+        assertEquals(listOf("action", "dispose"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeNextTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeNextTest.kt
@@ -4,10 +4,9 @@ import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.observable.DefaultObservableObserver
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import com.badoo.reaktive.utils.atomic.AtomicInt
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -19,7 +18,7 @@ class DoOnBeforeNextTest
 
     @Test
     fun calls_action_before_emitting() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         upstream
             .doOnBeforeNext { value ->
@@ -36,7 +35,7 @@ class DoOnBeforeNextTest
         upstream.onNext(0)
         upstream.onNext(1)
 
-        assertEquals(listOf("action 0", "onNext 0", "action 1", "onNext 1"), callOrder.value)
+        assertEquals(listOf("action 0", "onNext 0", "action 1", "onNext 1"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeSubscribeTest.kt
@@ -5,9 +5,8 @@ import com.badoo.reaktive.disposable.disposable
 import com.badoo.reaktive.test.observable.DefaultObservableObserver
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -17,7 +16,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun calls_action_before_downstream_onSubscribe_WHEN_action_does_not_throw_exception() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         observableUnsafe<Nothing> {}
             .doOnBeforeSubscribe {
@@ -31,12 +30,12 @@ class DoOnBeforeSubscribeTest
                 }
             )
 
-        assertEquals(listOf("action", "onSubscribe"), callOrder.value)
+        assertEquals(listOf("action", "onSubscribe"), callOrder)
     }
 
     @Test
     fun delegates_error_to_downstream_after_downstream_onSubscribe_WHEN_action_throws_exception() {
-        val callOrder = atomicList<Any>()
+        val callOrder = SharedList<Any>()
         val exception = Exception()
 
         observableUnsafe<Nothing> {}
@@ -55,7 +54,7 @@ class DoOnBeforeSubscribeTest
                 }
             )
 
-        assertEquals(listOf("onSubscribe", exception), callOrder.value)
+        assertEquals(listOf<Any>("onSubscribe", exception), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeTerminateTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeTerminateTest.kt
@@ -5,9 +5,8 @@ import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.observable.DefaultObservableObserver
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -18,7 +17,7 @@ class DoOnBeforeTerminateTest
     : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeTerminate {} }) {
 
     private val upstream = TestObservable<Int>()
-    private val callOrder = atomicList<String>()
+    private val callOrder = SharedList<String>()
 
     @Test
     fun calls_action_before_completion() {
@@ -36,12 +35,12 @@ class DoOnBeforeTerminateTest
 
         upstream.onComplete()
 
-        assertEquals(listOf("action", "onComplete"), callOrder.value)
+        assertEquals(listOf("action", "onComplete"), callOrder)
     }
 
     @Test
     fun calls_action_before_failing() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
         val exception = Exception()
 
         upstream
@@ -58,7 +57,7 @@ class DoOnBeforeTerminateTest
 
         upstream.onError(exception)
 
-        assertEquals(listOf("action", "onError"), callOrder.value)
+        assertEquals(listOf("action", "onError"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeDisposeTest.kt
@@ -5,9 +5,8 @@ import com.badoo.reaktive.test.base.assertDisposed
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.test.single.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -19,7 +18,7 @@ class DoOnBeforeDisposeTest
 
     @Test
     fun calls_action_before_disposing_upstream() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         singleUnsafe<Nothing> { observer ->
             observer.onSubscribe(
@@ -34,7 +33,7 @@ class DoOnBeforeDisposeTest
             .test()
             .dispose()
 
-        assertEquals(listOf("action", "dispose"), callOrder.value)
+        assertEquals(listOf("action", "dispose"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeErrorTest.kt
@@ -4,9 +4,8 @@ import com.badoo.reaktive.base.exceptions.CompositeException
 import com.badoo.reaktive.test.single.DefaultSingleObserver
 import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.test.single.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -20,8 +19,8 @@ class DoOnBeforeErrorTest
 
     @Test
     fun calls_action_before_failing() {
-        val callOrder = atomicList<Pair<String, Throwable>>()
-        val exception = Exception()
+        val callOrder = SharedList<Pair<String, Throwable>>()
+        val exception = Throwable()
 
         upstream
             .doOnBeforeError { error ->
@@ -37,7 +36,7 @@ class DoOnBeforeErrorTest
 
         upstream.onError(exception)
 
-        assertEquals(listOf("action" to exception, "onError" to exception), callOrder.value)
+        assertEquals(listOf("action" to exception, "onError" to exception), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeFinallyTest.kt
@@ -7,9 +7,8 @@ import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.single.DefaultSingleObserver
 import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.test.single.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicInt
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
@@ -22,7 +21,7 @@ class DoOnBeforeFinallyTest
 
     @Test
     fun calls_action_before_success() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         upstream
             .doOnBeforeFinally {
@@ -38,12 +37,12 @@ class DoOnBeforeFinallyTest
 
         upstream.onSuccess(0)
 
-        assertEquals(listOf("action", "onSuccess"), callOrder.value)
+        assertEquals(listOf("action", "onSuccess"), callOrder)
     }
 
     @Test
     fun calls_action_before_failing() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
         val exception = Exception()
 
         upstream
@@ -60,12 +59,12 @@ class DoOnBeforeFinallyTest
 
         upstream.onError(exception)
 
-        assertEquals(listOf("action", "onError"), callOrder.value)
+        assertEquals(listOf("action", "onError"), callOrder)
     }
 
     @Test
     fun calls_action_before_disposing_upstream() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         singleUnsafe<Unit> { observer ->
             observer.onSubscribe(
@@ -80,7 +79,7 @@ class DoOnBeforeFinallyTest
             .test()
             .dispose()
 
-        assertEquals(listOf("action", "dispose"), callOrder.value)
+        assertEquals(listOf("action", "dispose"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSubscribeTest.kt
@@ -5,9 +5,8 @@ import com.badoo.reaktive.disposable.disposable
 import com.badoo.reaktive.test.single.DefaultSingleObserver
 import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.test.single.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -17,7 +16,7 @@ class DoOnBeforeSubscribeTest
 
     @Test
     fun calls_action_before_downstream_onSubscribe_WHEN_action_does_not_throw_exception() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         singleUnsafe<Nothing> {}
             .doOnBeforeSubscribe {
@@ -31,12 +30,12 @@ class DoOnBeforeSubscribeTest
                 }
             )
 
-        assertEquals(listOf("action", "onSubscribe"), callOrder.value)
+        assertEquals(listOf("action", "onSubscribe"), callOrder)
     }
 
     @Test
     fun delegates_error_to_downstream_after_downstream_onSubscribe_WHEN_action_throws_exception() {
-        val callOrder = atomicList<Any>()
+        val callOrder = SharedList<Any>()
         val exception = Exception()
 
         singleUnsafe<Nothing> {}
@@ -55,7 +54,7 @@ class DoOnBeforeSubscribeTest
                 }
             )
 
-        assertEquals(listOf("onSubscribe", exception), callOrder.value)
+        assertEquals(listOf<Any>("onSubscribe", exception), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSuccessTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSuccessTest.kt
@@ -4,9 +4,8 @@ import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.single.DefaultSingleObserver
 import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.test.single.test
+import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -18,7 +17,7 @@ class DoOnBeforeSuccessTest
 
     @Test
     fun calls_action_before_emitting() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         upstream
             .doOnBeforeSuccess { value ->
@@ -34,7 +33,7 @@ class DoOnBeforeSuccessTest
 
         upstream.onSuccess(0)
 
-        assertEquals(listOf("action 0", "onNext 0"), callOrder.value)
+        assertEquals(listOf("action 0", "onNext 0"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeTerminateTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeTerminateTest.kt
@@ -5,8 +5,7 @@ import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.single.DefaultSingleObserver
 import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.test.single.test
-import com.badoo.reaktive.utils.atomic.atomicList
-import com.badoo.reaktive.utils.atomic.plusAssign
+import com.badoo.reaktive.utils.SharedList
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
@@ -19,7 +18,7 @@ class DoOnBeforeTerminateTest
 
     @Test
     fun calls_action_before_success() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
 
         upstream
             .doOnBeforeTerminate {
@@ -35,12 +34,12 @@ class DoOnBeforeTerminateTest
 
         upstream.onSuccess(0)
 
-        assertEquals(listOf("action", "onSuccess"), callOrder.value)
+        assertEquals(listOf("action", "onSuccess"), callOrder)
     }
 
     @Test
     fun calls_action_before_failing() {
-        val callOrder = atomicList<String>()
+        val callOrder = SharedList<String>()
         val exception = Exception()
 
         upstream
@@ -57,7 +56,7 @@ class DoOnBeforeTerminateTest
 
         upstream.onError(exception)
 
-        assertEquals(listOf("action", "onError"), callOrder.value)
+        assertEquals(listOf("action", "onError"), callOrder)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/SharedListIteratorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/SharedListIteratorTest.kt
@@ -1,0 +1,61 @@
+package com.badoo.reaktive.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SharedListIteratorTest {
+
+    @Test
+    fun listIterator() {
+        val lists: Pair<MutableList<Int?>, MutableList<Int?>> = Pair(SharedList(), ArrayList())
+        lists.first.addAll(listOf(0, null, 1, null, 2))
+        lists.second.addAll(listOf(0, null, 1, null, 2))
+        val iterators = Pair(lists.first.listIterator(), lists.second.listIterator())
+
+        iterators.verifyState()
+        iterators.actionAndVerify { next() }
+        iterators.actionAndVerify { next() }
+        iterators.actionAndVerify { next() }
+        iterators.actionAndVerify { next() }
+        iterators.actionAndVerify { next() }
+        iterators.actionAndVerify { previous() }
+        iterators.actionAndVerify { previous() }
+        iterators.actionAndVerify { previous() }
+        iterators.actionAndVerify { previous() }
+        iterators.actionAndVerify { next() }
+        iterators.actionAndVerify { next() }
+        iterators.actionAndVerify { add(3) }
+        iterators.actionAndVerify { next() }
+        iterators.actionAndVerify { add(4) }
+        iterators.actionAndVerify { previous() }
+        iterators.actionAndVerify { remove() }
+        iterators.actionAndVerify { previous() }
+        iterators.actionAndVerify { remove() }
+        iterators.actionAndVerify { next() }
+        iterators.actionAndVerify { previous() }
+        iterators.actionAndVerify { set(5) }
+        iterators.actionAndVerify { previous() }
+        iterators.actionAndVerify { next() }
+        iterators.actionAndVerify { next() }
+        iterators.actionAndVerify { previous() }
+        iterators.actionAndVerify { previous() }
+        iterators.actionAndVerify { remove() }
+        iterators.actionAndVerify { next() }
+        iterators.actionAndVerify { previous() }
+        assertEquals(lists.second.size, lists.first.size)
+    }
+
+    private inline fun <T : MutableListIterator<*>, R> Pair<T, T>.actionAndVerify(block: T.() -> R) {
+        val actual = first.block()
+        val expected = second.block()
+        assertEquals(expected, actual)
+        verifyState()
+    }
+
+    private fun Pair<MutableListIterator<*>, MutableListIterator<*>>.verifyState() {
+        assertEquals(second.hasNext(), first.hasNext())
+        assertEquals(second.hasPrevious(), first.hasPrevious())
+        assertEquals(second.nextIndex(), first.nextIndex())
+        assertEquals(second.previousIndex(), first.previousIndex())
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/SharedListTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/SharedListTest.kt
@@ -1,0 +1,173 @@
+package com.badoo.reaktive.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SharedListTest {
+
+    private val list: MutableList<Int?> = SharedList()
+
+    @Test
+    fun contains() {
+        add(0, null, 1, null, 2)
+
+        assertTrue(list.contains(null))
+        assertTrue(list.contains(1))
+        assertFalse(list.contains(3))
+    }
+
+    @Test
+    fun containsAll() {
+        add(0, null, 1, null, 2)
+
+        assertTrue(list.containsAll(listOf(null)))
+        assertTrue(list.containsAll(listOf(null, null)))
+        assertTrue(list.containsAll(listOf(null, null, null)))
+        assertTrue(list.containsAll(listOf(1)))
+        assertTrue(list.containsAll(listOf(1, 1)))
+        assertTrue(list.containsAll(listOf(null, 0, 2)))
+        assertFalse(list.containsAll(listOf(null, 0, 2, 3)))
+    }
+
+    @Test
+    fun get() {
+        add(0, null, 1, null, 2)
+
+        assertEquals(null, list[1])
+        assertEquals(1, list[2])
+        assertFailsWith<IndexOutOfBoundsException> { list[5] }
+        assertFailsWith<IndexOutOfBoundsException> { list[-1] }
+    }
+
+    @Test
+    fun indexOf() {
+        add(0, null, 1, 2)
+
+        assertEquals(1, list.indexOf(null))
+        assertEquals(2, list.indexOf(1))
+        assertEquals(-1, list.indexOf(3))
+    }
+
+    @Test
+    fun isEmpty() {
+        assertTrue(list.isEmpty())
+        list.add(0)
+        assertFalse(list.isEmpty())
+    }
+
+    @Test
+    fun lastIndexOf() {
+        add(0, null, 1)
+
+        assertEquals(2, list.lastIndexOf(1))
+        assertEquals(-1, list.lastIndexOf(2))
+    }
+
+    @Test
+    fun add() {
+        list.add(null)
+        list.add(0)
+        list.add(1)
+        list.add(2)
+        list.add(0, 3)
+        list.add(2, 4)
+        list.add(5, 5)
+        list.add(7, 6)
+
+        assertEquals(listOf<Int?>(3, null, 4, 0, 1, 5, 2, 6), list)
+    }
+
+    @Test
+    fun addAll() {
+        val collection = List(5) { it }
+        list.addAll(collection)
+        list.addAll(0, collection)
+        list.addAll(7, collection)
+        list.addAll(15, collection)
+
+        assertEquals(listOf<Int?>(0, 1, 2, 3, 4, 0, 1, 0, 1, 2, 3, 4, 2, 3, 4, 0, 1, 2, 3, 4), list)
+    }
+
+    @Test
+    fun clear() {
+        add(0, null, 1)
+
+        list.clear()
+
+        assertEquals(0, list.size)
+        assertFalse(list.contains(0))
+        assertFalse(list.contains(null))
+        assertFalse(list.contains(1))
+    }
+
+    @Test
+    fun remove() {
+        add(0, null, 1)
+
+        list.remove(null)
+        assertEquals(2, list.size)
+        assertFalse(list.contains(null))
+        list.remove(0)
+        assertEquals(1, list.size)
+        assertFalse(list.contains(0))
+        assertTrue(list.contains(1))
+    }
+
+    @Test
+    fun removeAll() {
+        add(0, null, 1, null, 1, 2)
+
+        list.removeAll(listOf(null, 1))
+
+        assertEquals(2, list.size)
+        assertFalse(list.contains(null))
+        assertFalse(list.contains(1))
+        assertTrue(list.contains(0))
+        assertTrue(list.contains(2))
+    }
+
+    @Test
+    fun removeAt() {
+        add(0, null, 1)
+
+        list.removeAt(1)
+        list.removeAt(1)
+
+        assertFalse(list.contains(null))
+        assertFalse(list.contains(1))
+        assertTrue(list.contains(0))
+    }
+
+    @Test
+    fun retainAll() {
+        add(0, null, 1, null, 2)
+
+        list.retainAll(listOf(null, 1))
+
+        assertEquals(3, list.size)
+        assertFalse(list.contains(0))
+        assertTrue(list.contains(null))
+        assertTrue(list.contains(1))
+        assertFalse(list.contains(2))
+    }
+
+    @Test
+    fun set() {
+        add(0, null, 1)
+
+        list[0] = 3
+        list[1] = 4
+
+        assertEquals(3, list.size)
+        assertEquals(3, list[0])
+        assertEquals(4, list[1])
+        assertEquals(1, list[2])
+    }
+
+    private fun add(vararg items: Int?) {
+        list.addAll(items)
+    }
+}

--- a/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/SharedList.kt
+++ b/reaktive/src/jsMain/kotlin/com/badoo/reaktive/utils/SharedList.kt
@@ -1,0 +1,3 @@
+package com.badoo.reaktive.utils
+
+internal actual class SharedList<T> actual constructor(initialCapacity: Int) : ArrayList<T>(initialCapacity), MutableList<T>

--- a/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/SharedList.kt
+++ b/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/SharedList.kt
@@ -1,0 +1,3 @@
+package com.badoo.reaktive.utils
+
+internal actual class SharedList<T> actual constructor(initialCapacity: Int) : java.util.ArrayList<T>(initialCapacity), MutableList<T>

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/SharedList.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/SharedList.kt
@@ -1,0 +1,164 @@
+package com.badoo.reaktive.utils
+
+import com.badoo.reaktive.utils.atomic.AtomicList
+import com.badoo.reaktive.utils.atomic.add
+import com.badoo.reaktive.utils.atomic.clear
+import com.badoo.reaktive.utils.atomic.get
+import com.badoo.reaktive.utils.atomic.isEmpty
+import com.badoo.reaktive.utils.atomic.plusAssign
+import com.badoo.reaktive.utils.atomic.remove
+import com.badoo.reaktive.utils.atomic.removeAt
+import com.badoo.reaktive.utils.atomic.set
+import com.badoo.reaktive.utils.atomic.size
+
+internal actual class SharedList<T> actual constructor(initialCapacity: Int) : MutableList<T> {
+
+    private val delegate = AtomicList<T>(emptyList())
+
+    override val size: Int get() = delegate.size
+
+    override fun contains(element: T): Boolean = delegate.value.contains(element)
+
+    override fun containsAll(elements: Collection<T>): Boolean = delegate.value.containsAll(elements)
+
+    override fun get(index: Int): T = delegate[index]
+
+    override fun indexOf(element: T): Int = delegate.value.indexOf(element)
+
+    override fun isEmpty(): Boolean = delegate.isEmpty
+
+    override fun iterator(): MutableIterator<T> = MutableListIteratorImpl(this, 0)
+
+    override fun lastIndexOf(element: T): Int = delegate.value.lastIndexOf(element)
+
+    override fun add(element: T): Boolean {
+        delegate += element
+
+        return true
+    }
+
+    override fun add(index: Int, element: T) {
+        delegate.add(index, element)
+    }
+
+    override fun addAll(index: Int, elements: Collection<T>): Boolean {
+        if (elements.isEmpty()) {
+            return false
+        }
+
+        val oldList = delegate.value
+        val newList = ArrayList<T>(oldList.size + elements.size)
+
+        for (i in 0 until index) {
+            newList.add(oldList[i])
+        }
+
+        newList.addAll(elements)
+
+        for (i in index until oldList.size) {
+            newList.add(oldList[i])
+        }
+
+        delegate.value = newList
+
+        return true
+    }
+
+    override fun addAll(elements: Collection<T>): Boolean {
+        if (elements.isEmpty()) {
+            return false
+        }
+
+        delegate.value = delegate.value + elements
+
+        return true
+    }
+
+    override fun clear() {
+        delegate.clear()
+    }
+
+    override fun listIterator(): MutableListIterator<T> = MutableListIteratorImpl(this, 0)
+
+    override fun listIterator(index: Int): MutableListIterator<T> = MutableListIteratorImpl(this, index)
+
+    override fun remove(element: T): Boolean = delegate.remove(element)
+
+    override fun removeAll(elements: Collection<T>): Boolean {
+        val oldList = delegate.value
+        val newList = oldList - elements
+        delegate.value = newList
+
+        return newList.size < oldList.size
+    }
+
+    override fun removeAt(index: Int): T = delegate.removeAt(index)
+
+    override fun retainAll(elements: Collection<T>): Boolean {
+        val oldList = delegate.value
+        val newList = oldList.filter(elements::contains)
+        delegate.value = newList
+
+        return newList.size < oldList.size
+    }
+
+    override fun set(index: Int, element: T): T = delegate.set(index, element)
+
+    override fun subList(fromIndex: Int, toIndex: Int): MutableList<T> {
+        throw NotImplementedError() // It's tricky and we need it at the moment
+    }
+
+    override fun equals(other: Any?): Boolean = delegate.value == other
+
+    override fun hashCode(): Int = delegate.value.hashCode()
+
+    private inner class MutableListIteratorImpl<T>(
+        private val list: MutableList<T>,
+        private var index: Int
+    ) : MutableListIterator<T> {
+        private var lastIndex = -1
+
+        override fun hasPrevious(): Boolean = index > 0
+        override fun hasNext(): Boolean = index < list.size
+
+        override fun previousIndex(): Int = index - 1
+        override fun nextIndex(): Int = index
+
+        override fun previous(): T {
+            if (index <= 0) {
+                throw NoSuchElementException()
+            }
+
+            lastIndex = --index
+
+            return list[lastIndex]
+        }
+
+        override fun next(): T {
+            if (index >= list.size) {
+                throw NoSuchElementException()
+            }
+
+            lastIndex = index++
+
+            return list[lastIndex]
+        }
+
+        override fun set(element: T) {
+            list[lastIndex] = element
+        }
+
+        override fun add(element: T) {
+            list.add(index++, element)
+            lastIndex = -1
+        }
+
+        override fun remove() {
+            check(lastIndex != -1) { "Call next() or previous() before removing element from the iterator." }
+
+            list.removeAt(lastIndex)
+            index = lastIndex
+            lastIndex = -1
+        }
+    }
+}


### PR DESCRIPTION
There are cases when using of `AtomicList` is inefficient in JVM and JS. The most common case is when access to the list is already synchronized by e.g. `Serializer` or by nature of the `Observer` callbacks. In this PR I'm introducing internal `SharedList` that implements `MutableList`. In JVM and JS it's backed by `ArrayList` and in Native it uses `AtomicList`, so it still can be frozen.

PS: replaced all usages of `AtomicList` with `SharedList` where possible
PPS: also made `AtomicList` and all its extensions internal - it's just typealias and we will have more control over it.
PPPS: `SharedList` will be very useful in next my PR about `Observable.replay` operator
PPPPS: There are 3 commits: `SharedList` itself, tests and refactoring