### PR TITLE
Split CompositeDisposable for Native and JVM/JS

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/DoOnBefore.kt
@@ -135,7 +135,7 @@ fun Completable.doOnBeforeDispose(action: () -> Unit): Completable =
 
                 private inline fun onUpstreamFinished(block: () -> Unit) {
                     try {
-                        disposables.clear(dispose = false) // Prevent "action" from being called
+                        disposables.clear(false) // Prevent "action" from being called
                         block()
                     } finally {
                         disposables.dispose()
@@ -183,7 +183,7 @@ fun Completable.doOnBeforeFinally(action: () -> Unit): Completable =
 
                 private inline fun onUpstreamFinished(block: () -> Unit) {
                     try {
-                        disposables.clear(dispose = false) // Prevent "action" from being called while disposing
+                        disposables.clear(false) // Prevent "action" from being called while disposing
                         block()
                     } finally {
                         disposables.dispose()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
@@ -7,6 +7,12 @@ package com.badoo.reaktive.disposable
 expect class CompositeDisposable() : Disposable {
 
     /**
+     * Disposes the [CompositeDisposable] and all its [Disposable]s.
+     * All future [Disposable]s will be immediately disposed.
+     */
+    override fun dispose()
+
+    /**
      * Atomically either adds the specified [Disposable] or disposes it if container is already disposed.
      * Also removes already disposed Disposables.
      */

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
@@ -3,7 +3,7 @@ package com.badoo.reaktive.disposable
 /**
  * Thread-safe collection of [Disposable]
  */
-
+@Suppress("EmptyDefaultConstructor")
 expect class CompositeDisposable() : Disposable {
 
     /**

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
@@ -1,56 +1,26 @@
 package com.badoo.reaktive.disposable
 
-import com.badoo.reaktive.utils.atomic.AtomicReference
-import com.badoo.reaktive.utils.atomic.getAndSet
-import com.badoo.reaktive.utils.atomic.getAndUpdate
-
 /**
  * Thread-safe collection of [Disposable]
  */
-class CompositeDisposable : Disposable {
 
-    private val list = AtomicReference<List<Disposable>?>(emptyList())
-    override val isDisposed: Boolean get() = list.value == null
-
-    override fun dispose() {
-        list
-            .getAndSet(null)
-            ?.forEach(Disposable::dispose)
-    }
+expect class CompositeDisposable() : Disposable {
 
     /**
      * Atomically either adds the specified [Disposable] or disposes it if container is already disposed.
      * Also removes already disposed Disposables.
      */
-    fun add(disposable: Disposable) {
-        list
-            .getAndUpdate {
-                it
-                    ?.toCollection(ArrayList(it.size + 1))
-                    ?.apply {
-                        removeAll(Disposable::isDisposed)
-                        add(disposable)
-                    }
-            }
-            ?: disposable.dispose()
-    }
+    fun add(disposable: Disposable)
 
     /**
      * See [add]
      */
-    operator fun plusAssign(disposable: Disposable) {
-        add(disposable)
-    }
+    operator fun plusAssign(disposable: Disposable)
 
     /**
      * Atomically clears all the [Disposable]s
      *
      * @param dispose if true then removed [Disposable]s will be disposed, default value is true
      */
-    fun clear(dispose: Boolean = true) {
-        list
-            .getAndUpdate { it?.let { emptyList() } }
-            ?.takeIf { dispose }
-            ?.forEach(Disposable::dispose)
-    }
+    fun clear(dispose: Boolean = true)
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DoOnBefore.kt
@@ -171,7 +171,7 @@ fun <T> Maybe<T>.doOnBeforeDispose(action: () -> Unit): Maybe<T> =
 
                 private inline fun onUpstreamFinished(block: () -> Unit) {
                     try {
-                        disposables.clear(dispose = false) // Prevent "action" from being called
+                        disposables.clear(false) // Prevent "action" from being called
                         block()
                     } finally {
                         disposables.dispose()
@@ -227,7 +227,7 @@ fun <T> Maybe<T>.doOnBeforeFinally(action: () -> Unit): Maybe<T> =
 
                 private inline fun onUpstreamFinished(block: () -> Unit) {
                     try {
-                        disposables.clear(dispose = false) // Prevent "action" from being called while disposing
+                        disposables.clear(false) // Prevent "action" from being called while disposing
                         block()
                     } finally {
                         disposables.dispose()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DoOnBefore.kt
@@ -155,7 +155,7 @@ fun <T> Observable<T>.doOnBeforeDispose(action: () -> Unit): Observable<T> =
 
                 private inline fun onUpstreamFinished(block: () -> Unit) {
                     try {
-                        disposables.clear(dispose = false) // Prevent "action" from being called
+                        disposables.clear(false) // Prevent "action" from being called
                         block()
                     } finally {
                         disposables.dispose()
@@ -203,7 +203,7 @@ fun <T> Observable<T>.doOnBeforeFinally(action: () -> Unit): Observable<T> =
 
                 private inline fun onUpstreamFinished(block: () -> Unit) {
                     try {
-                        disposables.clear(dispose = false) // Prevent "action" from being called while disposing
+                        disposables.clear(false) // Prevent "action" from being called while disposing
                         block()
                     } finally {
                         disposables.dispose()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/DoOnBefore.kt
@@ -138,7 +138,7 @@ fun <T> Single<T>.doOnBeforeDispose(action: () -> Unit): Single<T> =
 
                 private inline fun onUpstreamFinished(block: () -> Unit) {
                     try {
-                        disposables.clear(dispose = false) // Prevent "action" from being called
+                        disposables.clear(false) // Prevent "action" from being called
                         block()
                     } finally {
                         disposables.dispose()
@@ -186,7 +186,7 @@ fun <T> Single<T>.doOnBeforeFinally(action: () -> Unit): Single<T> =
 
                 private inline fun onUpstreamFinished(block: () -> Unit) {
                     try {
-                        disposables.clear(dispose = false) // Prevent "action" from being called while disposing
+                        disposables.clear(false) // Prevent "action" from being called while disposing
                         block()
                     } finally {
                         disposables.dispose()

--- a/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
+++ b/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
@@ -1,0 +1,56 @@
+package com.badoo.reaktive.disposable
+
+import kotlin.jvm.Volatile
+
+actual class CompositeDisposable actual constructor() : Disposable {
+
+    private var list: MutableList<Disposable>? = null
+    @Volatile
+    private var _isDisposed = false
+    override val isDisposed: Boolean get() = _isDisposed
+
+    override fun dispose() {
+        val listToDispose: List<Disposable>?
+
+        synchronized(this) {
+            _isDisposed = true
+            listToDispose = list
+            list = null
+        }
+
+        listToDispose?.forEach(Disposable::dispose)
+    }
+
+    actual fun add(disposable: Disposable) {
+        synchronized(this) {
+            if (!_isDisposed) {
+                var listToAdd = list
+                if (listToAdd == null) {
+                    listToAdd = ArrayList()
+                    list = listToAdd
+                }
+
+                listToAdd.add(disposable)
+
+                return
+            }
+        }
+
+        disposable.dispose()
+    }
+
+    actual operator fun plusAssign(disposable: Disposable) {
+        add(disposable)
+    }
+
+    actual fun clear(dispose: Boolean) {
+        val listToDispose: List<Disposable>?
+
+        synchronized(this) {
+            listToDispose = list?.takeIf { dispose }
+            list = null
+        }
+
+        listToDispose?.forEach(Disposable::dispose)
+    }
+}

--- a/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
+++ b/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
@@ -2,6 +2,10 @@ package com.badoo.reaktive.disposable
 
 import kotlin.jvm.Volatile
 
+/**
+ * Thread-safe collection of [Disposable]
+ */
+@Suppress("EmptyDefaultConstructor")
 actual class CompositeDisposable actual constructor() : Disposable {
 
     private var list: MutableList<Disposable>? = null
@@ -9,6 +13,11 @@ actual class CompositeDisposable actual constructor() : Disposable {
     private var _isDisposed = false
     override val isDisposed: Boolean get() = _isDisposed
 
+    /**
+     * {@inheritDoc}
+     * Disposes the [CompositeDisposable] and all its [Disposable]s.
+     * All future [Disposable]s will be immediately disposed.
+     */
     override fun dispose() {
         val listToDispose: List<Disposable>?
 
@@ -21,6 +30,10 @@ actual class CompositeDisposable actual constructor() : Disposable {
         listToDispose?.forEach(Disposable::dispose)
     }
 
+    /**
+     * Atomically either adds the specified [Disposable] or disposes it if container is already disposed.
+     * Also removes already disposed Disposables.
+     */
     actual fun add(disposable: Disposable) {
         synchronized(this) {
             if (!_isDisposed) {
@@ -39,10 +52,18 @@ actual class CompositeDisposable actual constructor() : Disposable {
         disposable.dispose()
     }
 
+    /**
+     * See [add]
+     */
     actual operator fun plusAssign(disposable: Disposable) {
         add(disposable)
     }
 
+    /**
+     * Atomically clears all the [Disposable]s
+     *
+     * @param dispose if true then removed [Disposable]s will be disposed, default value is true
+     */
     actual fun clear(dispose: Boolean) {
         val listToDispose: List<Disposable>?
 

--- a/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
+++ b/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
@@ -14,11 +14,10 @@ actual class CompositeDisposable actual constructor() : Disposable {
     override val isDisposed: Boolean get() = _isDisposed
 
     /**
-     * {@inheritDoc}
      * Disposes the [CompositeDisposable] and all its [Disposable]s.
      * All future [Disposable]s will be immediately disposed.
      */
-    override fun dispose() {
+    actual override fun dispose() {
         val listToDispose: List<Disposable>?
 
         synchronized(this) {

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
@@ -17,7 +17,7 @@ actual class CompositeDisposable actual constructor() : Disposable {
      * Disposes the [CompositeDisposable] and all its [Disposable]s.
      * All future [Disposable]s will be immediately disposed.
      */
-    override fun dispose() {
+    actual override fun dispose() {
         list
             .getAndSet(null)
             ?.forEach(Disposable::dispose)

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
@@ -4,11 +4,19 @@ import com.badoo.reaktive.utils.atomic.AtomicReference
 import com.badoo.reaktive.utils.atomic.getAndSet
 import com.badoo.reaktive.utils.atomic.getAndUpdate
 
+/**
+ * Thread-safe collection of [Disposable]
+ */
+@Suppress("EmptyDefaultConstructor")
 actual class CompositeDisposable actual constructor() : Disposable {
 
     private val list = AtomicReference<List<Disposable>?>(emptyList())
     override val isDisposed: Boolean get() = list.value == null
 
+    /**
+     * Disposes the [CompositeDisposable] and all its [Disposable]s.
+     * All future [Disposable]s will be immediately disposed.
+     */
     override fun dispose() {
         list
             .getAndSet(null)

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
@@ -1,0 +1,53 @@
+package com.badoo.reaktive.disposable
+
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.getAndSet
+import com.badoo.reaktive.utils.atomic.getAndUpdate
+
+actual class CompositeDisposable actual constructor() : Disposable {
+
+    private val list = AtomicReference<List<Disposable>?>(emptyList())
+    override val isDisposed: Boolean get() = list.value == null
+
+    override fun dispose() {
+        list
+            .getAndSet(null)
+            ?.forEach(Disposable::dispose)
+    }
+
+    /**
+     * Atomically either adds the specified [Disposable] or disposes it if container is already disposed.
+     * Also removes already disposed Disposables.
+     */
+    actual fun add(disposable: Disposable) {
+        list
+            .getAndUpdate {
+                it
+                    ?.toCollection(ArrayList(it.size + 1))
+                    ?.apply {
+                        removeAll(Disposable::isDisposed)
+                        add(disposable)
+                    }
+            }
+            ?: disposable.dispose()
+    }
+
+    /**
+     * See [add]
+     */
+    actual operator fun plusAssign(disposable: Disposable) {
+        add(disposable)
+    }
+
+    /**
+     * Atomically clears all the [Disposable]s
+     *
+     * @param dispose if true then removed [Disposable]s will be disposed, default value is true
+     */
+    actual fun clear(dispose: Boolean) {
+        list
+            .getAndUpdate { it?.let { emptyList() } }
+            ?.takeIf { dispose }
+            ?.forEach(Disposable::dispose)
+    }
+}


### PR DESCRIPTION
Separate implementations of CompositeDisposable for Native and JVM/JS. For the last ones we can use mutable collections with synchronization (JVM). Improves Scrabble benchmark results by -67%.