### PR TITLE
Remove .konan from cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ cache:
     - $HOME/.gradle/wrapper/
     - $HOME/.gradle/nodejs/
     - $HOME/.gradle/yarn/
-    - $HOME/.konan/
     - build/js/node_modules
 deploy:
   skip_cleanup: true


### PR DESCRIPTION
Our cache is too huge now (3.5 GB). Looks like diff calculation for cache takes 5-10 minutes every build. I want to try to remove `.konan` folder from cache and check, maybe it is faster to download it every time.

https://docs.travis-ci.com/user/caching/#things-not-to-cache

Official documentation is not so obvious.

> Large files that are quick to install but slow to download do not benefit from caching

I can tell the same about Gradle wrapper, just ZIP archive, that should be extracted. But still they add it to cache by default.

I will drop all caches after ticket is merged. 