### PR TITLE
Update Kotlin to 1.3.60

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.reaktive_version = '1.1.0'
+    ext.reaktive_version = '1.1.1'
     ext.reaktive_group_id = 'com.badoo.reaktive'
 }
 

--- a/buildSrc/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/buildSrc/src/main/kotlin/Deps.kt
@@ -1,7 +1,7 @@
 object Deps {
 
-    private const val kotlinVersion = "1.3.50"
-    private const val coroutinesVersion = "1.3.2"
+    private const val kotlinVersion = "1.3.60"
+    private const val coroutinesVersion = "1.3.2-native-mt-1"
     private const val detektVersion = "1.1.1"
 
     val kotlin = Kotlin

--- a/buildSrc/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/buildSrc/src/main/kotlin/Deps.kt
@@ -1,7 +1,7 @@
 object Deps {
 
     private const val kotlinVersion = "1.3.60"
-    private const val coroutinesVersion = "1.3.2-native-mt-1"
+    private const val coroutinesVersion = "1.3.2-1.3.60"
     private const val detektVersion = "1.1.1"
 
     val kotlin = Kotlin


### PR DESCRIPTION
Version of coroutines used is `1.3.2-native-mt-1`. Let me know if I missed something: [Kotlin 1.3.60 release notes](https://blog.jetbrains.com/kotlin/2019/11/kotlin-1-3-60-released/).
Fixes #303 