### PR TITLE
Optimized error handling on subscriptions

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/ErrorCallbackExt.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/ErrorCallbackExt.kt
@@ -1,5 +1,7 @@
 package com.badoo.reaktive.base
 
+import com.badoo.reaktive.utils.handleSourceError
+
 internal inline fun <T> ErrorCallback.tryCatch(
     block: () -> T,
     errorTransformer: (Throwable) -> Throwable = { it },
@@ -8,7 +10,7 @@ internal inline fun <T> ErrorCallback.tryCatch(
     try {
         block()
     } catch (e: Throwable) {
-        onError(errorTransformer(e))
+        handleSourceError(errorTransformer(e), ::onError)
         return
     }
         .also(onSuccess)
@@ -21,6 +23,6 @@ internal inline fun ErrorCallback.tryCatch(
     try {
         block()
     } catch (e: Throwable) {
-        onError(errorTransformer(e))
+        handleSourceError(errorTransformer(e), ::onError)
     }
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AndThen.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AndThen.kt
@@ -13,7 +13,7 @@ import com.badoo.reaktive.single.flatMapObservable
 
 fun Completable.andThen(completable: Completable): Completable =
     completable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : CompletableObserver, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsObservable.kt
@@ -1,13 +1,12 @@
 package com.badoo.reaktive.completable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.observable.observable
 
 fun <T> Completable.asObservable(): Observable<T> =
     observable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : CompletableObserver, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsSingle.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsSingle.kt
@@ -1,7 +1,6 @@
 package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.base.ErrorCallback
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.single.Single
@@ -22,7 +21,7 @@ private inline fun <T> Completable.asSingleOrAction(
     crossinline onComplete: (observer: SingleEmitter<T>) -> Unit
 ): Single<T> =
     single { emitter ->
-        subscribeSafe(
+        subscribe(
             object : CompletableObserver, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Concat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Concat.kt
@@ -30,7 +30,7 @@ fun Iterable<Completable>.concat(): Completable =
                 }
             }
 
-        sources[0].subscribeSafe(upstreamObserver)
+        sources[0].subscribe(upstreamObserver)
     }
 
 fun concat(vararg sources: Completable): Completable =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Delay.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Delay.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.completable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
@@ -12,7 +11,7 @@ fun Completable.delay(delayMillis: Long, scheduler: Scheduler, delayError: Boole
         val executor = scheduler.newExecutor()
         disposables += executor
 
-        subscribeSafe(
+        subscribe(
             object : CompletableObserver {
                 override fun onSubscribe(disposable: Disposable) {
                     disposables += disposable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/DoOnBefore.kt
@@ -48,7 +48,7 @@ fun Completable.doOnBeforeSubscribe(action: (Disposable) -> Unit): Completable =
 
 fun Completable.doOnBeforeComplete(action: () -> Unit): Completable =
     completable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : CompletableObserver, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)
@@ -65,7 +65,7 @@ fun Completable.doOnBeforeComplete(action: () -> Unit): Completable =
 
 fun Completable.doOnBeforeError(consumer: (Throwable) -> Unit): Completable =
     completable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : CompletableObserver, CompleteCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)
@@ -82,7 +82,7 @@ fun Completable.doOnBeforeError(consumer: (Throwable) -> Unit): Completable =
 
 fun Completable.doOnBeforeTerminate(action: () -> Unit): Completable =
     completable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : CompletableObserver {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/ObserveOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/ObserveOn.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.completable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
@@ -13,7 +12,7 @@ fun Completable.observeOn(scheduler: Scheduler): Completable =
         val executor = scheduler.newExecutor()
         disposables += executor
 
-        subscribeSafe(
+        subscribe(
             object : CompletableObserver {
                 override fun onSubscribe(disposable: Disposable) {
                     disposables += disposable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/OnErrorResumeNext.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/OnErrorResumeNext.kt
@@ -9,7 +9,7 @@ import com.badoo.reaktive.disposable.Disposable
 
 fun Completable.onErrorResumeNext(nextSupplier: (Throwable) -> Completable): Completable =
     completable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : CompletableObserver, CompleteCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Retry.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Retry.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.disposable.Disposable
 
 fun Completable.retry(predicate: (attempt: Int, Throwable) -> Boolean = { _, _ -> true }): Completable =
     completable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : CompletableObserver, CompletableCallbacks by emitter {
                 private val retry = Retry(emitter, predicate)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/ThreadLocal.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/ThreadLocal.kt
@@ -1,7 +1,6 @@
 package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.base.exceptions.CompositeException
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.utils.ThreadLocalStorage
@@ -14,7 +13,7 @@ fun Completable.threadLocal(): Completable =
         val emitterStorage = ThreadLocalStorage(it)
         disposables += emitterStorage
 
-        subscribeSafe(
+        subscribe(
             object : CompletableObserver {
                 override fun onSubscribe(disposable: Disposable) {
                     disposables += disposable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsCompletable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsCompletable.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.maybe
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.completable.completable
@@ -8,7 +7,7 @@ import com.badoo.reaktive.disposable.Disposable
 
 fun Maybe<*>.asCompletable(): Completable =
     completable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<Any?>, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsObservable.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.maybe
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.observable.Observable
@@ -8,7 +7,7 @@ import com.badoo.reaktive.observable.observable
 
 fun <T> Maybe<T>.asObservable(): Observable<T> =
     observable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<T>, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsSingle.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/AsSingle.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.maybe
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.single.Single
@@ -22,7 +21,7 @@ internal inline fun <T> Maybe<T>.asSingleOrAction(
     crossinline onComplete: (emitter: SingleEmitter<T>) -> Unit
 ): Single<T> =
     single { emitter ->
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<T>, SingleCallbacks<T> by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Delay.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Delay.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.maybe
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
@@ -12,7 +11,7 @@ fun <T> Maybe<T>.delay(delayMillis: Long, scheduler: Scheduler, delayError: Bool
         val executor = scheduler.newExecutor()
         disposables += executor
 
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<T> {
                 override fun onSubscribe(disposable: Disposable) {
                     disposables += disposable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DoOnBefore.kt
@@ -56,7 +56,7 @@ fun <T> Maybe<T>.doOnBeforeSubscribe(action: (Disposable) -> Unit): Maybe<T> =
 
 fun <T> Maybe<T>.doOnBeforeSuccess(consumer: (T) -> Unit): Maybe<T> =
     maybe { emitter ->
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<T>, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)
@@ -75,7 +75,7 @@ fun <T> Maybe<T>.doOnBeforeSuccess(consumer: (T) -> Unit): Maybe<T> =
 
 fun <T> Maybe<T>.doOnBeforeComplete(action: () -> Unit): Maybe<T> =
     maybe { emitter ->
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<T>, SuccessCallback<T> by emitter, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)
@@ -92,7 +92,7 @@ fun <T> Maybe<T>.doOnBeforeComplete(action: () -> Unit): Maybe<T> =
 
 fun <T> Maybe<T>.doOnBeforeError(consumer: (Throwable) -> Unit): Maybe<T> =
     maybe { emitter ->
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<T>, SuccessCallback<T> by emitter, CompleteCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)
@@ -109,7 +109,7 @@ fun <T> Maybe<T>.doOnBeforeError(consumer: (Throwable) -> Unit): Maybe<T> =
 
 fun <T> Maybe<T>.doOnBeforeTerminate(action: () -> Unit): Maybe<T> =
     maybe { emitter ->
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<T> {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Filter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Filter.kt
@@ -1,13 +1,12 @@
 package com.badoo.reaktive.maybe
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 
 fun <T> Maybe<T>.filter(predicate: (T) -> Boolean): Maybe<T> =
     maybe { emitter ->
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<T>, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/FlatMap.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/FlatMap.kt
@@ -1,14 +1,13 @@
 package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.base.Observer
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 
 fun <T, R> Maybe<T>.flatMap(mapper: (T) -> Maybe<R>): Maybe<R> =
     maybe { emitter ->
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<T>, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/FlatMapObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/FlatMapObservable.kt
@@ -1,7 +1,6 @@
 package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.base.Observer
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
@@ -13,7 +12,7 @@ import com.badoo.reaktive.observable.observable
 
 fun <T, R> Maybe<T>.flatMapObservable(mapper: (T) -> Observable<R>): Observable<R> =
     observable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<T>, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Map.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Map.kt
@@ -1,13 +1,12 @@
 package com.badoo.reaktive.maybe
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 
 fun <T, R> Maybe<T>.map(mapper: (T) -> R): Maybe<R> =
     maybe { emitter ->
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<T>, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/NotNull.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/NotNull.kt
@@ -1,12 +1,11 @@
 package com.badoo.reaktive.maybe
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 
 fun <T : Any> Maybe<T?>.notNull(): Maybe<T> =
     maybe { emitter ->
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<T?>, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/ObserveOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/ObserveOn.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.maybe
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
@@ -13,7 +12,7 @@ fun <T> Maybe<T>.observeOn(scheduler: Scheduler): Maybe<T> =
         val executor = scheduler.newExecutor()
         disposables += executor
 
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<T> {
                 override fun onSubscribe(disposable: Disposable) {
                     disposables += disposable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/OnErrorResumeNext.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/OnErrorResumeNext.kt
@@ -10,7 +10,7 @@ import com.badoo.reaktive.disposable.Disposable
 
 fun <T> Maybe<T>.onErrorResumeNext(nextSupplier: (Throwable) -> Maybe<T>): Maybe<T> =
     maybe { emitter ->
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<T>, SuccessCallback<T> by emitter, CompleteCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Retry.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Retry.kt
@@ -8,7 +8,7 @@ import com.badoo.reaktive.disposable.Disposable
 
 fun <T> Maybe<T>.retry(predicate: (attempt: Int, Throwable) -> Boolean = { _, _ -> true }): Maybe<T> =
     maybe { emitter ->
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<T>, SuccessCallback<T> by emitter, CompleteCallback by emitter {
                 private val retry = Retry(emitter, predicate)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/SwitchIfEmpty.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/SwitchIfEmpty.kt
@@ -10,7 +10,7 @@ import com.badoo.reaktive.single.asMaybe
 
 fun <T> Maybe<T>.switchIfEmpty(other: Maybe<T>): Maybe<T> =
     maybe { emitter ->
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<T>, SuccessCallback<T> by emitter, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/ThreadLocal.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/ThreadLocal.kt
@@ -1,7 +1,6 @@
 package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.base.exceptions.CompositeException
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.utils.ThreadLocalStorage
@@ -14,7 +13,7 @@ fun <T> Maybe<T>.threadLocal(): Maybe<T> =
         val emitterStorage = ThreadLocalStorage(it)
         disposables += emitterStorage
 
-        subscribeSafe(
+        subscribe(
             object : MaybeObserver<T> {
                 override fun onSubscribe(disposable: Disposable) {
                     disposables += disposable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/AsCompletable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/AsCompletable.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.completable.completable
@@ -8,7 +7,7 @@ import com.badoo.reaktive.disposable.Disposable
 
 fun Observable<*>.asCompletable(): Completable =
     completable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<Any?>, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Collect.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Collect.kt
@@ -1,7 +1,6 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.base.ErrorCallback
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.single.Single
@@ -10,7 +9,7 @@ import com.badoo.reaktive.utils.ObjectReference
 
 fun <T, C> Observable<T>.collect(initialCollection: C, accumulator: (C, T) -> C): Single<C> =
     single { emitter ->
-        subscribeSafe(
+        subscribe(
             object : ObjectReference<C>(initialCollection), ObservableObserver<T>, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/CombineLatest.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/CombineLatest.kt
@@ -2,7 +2,6 @@
 
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.utils.SharedList
@@ -59,7 +58,7 @@ fun <T, R> Collection<Observable<T>>.combineLatest(mapper: (List<T>) -> R): Obse
             }
 
         forEachIndexed { index, source ->
-            source.subscribeSafe(
+            source.subscribe(
                 object : ObservableObserver<T> {
                     override fun onSubscribe(disposable: Disposable) {
                         disposables += disposable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ConcatMap.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ConcatMap.kt
@@ -18,7 +18,7 @@ fun <T, R> Observable<T>.concatMap(mapper: (T) -> Observable<R>): Observable<R> 
 
         val state = AtomicReference(ConcatMapState<T>())
 
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, ErrorCallback by serializedEmitter {
                 val mappedObserver =
                     object : ObservableObserver<R>, Observer by this, ObservableCallbacks<R> by serializedEmitter {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Debounce.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Debounce.kt
@@ -2,7 +2,6 @@
 
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
@@ -17,7 +16,7 @@ fun <T> Observable<T>.debounce(timeoutMillis: Long, scheduler: Scheduler): Obser
         val executor = scheduler.newExecutor()
         disposables += executor
 
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T> {
                 private val pendingValue = AtomicReference<DebouncePendingValue<T>?>(null)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DebounceWithSelector.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DebounceWithSelector.kt
@@ -21,7 +21,7 @@ fun <T> Observable<T>.debounce(debounceSelector: (T) -> Completable): Observable
 
         val serializedEmitter = emitter.serialize()
 
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, ErrorCallback by serializedEmitter {
                 private val pendingValue = AtomicReference<DebouncePendingValue<T>?>(null)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Delay.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Delay.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
@@ -12,7 +11,7 @@ fun <T> Observable<T>.delay(delayMillis: Long, scheduler: Scheduler, delayError:
         val executor = scheduler.newExecutor()
         disposables += executor
 
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T> {
                 override fun onSubscribe(disposable: Disposable) {
                     disposables += disposable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DistinctUntilChanged.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DistinctUntilChanged.kt
@@ -1,11 +1,9 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.utils.ObjectReference
 import com.badoo.reaktive.utils.Uninitialized
-import com.badoo.reaktive.utils.atomic.AtomicReference
 
 fun <T> Observable<T>.distinctUntilChanged(comparator: (T, T) -> Boolean = ::equals): Observable<T> =
     distinctUntilChanged({ it }, comparator)
@@ -15,7 +13,7 @@ fun <T, R> Observable<T>.distinctUntilChanged(
     comparator: (R, R) -> Boolean = ::equals
 ): Observable<T> =
     observable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, CompletableCallbacks by emitter {
                 val cache = ObjectReference<Any?>(Uninitialized)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DoOnBefore.kt
@@ -50,7 +50,7 @@ fun <T> Observable<T>.doOnBeforeSubscribe(action: (Disposable) -> Unit): Observa
 
 fun <T> Observable<T>.doOnBeforeNext(consumer: (T) -> Unit): Observable<T> =
     observable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)
@@ -69,7 +69,7 @@ fun <T> Observable<T>.doOnBeforeNext(consumer: (T) -> Unit): Observable<T> =
 
 fun <T> Observable<T>.doOnBeforeComplete(action: () -> Unit): Observable<T> =
     observable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, ValueCallback<T> by emitter, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)
@@ -86,7 +86,7 @@ fun <T> Observable<T>.doOnBeforeComplete(action: () -> Unit): Observable<T> =
 
 fun <T> Observable<T>.doOnBeforeError(consumer: (Throwable) -> Unit): Observable<T> =
     observable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, ValueCallback<T> by emitter, CompleteCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)
@@ -103,7 +103,7 @@ fun <T> Observable<T>.doOnBeforeError(consumer: (Throwable) -> Unit): Observable
 
 fun <T> Observable<T>.doOnBeforeTerminate(action: () -> Unit): Observable<T> =
     observable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, ValueCallback<T> by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Filter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Filter.kt
@@ -1,13 +1,12 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 
 fun <T> Observable<T>.filter(predicate: (T) -> Boolean): Observable<T> =
     observable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FirstOrComplete.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FirstOrComplete.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
@@ -12,7 +11,7 @@ fun <T> Observable<T>.firstOrComplete(): Maybe<T> =
         val disposableWrapper = DisposableWrapper()
         emitter.setDisposable(disposableWrapper)
 
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FirstOrDefault.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FirstOrDefault.kt
@@ -1,7 +1,6 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.base.ErrorCallback
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
@@ -26,7 +25,7 @@ internal inline fun <T> Observable<T>.firstOrAction(
         val disposableWrapper = DisposableWrapper()
         emitter.setDisposable(disposableWrapper)
 
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMap.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMap.kt
@@ -4,7 +4,6 @@ import com.badoo.reaktive.base.CompositeDisposableObserver
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.base.ValueCallback
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.utils.atomic.AtomicInt
@@ -36,7 +35,7 @@ fun <T, R> Observable<T>.flatMap(mapper: (T) -> Observable<R>): Observable<R> =
 
         emitter.setDisposable(upstreamObserver)
 
-        subscribeSafe(upstreamObserver)
+        subscribe(upstreamObserver)
     }
 
 fun <T, U, R> Observable<T>.flatMap(mapper: (T) -> Observable<U>, resultSelector: (T, U) -> R): Observable<R> =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMapCompletable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMapCompletable.kt
@@ -2,7 +2,6 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.Observer
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.completable.CompletableCallbacks
@@ -19,7 +18,7 @@ fun <T> Observable<T>.flatMapCompletable(mapper: (T) -> Completable): Completabl
         emitter.setDisposable(disposables)
         val serializedEmitter = emitter.serialize()
 
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, ErrorCallback by serializedEmitter {
                 private val activeSourceCount = AtomicInt(1)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMapMaybe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMapMaybe.kt
@@ -3,7 +3,6 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.base.CompositeDisposableObserver
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.Observer
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.maybe.Maybe
@@ -41,7 +40,7 @@ fun <T, R> Observable<T>.flatMapMaybe(mapper: (T) -> Maybe<R>): Observable<R> =
 
         emitter.setDisposable(upstreamObserver)
 
-        subscribeSafe(upstreamObserver)
+        subscribe(upstreamObserver)
     }
 
 fun <T, U, R> Observable<T>.flatMapMaybe(mapper: (T) -> Maybe<U>, resultSelector: (T, U) -> R): Observable<R> =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMapSingle.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMapSingle.kt
@@ -3,7 +3,6 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.base.CompositeDisposableObserver
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.Observer
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.single.Single
 import com.badoo.reaktive.single.SingleObserver
@@ -40,7 +39,7 @@ fun <T, R> Observable<T>.flatMapSingle(mapper: (T) -> Single<R>): Observable<R> 
 
         emitter.setDisposable(upstreamObserver)
 
-        subscribeSafe(upstreamObserver)
+        subscribe(upstreamObserver)
     }
 
 fun <T, U, R> Observable<T>.flatMapSingle(mapper: (T) -> Single<U>, resultSelector: (T, U) -> R): Observable<R> =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Map.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Map.kt
@@ -1,13 +1,12 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 
 fun <T, R> Observable<T>.map(mapper: (T) -> R): Observable<R> =
     observable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObserveOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObserveOn.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.BufferedExecutor
@@ -14,7 +13,7 @@ fun <T> Observable<T>.observeOn(scheduler: Scheduler): Observable<T> =
         val executor = scheduler.newExecutor()
         disposables += executor
 
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T> {
                 private val bufferedExecutor = BufferedExecutor(executor, emitter::onNext)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/OnErrorResumeNext.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/OnErrorResumeNext.kt
@@ -10,7 +10,7 @@ import com.badoo.reaktive.disposable.Disposable
 
 fun <T> Observable<T>.onErrorResumeNext(nextSupplier: (Throwable) -> Observable<T>): Observable<T> =
     observable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, ValueCallback<T> by emitter, CompleteCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Retry.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Retry.kt
@@ -8,7 +8,7 @@ import com.badoo.reaktive.disposable.Disposable
 
 fun <T> Observable<T>.retry(predicate: (attempt: Int, Throwable) -> Boolean = { _, _ -> true }): Observable<T> =
     observable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, ValueCallback<T> by emitter, CompleteCallback by emitter {
                 private val retry = Retry(emitter, predicate)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Sample.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Sample.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
@@ -13,7 +12,7 @@ fun <T> Observable<T>.sample(windowMillis: Long, scheduler: Scheduler): Observab
         val executor = scheduler.newExecutor()
         disposableWrapper += executor
 
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T> {
                 private val lastValue = AtomicReference<SampleLastValue<T>?>(null)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Scan.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Scan.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.utils.ObjectReference
@@ -8,7 +7,7 @@ import com.badoo.reaktive.utils.Uninitialized
 
 fun <T> Observable<T>.scan(accumulate: (acc: T, value: T) -> T): Observable<T> =
     observable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, CompletableCallbacks by emitter {
                 var cache = ObjectReference<Any?>(Uninitialized)
 
@@ -50,7 +49,7 @@ fun <T, R> Observable<T>.scan(getSeed: () -> R, accumulate: (acc: R, value: T) -
                 .also(emitter::onNext)
                 .let(::ObjectReference)
 
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, CompletableCallbacks by emitter {
 
                 override fun onNext(value: T) {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Skip.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Skip.kt
@@ -1,12 +1,11 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.utils.atomic.AtomicLong
 
 fun <T> Observable<T>.skip(count: Long): Observable<T> =
     observable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, ObservableCallbacks<T> by emitter {
                 private var remaining = AtomicLong(count)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SwitchIfEmpty.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SwitchIfEmpty.kt
@@ -15,7 +15,7 @@ fun <T> Observable<T>.switchIfEmpty(otherObservable: () -> Observable<T>): Obser
         val disposableWrapper = DisposableWrapper()
         emitter.setDisposable(disposableWrapper)
 
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, ErrorCallback by emitter {
                 private val isEmpty = AtomicBoolean(true)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SwitchMap.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SwitchMap.kt
@@ -22,7 +22,7 @@ fun <T, R> Observable<T>.switchMap(mapper: (T) -> Observable<R>): Observable<R> 
         val state = AtomicReference(SwitchMapState())
         val serializedEmitter = emitter.serialize()
 
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, ErrorCallback by serializedEmitter {
                 override fun onSubscribe(disposable: Disposable) {
                     disposables += disposable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/TakeObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/TakeObservable.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
@@ -18,7 +17,7 @@ fun <T> Observable<T>.take(limit: Int): Observable<T> {
 
         val remaining = AtomicInt(limit)
 
-        subscribeSafe(object : ObservableObserver<T>, CompletableCallbacks by emitter {
+        subscribe(object : ObservableObserver<T>, CompletableCallbacks by emitter {
             override fun onSubscribe(disposable: Disposable) {
                 disposableWrapper.set(disposable)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/TakeUntilObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/TakeUntilObservable.kt
@@ -1,7 +1,6 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.base.Observer
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
@@ -19,7 +18,7 @@ fun <T> Observable<T>.takeUntil(other: Observable<*>): Observable<T> =
                 }
             }
 
-        other.subscribeSafe(
+        other.subscribe(
             object : ObservableObserver<Any?>, Observer by upstreamObserver, CompletableCallbacks by upstreamObserver {
                 override fun onNext(value: Any?) {
                     upstreamObserver.onComplete()
@@ -27,5 +26,5 @@ fun <T> Observable<T>.takeUntil(other: Observable<*>): Observable<T> =
             }
         )
 
-        subscribeSafe(upstreamObserver)
+        subscribe(upstreamObserver)
     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/TakeUntilPredicate.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/TakeUntilPredicate.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
@@ -11,7 +10,7 @@ fun <T> Observable<T>.takeUntil(predicate: (T) -> Boolean): Observable<T> =
         val disposableWrapper = DisposableWrapper()
         emitter.setDisposable(disposableWrapper)
 
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     disposableWrapper.set(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ThreadLocal.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ThreadLocal.kt
@@ -1,7 +1,6 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.base.exceptions.CompositeException
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.utils.ThreadLocalStorage
@@ -14,7 +13,7 @@ fun <T> Observable<T>.threadLocal(): Observable<T> =
         val emitterStorage = ThreadLocalStorage(it)
         disposables += emitterStorage
 
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T> {
                 override fun onSubscribe(disposable: Disposable) {
                     disposables += disposable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Throttle.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Throttle.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.utils.atomic.AtomicLong
 import com.badoo.reaktive.utils.clock.Clock
@@ -10,7 +9,7 @@ fun <T> Observable<T>.throttle(windowMillis: Long): Observable<T> = throttle(win
 
 internal fun <T> Observable<T>.throttle(windowMillis: Long, clock: Clock): Observable<T> =
     observable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, ObservableCallbacks<T> by emitter {
                 private val lastTime = AtomicLong(-windowMillis)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/WithLatestFrom.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/WithLatestFrom.kt
@@ -40,7 +40,7 @@ fun <T, U, R> Observable<T>.withLatestFrom(
             )
         }
 
-        subscribeSafe(
+        subscribe(
             object : ObservableObserver<T>, CompletableCallbacks by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     disposables += disposable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Zip.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Zip.kt
@@ -2,7 +2,6 @@
 
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.utils.SharedList
@@ -79,7 +78,7 @@ fun <T, R> Collection<Observable<T>>.zip(mapper: (List<T>) -> R): Observable<R> 
             }
 
         forEachIndexed { index, source ->
-            source.subscribeSafe(
+            source.subscribe(
                 object : ObservableObserver<T> {
                     override fun onSubscribe(disposable: Disposable) {
                         disposables += disposable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/AsCompletable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/AsCompletable.kt
@@ -1,14 +1,13 @@
 package com.badoo.reaktive.single
 
 import com.badoo.reaktive.base.ErrorCallback
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.completable.completable
 import com.badoo.reaktive.disposable.Disposable
 
 fun Single<*>.asCompletable(): Completable =
     completable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : SingleObserver<Any?>, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/AsMaybe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/AsMaybe.kt
@@ -2,14 +2,13 @@ package com.badoo.reaktive.single
 
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.SuccessCallback
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.maybe.Maybe
 import com.badoo.reaktive.maybe.maybe
 
 fun <T> Single<T>.asMaybe(): Maybe<T> =
     maybe { emitter ->
-        subscribeSafe(
+        subscribe(
             object : SingleObserver<T>, SuccessCallback<T> by emitter, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/AsObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/AsObservable.kt
@@ -1,14 +1,13 @@
 package com.badoo.reaktive.single
 
 import com.badoo.reaktive.base.ErrorCallback
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.observable.observable
 
 fun <T> Single<T>.asObservable(): Observable<T> =
     observable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : SingleObserver<T>, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Delay.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Delay.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.single
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
@@ -12,7 +11,7 @@ fun <T> Single<T>.delay(delayMillis: Long, scheduler: Scheduler, delayError: Boo
         val executor = scheduler.newExecutor()
         disposables += executor
 
-        subscribeSafe(
+        subscribe(
             object : SingleObserver<T> {
                 override fun onSubscribe(disposable: Disposable) {
                     disposables += disposable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/DoOnBefore.kt
@@ -50,7 +50,7 @@ fun <T> Single<T>.doOnBeforeSubscribe(action: (Disposable) -> Unit): Single<T> =
 
 fun <T> Single<T>.doOnBeforeSuccess(consumer: (T) -> Unit): Single<T> =
     single { emitter ->
-        subscribeSafe(
+        subscribe(
             object : SingleObserver<T>, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)
@@ -69,7 +69,7 @@ fun <T> Single<T>.doOnBeforeSuccess(consumer: (T) -> Unit): Single<T> =
 
 fun <T> Single<T>.doOnBeforeError(consumer: (Throwable) -> Unit): Single<T> =
     single { emitter ->
-        subscribeSafe(
+        subscribe(
             object : SingleObserver<T>, SuccessCallback<T> by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)
@@ -86,7 +86,7 @@ fun <T> Single<T>.doOnBeforeError(consumer: (Throwable) -> Unit): Single<T> =
 
 fun <T> Single<T>.doOnBeforeTerminate(action: () -> Unit): Single<T> =
     single { emitter ->
-        subscribeSafe(
+        subscribe(
             object : SingleObserver<T> {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Filter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Filter.kt
@@ -1,7 +1,6 @@
 package com.badoo.reaktive.single
 
 import com.badoo.reaktive.base.ErrorCallback
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.maybe.Maybe
@@ -9,7 +8,7 @@ import com.badoo.reaktive.maybe.maybe
 
 fun <T> Single<T>.filter(predicate: (T) -> Boolean): Maybe<T> =
     maybe { emitter ->
-        subscribeSafe(
+        subscribe(
             object : SingleObserver<T>, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/FlatMap.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/FlatMap.kt
@@ -2,13 +2,12 @@ package com.badoo.reaktive.single
 
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.Observer
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 
 fun <T, R> Single<T>.flatMap(mapper: (T) -> Single<R>): Single<R> =
     single { emitter ->
-        subscribeSafe(
+        subscribe(
             object : SingleObserver<T>, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/FlatMapObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/FlatMapObservable.kt
@@ -2,7 +2,6 @@ package com.badoo.reaktive.single
 
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.Observer
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.observable.Observable
@@ -13,7 +12,7 @@ import com.badoo.reaktive.observable.observable
 
 fun <T, R> Single<T>.flatMapObservable(mapper: (T) -> Observable<R>): Observable<R> =
     observable { emitter ->
-        subscribeSafe(
+        subscribe(
             object : SingleObserver<T>, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Map.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Map.kt
@@ -1,13 +1,12 @@
 package com.badoo.reaktive.single
 
 import com.badoo.reaktive.base.ErrorCallback
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 
 fun <T, R> Single<T>.map(mapper: (T) -> R): Single<R> =
     single { emitter ->
-        subscribeSafe(
+        subscribe(
             object : SingleObserver<T>, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/NotNull.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/NotNull.kt
@@ -1,14 +1,13 @@
 package com.badoo.reaktive.single
 
 import com.badoo.reaktive.base.ErrorCallback
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.maybe.Maybe
 import com.badoo.reaktive.maybe.maybe
 
 fun <T : Any> Single<T?>.notNull(): Maybe<T> =
     maybe { emitter ->
-        subscribeSafe(
+        subscribe(
             object : SingleObserver<T?>, ErrorCallback by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/ObserveOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/ObserveOn.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.single
 
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
@@ -13,7 +12,7 @@ fun <T> Single<T>.observeOn(scheduler: Scheduler): Single<T> =
         val executor = scheduler.newExecutor()
         disposables += executor
 
-        subscribeSafe(
+        subscribe(
             object : SingleObserver<T> {
                 override fun onSubscribe(disposable: Disposable) {
                     disposables += disposable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/OnErrorResumeNext.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/OnErrorResumeNext.kt
@@ -9,7 +9,7 @@ import com.badoo.reaktive.disposable.Disposable
 
 fun <T> Single<T>.onErrorResumeNext(nextSupplier: (Throwable) -> Single<T>): Single<T> =
     single { emitter ->
-        subscribeSafe(
+        subscribe(
             object : SingleObserver<T>, SuccessCallback<T> by emitter {
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Retry.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Retry.kt
@@ -7,7 +7,7 @@ import com.badoo.reaktive.disposable.Disposable
 
 fun <T> Single<T>.retry(predicate: (attempt: Int, Throwable) -> Boolean = { _, _ -> true }): Single<T> =
     single { emitter ->
-        subscribeSafe(
+        subscribe(
             object : SingleObserver<T>, SuccessCallback<T> by emitter {
                 private val retry = Retry(emitter, predicate)
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/ThreadLocal.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/ThreadLocal.kt
@@ -1,7 +1,6 @@
 package com.badoo.reaktive.single
 
 import com.badoo.reaktive.base.exceptions.CompositeException
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.utils.ThreadLocalStorage
@@ -14,7 +13,7 @@ fun <T> Single<T>.threadLocal(): Single<T> =
         val emitterStorage = ThreadLocalStorage(it)
         disposables += emitterStorage
 
-        subscribeSafe(
+        subscribe(
             object : SingleObserver<T> {
                 override fun onSubscribe(disposable: Disposable) {
                     disposables += disposable


### PR DESCRIPTION
When using "by-emitter" builders it's safe to crash because the callback is already protected by try-catch. So we can just call `subscribe` instead of `subscribeSafe`. It removes nested try-catch block which also affects performance.