### PR TITLE
Add all build folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,10 @@
 .gradle
 /local.properties
 .idea
-/build
+build
 /classes
 /out
 .DS_Store*
-*/build
-buildSrc/buildSrc/build
 */node_modules
 */package-lock.json
 *.hprof


### PR DESCRIPTION
I don't think we will ever use `build` as package name.