### PR TITLE
Optimized source builders

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Various.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Various.kt
@@ -1,5 +1,7 @@
 package com.badoo.reaktive.maybe
 
+import com.badoo.reaktive.disposable.Disposable
+
 inline fun <T> maybeUnsafe(crossinline onSubscribe: (observer: MaybeObserver<T>) -> Unit): Maybe<T> =
     object : Maybe<T> {
         override fun subscribe(observer: MaybeObserver<T>) {
@@ -8,34 +10,59 @@ inline fun <T> maybeUnsafe(crossinline onSubscribe: (observer: MaybeObserver<T>)
     }
 
 fun <T> maybeOf(value: T): Maybe<T> =
-    maybe { emitter ->
-        emitter.onSuccess(value)
+    maybeUnsafe { observer ->
+        val disposable = Disposable()
+        observer.onSubscribe(disposable)
+
+        if (!disposable.isDisposed) {
+            observer.onSuccess(value)
+        }
     }
 
 fun <T> T.toMaybe(): Maybe<T> = maybeOf(this)
 
 fun <T : Any> maybeOfNotNull(value: T?): Maybe<T> =
-    maybe { emitter ->
-        if (value == null) {
-            emitter.onComplete()
-        } else {
-            emitter.onSuccess(value)
+    maybeUnsafe { observer ->
+        val disposable = Disposable()
+        observer.onSubscribe(disposable)
+
+        if (!disposable.isDisposed) {
+            if (value == null) {
+                observer.onComplete()
+            } else {
+                observer.onSuccess(value)
+            }
         }
     }
 
 fun <T : Any> T?.toMaybeNotNull(): Maybe<T> = maybeOfNotNull(this)
 
 fun <T> maybeOfError(error: Throwable): Maybe<T> =
-    maybe { emitter ->
-        emitter.onError(error)
+    maybeUnsafe { observer ->
+        val disposable = Disposable()
+        observer.onSubscribe(disposable)
+
+        if (!disposable.isDisposed) {
+            observer.onError(error)
+        }
     }
 
 fun <T> Throwable.toMaybeOfError(): Maybe<T> = maybeOfError(this)
 
 fun <T> maybeOfEmpty(): Maybe<T> =
-    maybe(MaybeEmitter<*>::onComplete)
+    maybeUnsafe { observer ->
+        val disposable = Disposable()
+        observer.onSubscribe(disposable)
 
-fun <T> maybeOfNever(): Maybe<T> = maybe {}
+        if (!disposable.isDisposed) {
+            observer.onComplete()
+        }
+    }
+
+fun <T> maybeOfNever(): Maybe<T> =
+    maybeUnsafe { observer ->
+        observer.onSubscribe(Disposable())
+    }
 
 fun <T> maybeFromFunction(func: () -> T): Maybe<T> =
     maybe { emitter ->

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Various.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Various.kt
@@ -1,5 +1,7 @@
 package com.badoo.reaktive.observable
 
+import com.badoo.reaktive.disposable.Disposable
+
 inline fun <T> observableUnsafe(crossinline onSubscribe: (observer: ObservableObserver<T>) -> Unit): Observable<T> =
     object : Observable<T> {
         override fun subscribe(observer: ObservableObserver<T>) {
@@ -8,33 +10,80 @@ inline fun <T> observableUnsafe(crossinline onSubscribe: (observer: ObservableOb
     }
 
 fun <T> observableOf(value: T): Observable<T> =
-    observable { emitter ->
-        emitter.onNext(value)
-        emitter.onComplete()
+    observableUnsafe { observer ->
+        val disposable = Disposable()
+        observer.onSubscribe(disposable)
+
+        if (!disposable.isDisposed) {
+            observer.onNext(value)
+            if (!disposable.isDisposed) {
+                observer.onComplete()
+            }
+        }
     }
 
 fun <T> T.toObservable(): Observable<T> = observableOf(this)
 
 fun <T> Iterable<T>.asObservable(): Observable<T> =
-    observable { emitter ->
-        forEach(emitter::onNext)
-        emitter.onComplete()
+    observableUnsafe { observer ->
+        val disposable = Disposable()
+        observer.onSubscribe(disposable)
+
+        if (!disposable.isDisposed) {
+            forEach {
+                observer.onNext(it)
+                if (disposable.isDisposed) {
+                    return@observableUnsafe
+                }
+            }
+
+            observer.onComplete()
+        }
     }
 
 fun <T> observableOf(vararg values: T): Observable<T> =
-    observable { emitter ->
-        values.forEach(emitter::onNext)
-        emitter.onComplete()
+    observableUnsafe { observer ->
+        val disposable = Disposable()
+        observer.onSubscribe(disposable)
+
+        if (!disposable.isDisposed) {
+            values.forEach {
+                observer.onNext(it)
+                if (disposable.isDisposed) {
+                    return@observableUnsafe
+                }
+            }
+
+            observer.onComplete()
+        }
     }
 
 fun <T> observableOfError(error: Throwable): Observable<T> =
-    observable { emitter -> emitter.onError(error) }
+    observableUnsafe { observer ->
+        val disposable = Disposable()
+        observer.onSubscribe(disposable)
+
+        if (!disposable.isDisposed) {
+            observer.onError(error)
+        }
+    }
 
 fun <T> Throwable.toObservableOfError(): Observable<T> = observableOfError(this)
 
-fun <T> observableOfEmpty(): Observable<T> = observable(ObservableEmitter<*>::onComplete)
+fun <T> observableOfEmpty(): Observable<T> =
+    observableUnsafe { observer ->
+        val disposable = Disposable()
+        observer.onSubscribe(disposable)
 
-fun <T> observableOfNever(): Observable<T> = observable {}
+        if (!disposable.isDisposed) {
+            observer.onComplete()
+        }
+    }
+
+fun <T> observableOfNever(): Observable<T> =
+    observableUnsafe { observer ->
+        observer.onSubscribe(Disposable())
+    }
 
 fun <T> observableFromFunction(func: () -> T): Observable<T> =
     observable { emitter ->


### PR DESCRIPTION
In such a simple cases it's better to avoid emitters allocations