### PR TITLE
Omptimized SourceByEmitter builders

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/DisposableEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/DisposableEmitter.kt
@@ -1,0 +1,11 @@
+package com.badoo.reaktive.base
+
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.DisposableWrapper
+
+internal open class DisposableEmitter : DisposableWrapper(), Emitter {
+
+    override fun setDisposable(disposable: Disposable) {
+        set(disposable)
+    }
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/CompletableByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/CompletableByEmitter.kt
@@ -1,33 +1,31 @@
 package com.badoo.reaktive.completable
 
+import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.doIfNotDisposed
 
 fun completable(onSubscribe: (emitter: CompletableEmitter) -> Unit): Completable =
     completableUnsafe { observer ->
-        val emitter =
-            object : DisposableWrapper(), CompletableEmitter {
-                override fun onComplete() {
-                    doIfNotDisposed(dispose = true, block = observer::onComplete)
-                }
-
-                override fun onError(error: Throwable) {
-                    doIfNotDisposed(dispose = true) {
-                        observer.onError(error)
-                    }
-                }
-
-                override fun setDisposable(disposable: Disposable) {
-                    set(disposable)
-                }
-            }
-
+        val emitter = DisposableEmitter(observer)
         observer.onSubscribe(emitter)
+        emitter.tryCatch(block = { onSubscribe(emitter) })
+    }
 
-        try {
-            onSubscribe(emitter)
-        } catch (e: Throwable) {
-            emitter.onError(e)
+private class DisposableEmitter(
+    private val observer: CompletableObserver
+) : DisposableWrapper(), CompletableEmitter {
+    override fun onComplete() {
+        doIfNotDisposed(dispose = true, block = observer::onComplete)
+    }
+
+    override fun onError(error: Throwable) {
+        doIfNotDisposed(dispose = true) {
+            observer.onError(error)
         }
     }
+
+    override fun setDisposable(disposable: Disposable) {
+        set(disposable)
+    }
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/CompletableByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/CompletableByEmitter.kt
@@ -1,31 +1,24 @@
 package com.badoo.reaktive.completable
 
+import com.badoo.reaktive.base.DisposableEmitter
 import com.badoo.reaktive.base.tryCatch
-import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.doIfNotDisposed
 
 fun completable(onSubscribe: (emitter: CompletableEmitter) -> Unit): Completable =
     completableUnsafe { observer ->
-        val emitter = DisposableEmitter(observer)
+        val emitter =
+            object : DisposableEmitter(), CompletableEmitter {
+                override fun onComplete() {
+                    doIfNotDisposed(dispose = true, block = observer::onComplete)
+                }
+
+                override fun onError(error: Throwable) {
+                    doIfNotDisposed(dispose = true) {
+                        observer.onError(error)
+                    }
+                }
+            }
+
         observer.onSubscribe(emitter)
         emitter.tryCatch(block = { onSubscribe(emitter) })
     }
-
-private class DisposableEmitter(
-    private val observer: CompletableObserver
-) : DisposableWrapper(), CompletableEmitter {
-    override fun onComplete() {
-        doIfNotDisposed(dispose = true, block = observer::onComplete)
-    }
-
-    override fun onError(error: Throwable) {
-        doIfNotDisposed(dispose = true) {
-            observer.onError(error)
-        }
-    }
-
-    override fun setDisposable(disposable: Disposable) {
-        set(disposable)
-    }
-}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/CompletableByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/CompletableByEmitter.kt
@@ -2,22 +2,19 @@ package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
+import com.badoo.reaktive.disposable.doIfNotDisposed
 
 fun completable(onSubscribe: (emitter: CompletableEmitter) -> Unit): Completable =
     completableUnsafe { observer ->
         val emitter =
             object : DisposableWrapper(), CompletableEmitter {
                 override fun onComplete() {
-                    if (!isDisposed) {
-                        observer.onComplete()
-                        dispose()
-                    }
+                    doIfNotDisposed(dispose = true, block = observer::onComplete)
                 }
 
                 override fun onError(error: Throwable) {
-                    if (!isDisposed) {
+                    doIfNotDisposed(dispose = true) {
                         observer.onError(error)
-                        dispose()
                     }
                 }
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/DisposableWrapper.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/DisposableWrapper.kt
@@ -6,6 +6,8 @@ package com.badoo.reaktive.disposable
 @Suppress("EmptyDefaultConstructor")
 expect open class DisposableWrapper() : Disposable {
 
+    override val isDisposed: Boolean
+
     /**
      * Disposes this [DisposableWrapper] and a stored [Disposable] if any.
      * Any future [Disposable] will be immediately disposed.

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/DisposableWrapper.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/DisposableWrapper.kt
@@ -4,7 +4,7 @@ package com.badoo.reaktive.disposable
  * Thread-safe container of one [Disposable]
  */
 @Suppress("EmptyDefaultConstructor")
-expect class DisposableWrapper() : Disposable {
+expect open class DisposableWrapper() : Disposable {
 
     /**
      * Disposes this [DisposableWrapper] and a stored [Disposable] if any.

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/MaybeByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/MaybeByEmitter.kt
@@ -2,29 +2,25 @@ package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
+import com.badoo.reaktive.disposable.doIfNotDisposed
 
 fun <T> maybe(onSubscribe: (emitter: MaybeEmitter<T>) -> Unit): Maybe<T> =
     maybeUnsafe { observer ->
         val emitter =
             object : DisposableWrapper(), MaybeEmitter<T> {
                 override fun onSuccess(value: T) {
-                    if (!isDisposed) {
+                    doIfNotDisposed(dispose = true) {
                         observer.onSuccess(value)
-                        dispose()
                     }
                 }
 
                 override fun onComplete() {
-                    if (!isDisposed) {
-                        observer.onComplete()
-                        dispose()
-                    }
+                    doIfNotDisposed(dispose = true, block = observer::onComplete)
                 }
 
                 override fun onError(error: Throwable) {
-                    if (!isDisposed) {
+                    doIfNotDisposed(dispose = true) {
                         observer.onError(error)
-                        dispose()
                     }
                 }
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/MaybeByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/MaybeByEmitter.kt
@@ -5,47 +5,35 @@ import com.badoo.reaktive.disposable.DisposableWrapper
 
 fun <T> maybe(onSubscribe: (emitter: MaybeEmitter<T>) -> Unit): Maybe<T> =
     maybeUnsafe { observer ->
-        val disposableWrapper = DisposableWrapper()
-        observer.onSubscribe(disposableWrapper)
-
         val emitter =
-            object : MaybeEmitter<T> {
-                override val isDisposed: Boolean get() = disposableWrapper.isDisposed
-
+            object : DisposableWrapper(), MaybeEmitter<T> {
                 override fun onSuccess(value: T) {
-                    if (!disposableWrapper.isDisposed) {
-                        try {
-                            observer.onSuccess(value)
-                        } finally {
-                            disposableWrapper.dispose()
-                        }
+                    if (!isDisposed) {
+                        observer.onSuccess(value)
+                        dispose()
                     }
                 }
 
                 override fun onComplete() {
-                    if (!disposableWrapper.isDisposed) {
-                        try {
-                            observer.onComplete()
-                        } finally {
-                            disposableWrapper.dispose()
-                        }
+                    if (!isDisposed) {
+                        observer.onComplete()
+                        dispose()
                     }
                 }
 
                 override fun onError(error: Throwable) {
-                    if (!disposableWrapper.isDisposed) {
-                        try {
-                            observer.onError(error)
-                        } finally {
-                            disposableWrapper.dispose()
-                        }
+                    if (!isDisposed) {
+                        observer.onError(error)
+                        dispose()
                     }
                 }
 
                 override fun setDisposable(disposable: Disposable) {
-                    disposableWrapper.set(disposable)
+                    set(disposable)
                 }
             }
+
+        observer.onSubscribe(emitter)
 
         try {
             onSubscribe(emitter)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/MaybeByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/MaybeByEmitter.kt
@@ -1,37 +1,30 @@
 package com.badoo.reaktive.maybe
 
+import com.badoo.reaktive.base.DisposableEmitter
 import com.badoo.reaktive.base.tryCatch
-import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.doIfNotDisposed
 
 fun <T> maybe(onSubscribe: (emitter: MaybeEmitter<T>) -> Unit): Maybe<T> =
     maybeUnsafe { observer ->
-        val emitter = DisposableEmitter(observer)
+        val emitter =
+            object : DisposableEmitter(), MaybeEmitter<T> {
+                override fun onSuccess(value: T) {
+                    doIfNotDisposed(dispose = true) {
+                        observer.onSuccess(value)
+                    }
+                }
+
+                override fun onComplete() {
+                    doIfNotDisposed(dispose = true, block = observer::onComplete)
+                }
+
+                override fun onError(error: Throwable) {
+                    doIfNotDisposed(dispose = true) {
+                        observer.onError(error)
+                    }
+                }
+            }
+
         observer.onSubscribe(emitter)
         emitter.tryCatch(block = { onSubscribe(emitter) })
     }
-
-private class DisposableEmitter<T>(
-    private val observer: MaybeObserver<T>
-) : DisposableWrapper(), MaybeEmitter<T> {
-    override fun onSuccess(value: T) {
-        doIfNotDisposed(dispose = true) {
-            observer.onSuccess(value)
-        }
-    }
-
-    override fun onComplete() {
-        doIfNotDisposed(dispose = true, block = observer::onComplete)
-    }
-
-    override fun onError(error: Throwable) {
-        doIfNotDisposed(dispose = true) {
-            observer.onError(error)
-        }
-    }
-
-    override fun setDisposable(disposable: Disposable) {
-        set(disposable)
-    }
-}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/MaybeByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/MaybeByEmitter.kt
@@ -1,39 +1,37 @@
 package com.badoo.reaktive.maybe
 
+import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.doIfNotDisposed
 
 fun <T> maybe(onSubscribe: (emitter: MaybeEmitter<T>) -> Unit): Maybe<T> =
     maybeUnsafe { observer ->
-        val emitter =
-            object : DisposableWrapper(), MaybeEmitter<T> {
-                override fun onSuccess(value: T) {
-                    doIfNotDisposed(dispose = true) {
-                        observer.onSuccess(value)
-                    }
-                }
-
-                override fun onComplete() {
-                    doIfNotDisposed(dispose = true, block = observer::onComplete)
-                }
-
-                override fun onError(error: Throwable) {
-                    doIfNotDisposed(dispose = true) {
-                        observer.onError(error)
-                    }
-                }
-
-                override fun setDisposable(disposable: Disposable) {
-                    set(disposable)
-                }
-            }
-
+        val emitter = DisposableEmitter(observer)
         observer.onSubscribe(emitter)
+        emitter.tryCatch(block = { onSubscribe(emitter) })
+    }
 
-        try {
-            onSubscribe(emitter)
-        } catch (e: Throwable) {
-            emitter.onError(e)
+private class DisposableEmitter<T>(
+    private val observer: MaybeObserver<T>
+) : DisposableWrapper(), MaybeEmitter<T> {
+    override fun onSuccess(value: T) {
+        doIfNotDisposed(dispose = true) {
+            observer.onSuccess(value)
         }
     }
+
+    override fun onComplete() {
+        doIfNotDisposed(dispose = true, block = observer::onComplete)
+    }
+
+    override fun onError(error: Throwable) {
+        doIfNotDisposed(dispose = true) {
+            observer.onError(error)
+        }
+    }
+
+    override fun setDisposable(disposable: Disposable) {
+        set(disposable)
+    }
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObservableByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObservableByEmitter.kt
@@ -1,37 +1,30 @@
 package com.badoo.reaktive.observable
 
+import com.badoo.reaktive.base.DisposableEmitter
 import com.badoo.reaktive.base.tryCatch
-import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.doIfNotDisposed
 
 fun <T> observable(onSubscribe: (emitter: ObservableEmitter<T>) -> Unit): Observable<T> =
     observableUnsafe { observer ->
-        val emitter = DisposableEmitter(observer)
+        val emitter =
+            object : DisposableEmitter(), ObservableEmitter<T> {
+                override fun onNext(value: T) {
+                    if (!isDisposed) {
+                        observer.onNext(value)
+                    }
+                }
+
+                override fun onComplete() {
+                    doIfNotDisposed(dispose = true, block = observer::onComplete)
+                }
+
+                override fun onError(error: Throwable) {
+                    doIfNotDisposed(dispose = true) {
+                        observer.onError(error)
+                    }
+                }
+            }
+
         observer.onSubscribe(emitter)
         emitter.tryCatch(block = { onSubscribe(emitter) })
     }
-
-private class DisposableEmitter<T>(
-    private val observer: ObservableObserver<T>
-) : DisposableWrapper(), ObservableEmitter<T> {
-    override fun onNext(value: T) {
-        if (!isDisposed) {
-            observer.onNext(value)
-        }
-    }
-
-    override fun onComplete() {
-        doIfNotDisposed(dispose = true, block = observer::onComplete)
-    }
-
-    override fun onError(error: Throwable) {
-        doIfNotDisposed(dispose = true) {
-            observer.onError(error)
-        }
-    }
-
-    override fun setDisposable(disposable: Disposable) {
-        set(disposable)
-    }
-}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObservableByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObservableByEmitter.kt
@@ -1,39 +1,37 @@
 package com.badoo.reaktive.observable
 
+import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.doIfNotDisposed
 
 fun <T> observable(onSubscribe: (emitter: ObservableEmitter<T>) -> Unit): Observable<T> =
     observableUnsafe { observer ->
-        val emitter =
-            object : DisposableWrapper(), ObservableEmitter<T> {
-                override fun onNext(value: T) {
-                    if (!isDisposed) {
-                        observer.onNext(value)
-                    }
-                }
-
-                override fun onComplete() {
-                    doIfNotDisposed(dispose = true, block = observer::onComplete)
-                }
-
-                override fun onError(error: Throwable) {
-                    doIfNotDisposed(dispose = true) {
-                        observer.onError(error)
-                    }
-                }
-
-                override fun setDisposable(disposable: Disposable) {
-                    set(disposable)
-                }
-            }
-
+        val emitter = DisposableEmitter(observer)
         observer.onSubscribe(emitter)
+        emitter.tryCatch(block = { onSubscribe(emitter) })
+    }
 
-        try {
-            onSubscribe(emitter)
-        } catch (e: Throwable) {
-            emitter.onError(e)
+private class DisposableEmitter<T>(
+    private val observer: ObservableObserver<T>
+) : DisposableWrapper(), ObservableEmitter<T> {
+    override fun onNext(value: T) {
+        if (!isDisposed) {
+            observer.onNext(value)
         }
     }
+
+    override fun onComplete() {
+        doIfNotDisposed(dispose = true, block = observer::onComplete)
+    }
+
+    override fun onError(error: Throwable) {
+        doIfNotDisposed(dispose = true) {
+            observer.onError(error)
+        }
+    }
+
+    override fun setDisposable(disposable: Disposable) {
+        set(disposable)
+    }
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObservableByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObservableByEmitter.kt
@@ -2,6 +2,7 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
+import com.badoo.reaktive.disposable.doIfNotDisposed
 
 fun <T> observable(onSubscribe: (emitter: ObservableEmitter<T>) -> Unit): Observable<T> =
     observableUnsafe { observer ->
@@ -14,16 +15,12 @@ fun <T> observable(onSubscribe: (emitter: ObservableEmitter<T>) -> Unit): Observ
                 }
 
                 override fun onComplete() {
-                    if (!isDisposed) {
-                        observer.onComplete()
-                        dispose()
-                    }
+                    doIfNotDisposed(dispose = true, block = observer::onComplete)
                 }
 
                 override fun onError(error: Throwable) {
-                    if (!isDisposed) {
+                    doIfNotDisposed(dispose = true) {
                         observer.onError(error)
-                        dispose()
                     }
                 }
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SingleByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SingleByEmitter.kt
@@ -2,22 +2,21 @@ package com.badoo.reaktive.single
 
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
+import com.badoo.reaktive.disposable.doIfNotDisposed
 
 fun <T> single(onSubscribe: (emitter: SingleEmitter<T>) -> Unit): Single<T> =
     singleUnsafe { observer ->
         val emitter =
             object : DisposableWrapper(), SingleEmitter<T> {
                 override fun onSuccess(value: T) {
-                    if (!isDisposed) {
+                    doIfNotDisposed(dispose = true) {
                         observer.onSuccess(value)
-                        dispose()
                     }
                 }
 
                 override fun onError(error: Throwable) {
-                    if (!isDisposed) {
+                    doIfNotDisposed(dispose = true) {
                         observer.onError(error)
-                        dispose()
                     }
                 }
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SingleByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SingleByEmitter.kt
@@ -20,7 +20,6 @@ fun <T> single(onSubscribe: (emitter: SingleEmitter<T>) -> Unit): Single<T> =
                     }
                 }
 
-                @Suppress("RedundantOverride") // IDEA complains that setDisposable is not implemented
                 override fun setDisposable(disposable: Disposable) {
                     set(disposable)
                 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SingleByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SingleByEmitter.kt
@@ -1,33 +1,26 @@
 package com.badoo.reaktive.single
 
+import com.badoo.reaktive.base.DisposableEmitter
 import com.badoo.reaktive.base.tryCatch
-import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.doIfNotDisposed
 
 fun <T> single(onSubscribe: (emitter: SingleEmitter<T>) -> Unit): Single<T> =
     singleUnsafe { observer ->
-        val emitter = DisposableEmitter(observer)
+        val emitter =
+            object : DisposableEmitter(), SingleEmitter<T> {
+                override fun onSuccess(value: T) {
+                    doIfNotDisposed(dispose = true) {
+                        observer.onSuccess(value)
+                    }
+                }
+
+                override fun onError(error: Throwable) {
+                    doIfNotDisposed(dispose = true) {
+                        observer.onError(error)
+                    }
+                }
+            }
+
         observer.onSubscribe(emitter)
         emitter.tryCatch(block = { onSubscribe(emitter) })
     }
-
-private class DisposableEmitter<T>(
-    private val observer: SingleObserver<T>
-) : DisposableWrapper(), SingleEmitter<T> {
-    override fun onSuccess(value: T) {
-        doIfNotDisposed(dispose = true) {
-            observer.onSuccess(value)
-        }
-    }
-
-    override fun onError(error: Throwable) {
-        doIfNotDisposed(dispose = true) {
-            observer.onError(error)
-        }
-    }
-
-    override fun setDisposable(disposable: Disposable) {
-        set(disposable)
-    }
-}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SingleByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SingleByEmitter.kt
@@ -1,35 +1,33 @@
 package com.badoo.reaktive.single
 
+import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.doIfNotDisposed
 
 fun <T> single(onSubscribe: (emitter: SingleEmitter<T>) -> Unit): Single<T> =
     singleUnsafe { observer ->
-        val emitter =
-            object : DisposableWrapper(), SingleEmitter<T> {
-                override fun onSuccess(value: T) {
-                    doIfNotDisposed(dispose = true) {
-                        observer.onSuccess(value)
-                    }
-                }
-
-                override fun onError(error: Throwable) {
-                    doIfNotDisposed(dispose = true) {
-                        observer.onError(error)
-                    }
-                }
-
-                override fun setDisposable(disposable: Disposable) {
-                    set(disposable)
-                }
-            }
-
+        val emitter = DisposableEmitter(observer)
         observer.onSubscribe(emitter)
+        emitter.tryCatch(block = { onSubscribe(emitter) })
+    }
 
-        try {
-            onSubscribe(emitter)
-        } catch (e: Throwable) {
-            emitter.onError(e)
+private class DisposableEmitter<T>(
+    private val observer: SingleObserver<T>
+) : DisposableWrapper(), SingleEmitter<T> {
+    override fun onSuccess(value: T) {
+        doIfNotDisposed(dispose = true) {
+            observer.onSuccess(value)
         }
     }
+
+    override fun onError(error: Throwable) {
+        doIfNotDisposed(dispose = true) {
+            observer.onError(error)
+        }
+    }
+
+    override fun setDisposable(disposable: Disposable) {
+        set(disposable)
+    }
+}

--- a/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/disposable/DisposableWrapper.kt
+++ b/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/disposable/DisposableWrapper.kt
@@ -6,7 +6,7 @@ import kotlin.jvm.Volatile
  * Thread-safe container of one [Disposable]
  */
 @Suppress("EmptyDefaultConstructor")
-actual class DisposableWrapper actual constructor() : Disposable {
+actual open class DisposableWrapper actual constructor() : Disposable {
 
     @Volatile
     private var _isDisposed: Boolean = false

--- a/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/disposable/DisposableWrapper.kt
+++ b/reaktive/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/disposable/DisposableWrapper.kt
@@ -10,7 +10,7 @@ actual open class DisposableWrapper actual constructor() : Disposable {
 
     @Volatile
     private var _isDisposed: Boolean = false
-    override val isDisposed: Boolean get() = _isDisposed
+    actual override val isDisposed: Boolean get() = _isDisposed
     private var disposable: Disposable? = null
 
     /**

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/disposable/DisposableWrapper.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/disposable/DisposableWrapper.kt
@@ -7,7 +7,7 @@ import com.badoo.reaktive.utils.atomic.getAndUpdate
  * Thread-safe container of one [Disposable]
  */
 @Suppress("EmptyDefaultConstructor")
-actual class DisposableWrapper actual constructor() : Disposable {
+actual open class DisposableWrapper actual constructor() : Disposable {
 
     private val ref = AtomicReference<Holder?>(Holder(null))
     override val isDisposed: Boolean get() = ref.value == null

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/disposable/DisposableWrapper.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/disposable/DisposableWrapper.kt
@@ -10,7 +10,7 @@ import com.badoo.reaktive.utils.atomic.getAndUpdate
 actual open class DisposableWrapper actual constructor() : Disposable {
 
     private val ref = AtomicReference<Holder?>(Holder(null))
-    override val isDisposed: Boolean get() = ref.value == null
+    actual override val isDisposed: Boolean get() = ref.value == null
 
     /**
      * Disposes this [DisposableWrapper] and a stored [Disposable] if any.


### PR DESCRIPTION
Our Scrabble results are already reduced from ~205 ms to ~131 ms on my machine. This PR improves it further to ~124 ms.

![image](https://user-images.githubusercontent.com/26204457/67204716-0efdb580-f406-11e9-8037-43a4e385be53.png)
