### PR TITLE
Introduce DisposableContainer

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/operator/Publish.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/operator/Publish.kt
@@ -3,6 +3,7 @@ package com.badoo.reaktive.base.operator
 import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.observable.ConnectableObservable
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.observable.ObservableObserver
@@ -30,7 +31,7 @@ internal fun <T> Observable<T>.publish(subjectFactory: () -> Subject<T>): Connec
             onConnect?.invoke(disposables)
 
             if ((oldState !is PublishState.Connected) && !disposables.isDisposed) {
-                this@publish.subscribeSafe(newState.subject.getObserver(disposables::add))
+                this@publish.subscribeSafe(newState.subject.getObserver { disposables.add(it) })
             }
         }
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Delay.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Delay.kt
@@ -2,6 +2,7 @@ package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
 
 fun Completable.delay(delayMillis: Long, scheduler: Scheduler, delayError: Boolean = false): Completable =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/DoOnBefore.kt
@@ -9,6 +9,7 @@ import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.doIfNotDisposed
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.utils.handleSourceError
 
 fun Completable.doOnBeforeSubscribe(action: (Disposable) -> Unit): Completable =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/ObserveOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/ObserveOn.kt
@@ -2,6 +2,7 @@ package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
 import com.badoo.reaktive.utils.freeze
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/SubscribeOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/SubscribeOn.kt
@@ -3,6 +3,7 @@ package com.badoo.reaktive.completable
 import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
 
 fun Completable.subscribeOn(scheduler: Scheduler): Completable =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/ThreadLocal.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/ThreadLocal.kt
@@ -3,6 +3,7 @@ package com.badoo.reaktive.completable
 import com.badoo.reaktive.base.exceptions.CompositeException
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.utils.ThreadLocalStorage
 import com.badoo.reaktive.utils.handleSourceError
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposable.kt
@@ -1,27 +1,33 @@
 package com.badoo.reaktive.disposable
 
 /**
- * Thread-safe collection of [Disposable]
+ * Thread-safe [Disposable] collection
  */
 @Suppress("EmptyDefaultConstructor")
 expect open class CompositeDisposable() : Disposable {
 
     /**
-     * Disposes the [CompositeDisposable] and all its [Disposable]s.
+     * Atomically disposes the collection and all its [Disposable]s.
      * All future [Disposable]s will be immediately disposed.
      */
     override fun dispose()
 
     /**
-     * Atomically either adds the specified [Disposable] or disposes it if container is already disposed.
-     * Also removes already disposed Disposables.
+     * Atomically either adds the specified [Disposable] or disposes it if container is already disposed
+     *
+     * @param disposable the [Disposable] to add
+     * @return true if [Disposable] was added to the collection, false otherwise
      */
-    fun add(disposable: Disposable)
+    fun add(disposable: Disposable): Boolean
 
     /**
-     * See [add]
+     * Atomically removes the specified [Disposable] from the collection.
+     *
+     * @param disposable the [Disposable] to remove
+     * @param dispose if true then the [Disposable] will be disposed if removed, default value is false
+     * @return true if [Disposable] was removed, false otherwise
      */
-    operator fun plusAssign(disposable: Disposable)
+    fun remove(disposable: Disposable, dispose: Boolean = false): Boolean
 
     /**
      * Atomically clears all the [Disposable]s
@@ -29,4 +35,9 @@ expect open class CompositeDisposable() : Disposable {
      * @param dispose if true then removed [Disposable]s will be disposed, default value is true
      */
     fun clear(dispose: Boolean = true)
+
+    /**
+     * Atomically removes already disposed [Disposable]s
+     */
+    fun purge()
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposableExt.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/CompositeDisposableExt.kt
@@ -1,0 +1,9 @@
+package com.badoo.reaktive.disposable
+
+operator fun CompositeDisposable.plusAssign(disposable: Disposable) {
+    add(disposable)
+}
+
+operator fun CompositeDisposable.minusAssign(disposable: Disposable) {
+    remove(disposable)
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Delay.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Delay.kt
@@ -2,6 +2,7 @@ package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
 
 fun <T> Maybe<T>.delay(delayMillis: Long, scheduler: Scheduler, delayError: Boolean = false): Maybe<T> =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DoOnBefore.kt
@@ -11,6 +11,7 @@ import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.doIfNotDisposed
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.utils.handleSourceError
 
 fun <T> Maybe<T>.doOnBeforeSubscribe(action: (Disposable) -> Unit): Maybe<T> =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/ObserveOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/ObserveOn.kt
@@ -2,6 +2,7 @@ package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
 import com.badoo.reaktive.utils.freeze
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/SubscribeOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/SubscribeOn.kt
@@ -3,6 +3,7 @@ package com.badoo.reaktive.maybe
 import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
 
 fun <T> Maybe<T>.subscribeOn(scheduler: Scheduler): Maybe<T> =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/ThreadLocal.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/ThreadLocal.kt
@@ -3,6 +3,7 @@ package com.badoo.reaktive.maybe
 import com.badoo.reaktive.base.exceptions.CompositeException
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.utils.ThreadLocalStorage
 import com.badoo.reaktive.utils.handleSourceError
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/CombineLatest.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/CombineLatest.kt
@@ -4,6 +4,7 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.Uninitialized
 import com.badoo.reaktive.utils.atomic.AtomicInt

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ConcatMap.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ConcatMap.kt
@@ -1,85 +1,98 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.base.ErrorCallback
-import com.badoo.reaktive.base.Observer
+import com.badoo.reaktive.base.ValueCallback
 import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.utils.ObjectReference
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import com.badoo.reaktive.utils.atomic.getAndUpdate
 import com.badoo.reaktive.utils.atomic.updateAndGet
 
 fun <T, R> Observable<T>.concatMap(mapper: (T) -> Observable<R>): Observable<R> =
     observable { emitter ->
-        val disposables = CompositeDisposable()
-        emitter.setDisposable(disposables)
-        val serializedEmitter = emitter.serialize()
-
-        val state = AtomicReference(ConcatMapState<T>())
-
-        subscribe(
-            object : ObservableObserver<T>, ErrorCallback by serializedEmitter {
-                val mappedObserver =
-                    object : ObservableObserver<R>, Observer by this, ObservableCallbacks<R> by serializedEmitter {
-                        override fun onComplete() {
-                            val oldState =
-                                state.getAndUpdate {
-                                    it.copy(
-                                        queue = it.queue.drop(1),
-                                        isMappedSourceActive = it.queue.isNotEmpty()
-                                    )
-                                }
-
-                            if (oldState.queue.isNotEmpty()) {
-                                mapAndSubscribe(oldState.queue[0])
-                            } else if (oldState.isUpstreamCompleted) {
-                                serializedEmitter.onComplete()
-                            }
-                        }
-                    }
-
-
-                override fun onSubscribe(disposable: Disposable) {
-                    disposables += disposable
-                }
-
-                override fun onNext(value: T) {
-                    val oldState =
-                        state.getAndUpdate {
-                            it.copy(
-                                queue = if (it.isMappedSourceActive) it.queue + value else it.queue,
-                                isMappedSourceActive = true
-                            )
-                        }
-
-                    if (!oldState.isMappedSourceActive) {
-                        mapAndSubscribe(value)
-                    }
-                }
-
-                override fun onComplete() {
-                    val newState =
-                        state.updateAndGet {
-                            it.copy(isUpstreamCompleted = true)
-                        }
-
-                    if (newState.isUpstreamCompleted && !newState.isMappedSourceActive) {
-                        serializedEmitter.onComplete()
-                    }
-                }
-
-                private fun mapAndSubscribe(value: T) {
-                    serializedEmitter.tryCatch(block = { mapper(value) }) {
-                        it.subscribeSafe(mappedObserver)
-                    }
-                }
-            }
-        )
+        val upstreamObserver = ConcatMapObserver(emitter.serialize(), mapper)
+        emitter.setDisposable(upstreamObserver)
+        subscribe(upstreamObserver)
     }
 
-private data class ConcatMapState<T>(
-    val queue: List<T> = emptyList(),
-    val isMappedSourceActive: Boolean = false,
-    val isUpstreamCompleted: Boolean = false
-)
+private class ConcatMapObserver<in T, in R>(
+    private val callbacks: ObservableCallbacks<R>,
+    private val mapper: (T) -> Observable<R>
+) : CompositeDisposable(), ObservableObserver<T>, ErrorCallback by callbacks {
+
+    private val state = AtomicReference(State<T>())
+
+    override fun onSubscribe(disposable: Disposable) {
+        add(disposable)
+    }
+
+    override fun onNext(value: T) {
+        val oldState =
+            state.getAndUpdate {
+                it.copy(
+                    queue = if (it.isMappedSourceActive) it.queue + value else it.queue,
+                    isMappedSourceActive = true
+                )
+            }
+
+        if (!oldState.isMappedSourceActive) {
+            mapAndSubscribe(value)
+        }
+    }
+
+    override fun onComplete() {
+        val newState =
+            state.updateAndGet {
+                it.copy(isUpstreamCompleted = true)
+            }
+
+        if (newState.isUpstreamCompleted && !newState.isMappedSourceActive) {
+            callbacks.onComplete()
+        }
+    }
+
+    private fun mapAndSubscribe(value: T) {
+        callbacks.tryCatch(block = { mapper(value) }) {
+            it.subscribeSafe(InnerObserver())
+        }
+    }
+
+    private data class State<out T>(
+        val queue: List<T> = emptyList(),
+        val isMappedSourceActive: Boolean = false,
+        val isUpstreamCompleted: Boolean = false
+    )
+
+    private inner class InnerObserver :
+        ObjectReference<Disposable?>(null),
+        ObservableObserver<R>,
+        ValueCallback<R> by callbacks,
+        ErrorCallback by callbacks {
+
+        override fun onSubscribe(disposable: Disposable) {
+            value = disposable
+            add(disposable)
+        }
+
+        override fun onComplete() {
+            remove(value!!)
+
+            val oldState =
+                state.getAndUpdate {
+                    it.copy(
+                        queue = it.queue.drop(1),
+                        isMappedSourceActive = it.queue.isNotEmpty()
+                    )
+                }
+
+            if (oldState.queue.isNotEmpty()) {
+                mapAndSubscribe(oldState.queue[0])
+            } else if (oldState.isUpstreamCompleted) {
+                callbacks.onComplete()
+            }
+        }
+    }
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Debounce.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Debounce.kt
@@ -4,6 +4,7 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import com.badoo.reaktive.utils.atomic.getAndUpdate

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DebounceWithSelector.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DebounceWithSelector.kt
@@ -8,6 +8,7 @@ import com.badoo.reaktive.completable.CompletableObserver
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import com.badoo.reaktive.utils.atomic.getAndUpdate
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Delay.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Delay.kt
@@ -2,6 +2,7 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
 
 fun <T> Observable<T>.delay(delayMillis: Long, scheduler: Scheduler, delayError: Boolean = false): Observable<T> =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DoOnBefore.kt
@@ -11,6 +11,7 @@ import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.doIfNotDisposed
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.utils.handleSourceError
 
 fun <T> Observable<T>.doOnBeforeSubscribe(action: (Disposable) -> Unit): Observable<T> =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMap.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMap.kt
@@ -1,42 +1,62 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.base.CompositeDisposableObserver
 import com.badoo.reaktive.base.ErrorCallback
-import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.base.ValueCallback
 import com.badoo.reaktive.base.tryCatch
-import com.badoo.reaktive.completable.CompletableCallbacks
+import com.badoo.reaktive.disposable.CompositeDisposable
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.utils.ObjectReference
 import com.badoo.reaktive.utils.atomic.AtomicInt
 
 fun <T, R> Observable<T>.flatMap(mapper: (T) -> Observable<R>): Observable<R> =
     observable { emitter ->
-        val serializedEmitter = emitter.serialize()
-
-        val upstreamObserver =
-            object : CompositeDisposableObserver(), ObservableObserver<T>, ErrorCallback by serializedEmitter {
-                private val activeSourceCount = AtomicInt(1)
-
-                private val mappedObserver =
-                    object : ObservableObserver<R>, Observer by this, CompletableCallbacks by this,
-                        ValueCallback<R> by serializedEmitter {
-                    }
-
-                override fun onNext(value: T) {
-                    activeSourceCount.addAndGet(1)
-                    serializedEmitter.tryCatch { mapper(value).subscribe(mappedObserver) }
-                }
-
-                override fun onComplete() {
-                    if (activeSourceCount.addAndGet(-1) <= 0) {
-                        serializedEmitter.onComplete()
-                    }
-                }
-            }
-
+        val upstreamObserver = FlatMapObserver(emitter.serialize(), mapper)
         emitter.setDisposable(upstreamObserver)
-
         subscribe(upstreamObserver)
     }
+
+private class FlatMapObserver<in T, in R>(
+    private val callbacks: ObservableCallbacks<R>,
+    private val mapper: (T) -> Observable<R>
+) : CompositeDisposable(), ObservableObserver<T>, ErrorCallback by callbacks {
+
+    private val activeSourceCount = AtomicInt(1)
+
+    override fun onSubscribe(disposable: Disposable) {
+        add(disposable)
+    }
+
+    override fun onNext(value: T) {
+        activeSourceCount.addAndGet(1)
+
+        callbacks.tryCatch {
+            mapper(value).subscribe(InnerObserver())
+        }
+    }
+
+    override fun onComplete() {
+        if (activeSourceCount.addAndGet(-1) <= 0) {
+            callbacks.onComplete()
+        }
+    }
+
+    private inner class InnerObserver :
+        ObjectReference<Disposable?>(null),
+        ObservableObserver<R>,
+        ErrorCallback by callbacks,
+        ValueCallback<R> by callbacks {
+
+        override fun onSubscribe(disposable: Disposable) {
+            value = disposable
+            add(disposable)
+        }
+
+        override fun onComplete() {
+            remove(value!!)
+            this@FlatMapObserver.onComplete()
+        }
+    }
+}
 
 fun <T, U, R> Observable<T>.flatMap(mapper: (T) -> Observable<U>, resultSelector: (T, U) -> R): Observable<R> =
     flatMap { t ->

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMapCompletable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMapCompletable.kt
@@ -1,7 +1,6 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.base.ErrorCallback
-import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.completable.CompletableCallbacks
@@ -10,36 +9,49 @@ import com.badoo.reaktive.completable.completable
 import com.badoo.reaktive.completable.serialize
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.utils.ObjectReference
 import com.badoo.reaktive.utils.atomic.AtomicInt
 
 fun <T> Observable<T>.flatMapCompletable(mapper: (T) -> Completable): Completable =
     completable { emitter ->
-        val disposables = CompositeDisposable()
-        emitter.setDisposable(disposables)
-        val serializedEmitter = emitter.serialize()
-
-        subscribe(
-            object : ObservableObserver<T>, ErrorCallback by serializedEmitter {
-                private val activeSourceCount = AtomicInt(1)
-
-                private val mappedObserver: CompletableObserver =
-                    object : CompletableObserver, Observer by this, CompletableCallbacks by this {
-                    }
-
-                override fun onSubscribe(disposable: Disposable) {
-                    disposables += disposable
-                }
-
-                override fun onNext(value: T) {
-                    activeSourceCount.addAndGet(1)
-                    serializedEmitter.tryCatch(block = { mapper(value).subscribe(mappedObserver) })
-                }
-
-                override fun onComplete() {
-                    if (activeSourceCount.addAndGet(-1) <= 0) {
-                        serializedEmitter.onComplete()
-                    }
-                }
-            }
-        )
+        val upstreamObserver = FlatMapCompletableObserver(emitter.serialize(), mapper)
+        emitter.setDisposable(upstreamObserver)
+        subscribe(upstreamObserver)
     }
+
+private class FlatMapCompletableObserver<in T>(
+    private val callbacks: CompletableCallbacks,
+    private val mapper: (T) -> Completable
+) : CompositeDisposable(), ObservableObserver<T>, ErrorCallback by callbacks {
+
+    private val activeSourceCount = AtomicInt(1)
+
+    override fun onSubscribe(disposable: Disposable) {
+        add(disposable)
+    }
+
+    override fun onNext(value: T) {
+        activeSourceCount.addAndGet(1)
+        callbacks.tryCatch {
+            mapper(value).subscribe(InnerObserver())
+        }
+    }
+
+    override fun onComplete() {
+        if (activeSourceCount.addAndGet(-1) <= 0) {
+            callbacks.onComplete()
+        }
+    }
+
+    private inner class InnerObserver : ObjectReference<Disposable?>(null), CompletableObserver, ErrorCallback by callbacks {
+        override fun onSubscribe(disposable: Disposable) {
+            value = disposable
+            add(disposable)
+        }
+
+        override fun onComplete() {
+            remove(value!!)
+            this@FlatMapCompletableObserver.onComplete()
+        }
+    }
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObserveOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObserveOn.kt
@@ -2,6 +2,7 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.BufferedExecutor
 import com.badoo.reaktive.scheduler.Scheduler
 import com.badoo.reaktive.utils.freeze

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/RefCount.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/RefCount.kt
@@ -2,6 +2,7 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.utils.atomic.AtomicInt
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import com.badoo.reaktive.utils.atomic.getAndUpdate

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Sample.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Sample.kt
@@ -2,22 +2,23 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
 import com.badoo.reaktive.utils.atomic.AtomicReference
 
 fun <T> Observable<T>.sample(windowMillis: Long, scheduler: Scheduler): Observable<T> =
     observable { emitter ->
-        val disposableWrapper = CompositeDisposable()
-        emitter.setDisposable(disposableWrapper)
+        val disposables = CompositeDisposable()
+        emitter.setDisposable(disposables)
         val executor = scheduler.newExecutor()
-        disposableWrapper += executor
+        disposables += executor
 
         subscribe(
             object : ObservableObserver<T> {
                 private val lastValue = AtomicReference<SampleLastValue<T>?>(null)
 
                 override fun onSubscribe(disposable: Disposable) {
-                    disposableWrapper += disposable
+                    disposables += disposable
 
                     executor.submitRepeating(periodMillis = windowMillis) {
                         lastValue

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SubscribeOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SubscribeOn.kt
@@ -3,6 +3,7 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
 
 fun <T> Observable<T>.subscribeOn(scheduler: Scheduler): Observable<T> =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SwitchMap.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SwitchMap.kt
@@ -7,6 +7,7 @@ import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import com.badoo.reaktive.utils.atomic.update
 import com.badoo.reaktive.utils.atomic.updateAndGet

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/TakeUntilObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/TakeUntilObservable.kt
@@ -4,6 +4,7 @@ import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 
 fun <T> Observable<T>.takeUntil(other: Observable<*>): Observable<T> =
     observable {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ThreadLocal.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ThreadLocal.kt
@@ -3,6 +3,7 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.base.exceptions.CompositeException
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.utils.ThreadLocalStorage
 import com.badoo.reaktive.utils.handleSourceError
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/WithLatestFrom.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/WithLatestFrom.kt
@@ -1,11 +1,11 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.base.ErrorCallback
-import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.utils.Uninitialized
 import com.badoo.reaktive.utils.atomic.atomicList
 import com.badoo.reaktive.utils.atomic.update
@@ -21,7 +21,7 @@ fun <T, U, R> Observable<T>.withLatestFrom(
         val otherValues = atomicList<Any?>(List(others.size) { Uninitialized })
 
         others.forEachIndexed { index, source ->
-            source.subscribeSafe(
+            source.subscribe(
                 object : ObservableObserver<U>, ErrorCallback by emitter {
                     override fun onSubscribe(disposable: Disposable) {
                         disposables += disposable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Zip.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Zip.kt
@@ -4,6 +4,7 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicList
 import com.badoo.reaktive.utils.atomic.update

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Delay.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Delay.kt
@@ -2,6 +2,7 @@ package com.badoo.reaktive.single
 
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
 
 fun <T> Single<T>.delay(delayMillis: Long, scheduler: Scheduler, delayError: Boolean = false): Single<T> =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/DoOnBefore.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/DoOnBefore.kt
@@ -9,6 +9,7 @@ import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.DisposableWrapper
 import com.badoo.reaktive.disposable.doIfNotDisposed
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.utils.handleSourceError
 
 fun <T> Single<T>.doOnBeforeSubscribe(action: (Disposable) -> Unit): Single<T> =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/ObserveOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/ObserveOn.kt
@@ -2,6 +2,7 @@ package com.badoo.reaktive.single
 
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
 import com.badoo.reaktive.utils.freeze
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SubscribeOn.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SubscribeOn.kt
@@ -3,6 +3,7 @@ package com.badoo.reaktive.single
 import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
 
 fun <T> Single<T>.subscribeOn(scheduler: Scheduler): Single<T> =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/ThreadLocal.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/ThreadLocal.kt
@@ -3,6 +3,7 @@ package com.badoo.reaktive.single
 import com.badoo.reaktive.base.exceptions.CompositeException
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.utils.ThreadLocalStorage
 import com.badoo.reaktive.utils.handleSourceError
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/disposable/CompositeDisposableTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/disposable/CompositeDisposableTest.kt
@@ -38,6 +38,22 @@ class CompositeDisposableTest {
     }
 
     @Test
+    fun add_returns_true_WHEN_not_disposed() {
+        val result = composite.add(disposable1)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun add_returns_false_WHEN_already_disposed() {
+        composite.dispose()
+
+        val result = composite.add(disposable1)
+
+        assertFalse(result)
+    }
+
+    @Test
     fun isDisposed_returns_false_WHEN_not_disposed() {
         assertFalse(composite.isDisposed)
     }
@@ -82,4 +98,199 @@ class CompositeDisposableTest {
         assertFalse(disposable1.isDisposed)
         assertFalse(disposable2.isDisposed)
     }
+
+    @Test
+    fun disposes_disposable_WHEN_contains_and_remove_with_true() {
+        composite += disposable1
+        composite += disposable2
+
+        composite.remove(disposable1, dispose = true)
+
+        assertTrue(disposable1.isDisposed)
+    }
+
+    @Test
+    fun does_not_dispose_other_disposables_WHEN_remove_with_true() {
+        composite += disposable1
+        composite += disposable2
+
+        composite.remove(disposable1, dispose = true)
+
+        assertFalse(disposable2.isDisposed)
+    }
+
+    @Test
+    fun does_not_dispose_disposable_WHEN_not_contains_and_remove_with_true() {
+        composite.remove(disposable1, dispose = true)
+
+        assertFalse(disposable1.isDisposed)
+    }
+
+    @Test
+    fun remove_returns_true_WHEN_contains_disposable_and_with_false() {
+        composite += disposable1
+
+        val result = composite.remove(disposable1, dispose = false)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun remove_returns_true_WHEN_contains_disposable_and_with_true() {
+        composite += disposable1
+
+        val result = composite.remove(disposable1, dispose = true)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun remove_returns_false_WHEN_not_contains_disposable_and_with_true() {
+        composite += disposable2
+
+        val result = composite.remove(disposable1, dispose = true)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun remove_returns_false_WHEN_not_contains_disposable_and_with_false() {
+        composite += disposable2
+
+        val result = composite.remove(disposable1, dispose = false)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun remove_returns_false_WHEN_disposable_was_added_and_with_false_and_already_disposed() {
+        composite += disposable1
+        composite.dispose()
+
+        val result = composite.remove(disposable1, dispose = false)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun remove_returns_false_WHEN_disposable_was_added_and_with_true_and_already_disposed() {
+        composite += disposable1
+        composite.dispose()
+
+        val result = composite.remove(disposable1, dispose = true)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun disposes_disposable_WHEN_remove_non_existing_disposable_and_then_remove_existing_disposable_with_true() {
+        composite += disposable1
+
+        composite.remove(disposable2)
+        composite.remove(disposable1, dispose = true)
+
+        assertTrue(disposable1.isDisposed)
+    }
+
+    @Test
+    fun checks_all_disposables_WHEN_purge() {
+        var isChecked1 = false
+
+        val disposable1 =
+            emptyDisposable {
+                isChecked1 = true
+                false
+            }
+
+        var isChecked2 = false
+
+        val disposable2 =
+            emptyDisposable {
+                isChecked2 = true
+                false
+            }
+
+        composite += disposable1
+        composite += disposable2
+
+        composite.purge()
+
+        assertTrue(isChecked1)
+        assertTrue(isChecked2)
+    }
+
+    @Test
+    fun does_not_check_disposed_disposables_WHEN_purge_second_time() {
+        var isChecked1: Boolean
+
+        val disposable1 =
+            emptyDisposable {
+                isChecked1 = true
+                true
+            }
+
+        val disposable2 = emptyDisposable { false }
+
+        var isChecked3: Boolean
+
+        val disposable3 =
+            emptyDisposable {
+                isChecked3 = true
+                true
+            }
+
+        composite += disposable1
+        composite += disposable2
+        composite += disposable3
+        composite.purge()
+        isChecked1 = false
+        isChecked3 = false
+
+        composite.purge()
+
+        assertFalse(isChecked1)
+        assertFalse(isChecked3)
+    }
+
+    @Test
+    fun checks_not_disposed_disposables_WHEN_purge_second_time() {
+        var isChecked1: Boolean
+
+        val disposable1 =
+            emptyDisposable {
+                isChecked1 = true
+                false
+            }
+
+        val disposable2 = emptyDisposable { true }
+
+        var isChecked3: Boolean
+
+        val disposable3 =
+            emptyDisposable {
+                isChecked3 = true
+                false
+            }
+
+        composite += disposable1
+        composite += disposable2
+        composite += disposable3
+        composite.purge()
+        isChecked1 = false
+        isChecked3 = false
+
+        composite.purge()
+
+        assertTrue(isChecked1)
+        assertTrue(isChecked3)
+    }
+
+    private fun emptyDisposable(isDisposed: () -> Boolean): Disposable =
+        object : Disposable {
+            override val isDisposed: Boolean get() = isDisposed.invoke()
+
+            override fun dispose() {
+                // no-op
+            }
+        }
 }

--- a/reaktive/src/iosCommonMain/kotlin/com/badoo/reaktive/scheduler/MainScheduler.kt
+++ b/reaktive/src/iosCommonMain/kotlin/com/badoo/reaktive/scheduler/MainScheduler.kt
@@ -2,6 +2,9 @@ package com.badoo.reaktive.scheduler
 
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.addTo
+import com.badoo.reaktive.disposable.minusAssign
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.utils.NANOS_IN_MILLI
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import com.badoo.reaktive.utils.atomic.getAndSet
@@ -14,21 +17,25 @@ internal class MainScheduler : Scheduler {
 
     private val disposables = CompositeDisposable()
 
-    override fun newExecutor(): Scheduler.Executor =
-        ExecutorImpl()
-            .also(disposables::add)
+    override fun newExecutor(): Scheduler.Executor = ExecutorImpl(disposables)
 
     override fun destroy() {
         disposables.dispose()
     }
 
-    private class ExecutorImpl : Scheduler.Executor {
+    private class ExecutorImpl(
+        private val disposables: CompositeDisposable
+    ) : Scheduler.Executor {
 
         private val operations = CompositeDisposable()
 
+        init {
+            disposables += this
+        }
+
         override fun submit(delayMillis: Long, task: () -> Unit) {
-            val operation = Operation(task)
-                .also(operations::add)
+            operations.purge()
+            val operation = Operation(task).addTo(operations)
             dispatch_after(
                 dispatch_time(DISPATCH_TIME_NOW, delayMillis.toNanos()),
                 dispatch_get_main_queue(),
@@ -37,10 +44,12 @@ internal class MainScheduler : Scheduler {
         }
 
         override fun submitRepeating(startDelayMillis: Long, periodMillis: Long, task: () -> Unit) {
-            val operation = Operation {
-                task()
-                submitRepeating(periodMillis, periodMillis, task)
-            }.also(operations::add)
+            operations.purge()
+            val operation =
+                Operation {
+                    task()
+                    submitRepeating(periodMillis, periodMillis, task)
+                }.addTo(operations)
             dispatch_after(
                 dispatch_time(DISPATCH_TIME_NOW, startDelayMillis.toNanos()),
                 dispatch_get_main_queue(),
@@ -57,6 +66,7 @@ internal class MainScheduler : Scheduler {
 
         override fun dispose() {
             operations.dispose()
+            disposables -= this
         }
 
         private class Operation(

--- a/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/scheduler/ExecutorServiceScheduler.kt
+++ b/reaktive/src/jvmCommonMain/kotlin/com/badoo/reaktive/scheduler/ExecutorServiceScheduler.kt
@@ -2,6 +2,8 @@ package com.badoo.reaktive.scheduler
 
 import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.disposable.minusAssign
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.utils.handleSourceError
 import java.util.concurrent.Future
 import java.util.concurrent.ScheduledExecutorService
@@ -13,9 +15,7 @@ internal class ExecutorServiceScheduler(
 
     private val disposables = CompositeDisposable()
 
-    override fun newExecutor(): Scheduler.Executor =
-        ExecutorImpl(executorServiceStrategy)
-            .also(disposables::add)
+    override fun newExecutor(): Scheduler.Executor = ExecutorImpl(disposables, executorServiceStrategy)
 
     override fun destroy() {
         disposables.dispose()
@@ -23,15 +23,20 @@ internal class ExecutorServiceScheduler(
     }
 
     private class ExecutorImpl(
+        private val disposables: CompositeDisposable,
         private val executorServiceStrategy: ExecutorServiceStrategy
     ) : Scheduler.Executor {
 
         @Volatile
         private var executor: ScheduledExecutorService? = executorServiceStrategy.get()
 
-        private val disposables = CompositeDisposable()
-        private val monitor: Any = disposables
+        private val taskDisposables = CompositeDisposable()
+        private val monitor: Any = taskDisposables
         override val isDisposed: Boolean get() = executor == null
+
+        init {
+            disposables += this
+        }
 
         override fun dispose() {
             if (executor != null) {
@@ -40,8 +45,9 @@ internal class ExecutorServiceScheduler(
                     executorToRecycle = executor ?: return
                     executor = null
                 }
-                disposables.dispose()
+                taskDisposables.dispose()
                 executorServiceStrategy.recycle(executorToRecycle)
+                disposables -= this
             }
         }
 
@@ -50,7 +56,7 @@ internal class ExecutorServiceScheduler(
                 it.schedule(wrapSchedulerTaskSafe(task), delayMillis, TimeUnit.MILLISECONDS)
             }
                 ?.toDisposable()
-                ?.also(disposables::add)
+                ?.let(taskDisposables::add)
         }
 
         override fun submitRepeating(startDelayMillis: Long, periodMillis: Long, task: () -> Unit) {
@@ -63,11 +69,11 @@ internal class ExecutorServiceScheduler(
                 )
             }
                 ?.toDisposable()
-                ?.also(disposables::add)
+                ?.let(taskDisposables::add)
         }
 
         override fun cancel() {
-            disposables.clear(true)
+            taskDisposables.clear(true)
         }
 
         private inline fun <T> executeIfNotRecycled(block: (ScheduledExecutorService) -> T): T? {

--- a/rxjava3-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Scheduler.kt
+++ b/rxjava3-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Scheduler.kt
@@ -1,51 +1,60 @@
 package com.badoo.reaktive.rxjavainterop
 
 import com.badoo.reaktive.disposable.CompositeDisposable
+import com.badoo.reaktive.disposable.minusAssign
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
 import java.util.concurrent.TimeUnit
 
 fun io.reactivex.rxjava3.core.Scheduler.asReaktive(): Scheduler =
-        object : Scheduler {
-            private val disposables = CompositeDisposable()
+    object : Scheduler {
+        private val disposables = CompositeDisposable()
 
-            override fun newExecutor(): Scheduler.Executor =
-                    this@asReaktive
-                        .createWorker()
-                        .asExecutor()
-                        .also(disposables::add)
+        override fun newExecutor(): Scheduler.Executor =
+            this@asReaktive
+                .createWorker()
+                .asExecutor(disposables)
 
-            override fun destroy() {
-                disposables.dispose()
-                this@asReaktive.shutdown()
-            }
+        override fun destroy() {
+            disposables.dispose()
+            this@asReaktive.shutdown()
+        }
+    }
+
+private fun io.reactivex.rxjava3.core.Scheduler.Worker.asExecutor(disposables: CompositeDisposable): Scheduler.Executor =
+    object : Scheduler.Executor {
+        private val taskDisposables = CompositeDisposable()
+        override val isDisposed: Boolean get() = taskDisposables.isDisposed
+
+        init {
+            disposables += this
         }
 
-private fun io.reactivex.rxjava3.core.Scheduler.Worker.asExecutor(): Scheduler.Executor =
-        object : Scheduler.Executor {
-            private val disposables = CompositeDisposable()
-            override val isDisposed: Boolean get() = disposables.isDisposed
-
-            override fun dispose() {
-                disposables.dispose()
-                this@asExecutor.dispose()
-            }
-
-            override fun submit(delayMillis: Long, task: () -> Unit) {
-                disposables +=
-                        this@asExecutor
-                            .schedule(task, delayMillis, TimeUnit.MILLISECONDS)
-                            .asReaktive()
-            }
-
-            override fun submitRepeating(startDelayMillis: Long, periodMillis: Long, task: () -> Unit) {
-                disposables +=
-                        this@asExecutor
-                            .schedulePeriodically(task, startDelayMillis, periodMillis, TimeUnit.MILLISECONDS)
-                            .asReaktive()
-            }
-
-            override fun cancel() {
-                disposables.clear()
-            }
+        override fun dispose() {
+            taskDisposables.dispose()
+            this@asExecutor.dispose()
+            disposables -= this
         }
-        
+
+        override fun submit(delayMillis: Long, task: () -> Unit) {
+            taskDisposables.purge()
+
+            taskDisposables +=
+                this@asExecutor
+                    .schedule(task, delayMillis, TimeUnit.MILLISECONDS)
+                    .asReaktive()
+        }
+
+        override fun submitRepeating(startDelayMillis: Long, periodMillis: Long, task: () -> Unit) {
+            taskDisposables.purge()
+
+            taskDisposables +=
+                this@asExecutor
+                    .schedulePeriodically(task, startDelayMillis, periodMillis, TimeUnit.MILLISECONDS)
+                    .asReaktive()
+        }
+
+        override fun cancel() {
+            taskDisposables.clear()
+        }
+    }

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/binder/KittenBinder.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/binder/KittenBinder.kt
@@ -1,6 +1,7 @@
 package com.badoo.reaktive.samplemppmodule.binder
 
 import com.badoo.reaktive.disposable.CompositeDisposable
+import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.observable.map
 import com.badoo.reaktive.observable.subscribe
 import com.badoo.reaktive.samplemppmodule.store.KittenStoreBuilder

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/store/KittenStoreImpl.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/store/KittenStoreImpl.kt
@@ -30,7 +30,7 @@ internal class KittenStoreImpl(
     }
 
     override fun accept(intent: Intent) {
-        execute(intent)?.also(disposables::add)
+        execute(intent)?.let(disposables::add)
     }
 
     private fun execute(intent: Intent): Disposable? =


### PR DESCRIPTION
- Deprecated `CompositeDisposable` (to avoid breaking changes)
- Implemented `DisposableContainer` with similar API as in RxJava

Commit 1: deprecated CompositeDisposable, introduced DisposableContainer, tests
Commit 2: replaced all usages