### PR TITLE
Add more descriptive assertion messages

### DIFF
--- a/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/base/TestObserver.kt
+++ b/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/base/TestObserver.kt
@@ -11,6 +11,7 @@ open class TestObserver : Observer, Disposable, ErrorCallback {
     val disposable: Disposable? get() = _disposable.value
     private val _error = AtomicReference<Throwable?>(null)
     val error: Throwable? get() = _error.value
+    val isError: Boolean get() = error != null
     override val isDisposed: Boolean get() = _disposable.value?.isDisposed == true
 
     override fun onSubscribe(disposable: Disposable) {
@@ -37,7 +38,7 @@ open class TestObserver : Observer, Disposable, ErrorCallback {
 
     protected open fun checkActive() {
         checkNotNull(disposable) { "Not subscribed" }
-        check(error == null) { "Already has error" }
+        check(error == null) { "Already failed" }
         check(!isDisposed) { "Already disposed" }
     }
 }

--- a/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/base/TestObserverExt.kt
+++ b/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/base/TestObserverExt.kt
@@ -6,38 +6,36 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-val TestObserver.isError: Boolean get() = error != null
-
 fun TestObserver.assertError() {
-    assertTrue(isError)
+    assertTrue(isError, "Source did not fail")
 }
 
 fun TestObserver.assertError(expectedError: Throwable) {
-    assertEquals(expectedError, error)
+    assertEquals(expectedError, error, "Source error does not match")
 }
 
 fun TestObserver.assertError(predicate: (Throwable) -> Boolean) {
-    val error = this.error
-    assertNotNull(error)
-    assertTrue(predicate(error))
+    assertError()
+    val error = this.error!!
+    assertTrue(predicate(error), "Source error does not match the predicate: $error")
 }
 
 fun TestObserver.assertNotError() {
-    assertFalse(isError)
+    assertFalse(isError, "Source failed")
 }
 
 fun TestObserver.assertSubscribed() {
-    assertNotNull(disposable)
+    assertNotNull(disposable, "Source is not subscribed")
 }
 
 fun TestObserver.assertNotSubscribed() {
-    assertNull(disposable)
+    assertNull(disposable, "Source is subscribed")
 }
 
 fun TestObserver.assertDisposed() {
-    assertTrue(isDisposed)
+    assertTrue(isDisposed, "Source is not disposed")
 }
 
 fun TestObserver.assertNotDisposed() {
-    assertFalse(isDisposed)
+    assertFalse(isDisposed, "Source is disposed")
 }

--- a/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/completable/TestCompletableObserver.kt
+++ b/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/completable/TestCompletableObserver.kt
@@ -31,6 +31,6 @@ class TestCompletableObserver(autoFreeze: Boolean = true) : TestObserver(), Comp
     override fun checkActive() {
         super.checkActive()
 
-        check(!isComplete) { "Already complete" }
+        check(!isComplete) { "Already completed" }
     }
 }

--- a/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/completable/TestCompletableObserverExt.kt
+++ b/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/completable/TestCompletableObserverExt.kt
@@ -10,7 +10,7 @@ fun TestCompletableObserver.assertComplete() {
 }
 
 fun TestCompletableObserver.assertNotComplete() {
-    assertFalse(isComplete, "Completable is complete")
+    assertFalse(isComplete, "Completable completed")
 }
 
 fun Completable.test(autoFreeze: Boolean = true): TestCompletableObserver {

--- a/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/maybe/TestMaybeObserver.kt
+++ b/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/maybe/TestMaybeObserver.kt
@@ -49,7 +49,7 @@ class TestMaybeObserver<T>(autoFreeze: Boolean = true) : TestObserver(), MaybeOb
         super.checkActive()
 
         check(!isSuccess) { "Already succeeded" }
-        check(!isComplete) { "Already complete" }
+        check(!isComplete) { "Already completed" }
     }
 
     private class Value<T>(val value: T)

--- a/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/maybe/TestMaybeObserverExt.kt
+++ b/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/maybe/TestMaybeObserverExt.kt
@@ -7,15 +7,15 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 fun <T> TestMaybeObserver<T>.assertSuccess() {
-    assertTrue(isSuccess, "Maybe did not success")
+    assertTrue(isSuccess, "Maybe did not succeed")
 }
 
 fun <T> TestMaybeObserver<T>.assertSuccess(expectedValue: T) {
-    assertEquals(expectedValue, value, "Maybe success values do not match")
+    assertEquals(expectedValue, value, "Maybe success value does not match")
 }
 
 fun <T> TestMaybeObserver<T>.assertNotSuccess() {
-    assertFalse(isSuccess, "Maybe is succeeded")
+    assertFalse(isSuccess, "Maybe succeeded")
 }
 
 fun TestMaybeObserver<*>.assertComplete() {
@@ -23,7 +23,7 @@ fun TestMaybeObserver<*>.assertComplete() {
 }
 
 fun TestMaybeObserver<*>.assertNotComplete() {
-    assertFalse(isComplete, "Maybe is complete")
+    assertFalse(isComplete, "Maybe completed")
 }
 
 fun <T> Maybe<T>.test(autoFreeze: Boolean = true): TestMaybeObserver<T> {

--- a/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/observable/TestObservableObserver.kt
+++ b/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/observable/TestObservableObserver.kt
@@ -42,6 +42,6 @@ class TestObservableObserver<T>(autoFreeze: Boolean = true) : TestObserver(), Ob
     override fun checkActive() {
         super.checkActive()
 
-        check(!isComplete) { "Already complete" }
+        check(!isComplete) { "Already completed" }
     }
 }

--- a/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/observable/TestObservableObserverExt.kt
+++ b/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/observable/TestObservableObserverExt.kt
@@ -23,11 +23,11 @@ fun TestObservableObserver<*>.assertNoValues() {
 }
 
 fun TestObservableObserver<*>.assertComplete() {
-    assertTrue(isComplete, "Observable was not complete")
+    assertTrue(isComplete, "Observable did not complete")
 }
 
 fun TestObservableObserver<*>.assertNotComplete() {
-    assertFalse(isComplete, "Observable is complete")
+    assertFalse(isComplete, "Observable completed")
 }
 
 fun <T> Observable<T>.test(autoFreeze: Boolean = true): TestObservableObserver<T> {

--- a/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/single/TestSingleObserverExt.kt
+++ b/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/single/TestSingleObserverExt.kt
@@ -7,15 +7,15 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 fun <T> TestSingleObserver<T>.assertSuccess() {
-    assertTrue(isSuccess, "Single was not success")
+    assertTrue(isSuccess, "Single did not succeed")
 }
 
 fun <T> TestSingleObserver<T>.assertSuccess(expectedValue: T) {
-    assertEquals(expectedValue, value, "Single success values do not match")
+    assertEquals(expectedValue, value, "Single success value does not match")
 }
 
 fun <T> TestSingleObserver<T>.assertNotSuccess() {
-    assertFalse(isSuccess, "Single is succeeded")
+    assertFalse(isSuccess, "Single succeeded")
 }
 
 fun <T> Single<T>.test(autoFreeze: Boolean = true): TestSingleObserver<T> {


### PR DESCRIPTION
* Cleanup assertion messages for testing API
* Move `isError` property inside `TestObserver`, as it's done with `isComplete`, `isSuccess`, etc.