### PR TITLE
Annotate _isPrintErrorEnabled with @SharedImmutable

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/PrintError.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/PrintError.kt
@@ -1,8 +1,10 @@
 package com.badoo.reaktive.utils
 
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
+import kotlin.native.concurrent.SharedImmutable
 
 @Suppress("ObjectPropertyName") // Backing field
+@SharedImmutable
 private val _isPrintErrorEnabled = AtomicBoolean(true)
 
 internal var isPrintErrorEnabled


### PR DESCRIPTION
Same as in `Schedulers.kt`, otherwise it's impossible to access this field from non main threads.