### PR TITLE
Extract generic source tests

### DIFF
--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/base/SourceTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/base/SourceTests.kt
@@ -8,9 +8,16 @@ import com.badoo.reaktive.test.base.assertSubscribed
 import com.badoo.reaktive.test.base.hasSubscribers
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 interface SourceTests {
+
+    @Test
+    fun subscribes_to_upstream_WHEN_subscribed()
+
+    @Test
+    fun subscribes_to_upstream_WHEN_subscribed_second_time()
 
     @Test
     fun calls_onSubscribe_only_once_WHEN_subscribed()
@@ -32,6 +39,16 @@ class SourceTestsImpl<S : TestSource<*>>(
 ) : SourceTests {
 
     private val observer = upstream.subscribeTest()
+
+    override fun subscribes_to_upstream_WHEN_subscribed() {
+        assertEquals(1, upstream.observers.size)
+    }
+
+    override fun subscribes_to_upstream_WHEN_subscribed_second_time() {
+        upstream.subscribeTest()
+
+        assertEquals(2, upstream.observers.size)
+    }
 
     override fun calls_onSubscribe_only_once_WHEN_subscribed() {
         observer.assertSubscribed()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/base/SourceTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/base/SourceTests.kt
@@ -1,0 +1,59 @@
+package com.badoo.reaktive.base
+
+import com.badoo.reaktive.test.base.TestObserver
+import com.badoo.reaktive.test.base.TestSource
+import com.badoo.reaktive.test.base.assertDisposed
+import com.badoo.reaktive.test.base.assertError
+import com.badoo.reaktive.test.base.assertSubscribed
+import com.badoo.reaktive.test.base.hasSubscribers
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+interface SourceTests {
+
+    @Test
+    fun calls_onSubscribe_only_once_WHEN_subscribed()
+
+    @Test
+    fun produces_error_WHEN_upstream_produced_error()
+
+    @Test
+    fun unsubscribes_from_upstream_WHEN_disposed()
+
+    @Test
+    fun disposes_downstream_disposable_WHEN_upstream_produced_error()
+}
+
+@Ignore
+class SourceTestsImpl<S : TestSource<*>>(
+    private val upstream: S,
+    private val subscribeTest: S.() -> TestObserver
+) : SourceTests {
+
+    private val observer = upstream.subscribeTest()
+
+    override fun calls_onSubscribe_only_once_WHEN_subscribed() {
+        observer.assertSubscribed()
+    }
+
+    override fun produces_error_WHEN_upstream_produced_error() {
+        val error = Throwable()
+
+        upstream.onError(error)
+
+        observer.assertError(error)
+    }
+
+    override fun unsubscribes_from_upstream_WHEN_disposed() {
+        observer.dispose()
+
+        assertFalse(upstream.hasSubscribers)
+    }
+
+    override fun disposes_downstream_disposable_WHEN_upstream_produced_error() {
+        upstream.onError(Throwable())
+
+        observer.assertDisposed()
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AndThenTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AndThenTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class AndThenTest : CompletableToCompletableTests by CompletableToCompletableTests({ andThen(TestCompletable()) }) {
+class AndThenTest : CompletableToCompletableTests by CompletableToCompletableTestsImpl({ andThen(TestCompletable()) }) {
 
     private val upstream = TestCompletable()
     private val inner = TestCompletable()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AsMaybeTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AsMaybeTests.kt
@@ -1,3 +1,3 @@
 package com.badoo.reaktive.completable
 
-class AsMaybeTests : CompletableToMaybeTests by CompletableToMaybeTests({ asMaybe<Nothing>() })
+class AsMaybeTests : CompletableToMaybeTests by CompletableToMaybeTestsImpl({ asMaybe<Nothing>() })

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AsObservableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AsObservableTests.kt
@@ -1,3 +1,3 @@
 package com.badoo.reaktive.completable
 
-class AsObservableTests : CompletableToObservableTests by CompletableToObservableTests({ asObservable<Nothing>() })
+class AsObservableTests : CompletableToObservableTests by CompletableToObservableTestsImpl({ asObservable<Nothing>() })

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AsSingleSupplierTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AsSingleSupplierTests.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.single.assertSuccess
 import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
 
-class AsSingleSupplierTests : CompletableToSingleTests by CompletableToSingleTests({ asSingle { 0 } }) {
+class AsSingleSupplierTests : CompletableToSingleTests by CompletableToSingleTestsImpl({ asSingle { 0 } }) {
 
     val upstream = TestCompletable()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AsSingleValueTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AsSingleValueTests.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.test.single.assertSuccess
 import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
 
-class AsSingleValueTests : CompletableToSingleTests by CompletableToSingleTests({ asSingle(0) }) {
+class AsSingleValueTests : CompletableToSingleTests by CompletableToSingleTestsImpl({ asSingle(0) }) {
 
     @Test
     fun succeeds_with_default_value_WHEN_upstream_completed() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToCompletableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToCompletableTests.kt
@@ -1,76 +1,40 @@
 package com.badoo.reaktive.completable
 
+import com.badoo.reaktive.base.SourceTests
+import com.badoo.reaktive.base.SourceTestsImpl
 import com.badoo.reaktive.test.base.assertDisposed
-import com.badoo.reaktive.test.base.assertError
-import com.badoo.reaktive.test.base.assertSubscribed
-import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.assertComplete
 import com.badoo.reaktive.test.completable.test
+import kotlin.test.Ignore
 import kotlin.test.Test
-import kotlin.test.assertFalse
 
-interface CompletableToCompletableTests {
-
-    @Test
-    fun calls_onSubscribe_only_once_WHEN_subscribed()
+interface CompletableToCompletableTests : SourceTests {
 
     @Test
     fun completes_WHEN_upstream_completed()
 
     @Test
-    fun produces_error_WHEN_upstream_produced_error()
-
-    @Test
-    fun unsubscribes_from_upstream_WHEN_disposed()
-
-    @Test
     fun disposes_downstream_disposable_WHEN_upstream_completed()
+}
 
-    @Test
-    fun disposes_downstream_disposable_WHEN_upstream_produced_error()
+@Ignore
+class CompletableToCompletableTestsImpl(
+    transform: Completable.() -> Completable
+) : CompletableToCompletableTests, SourceTests by SourceTestsImpl(TestCompletable(), { transform().test() }) {
 
-    companion object {
-        operator fun invoke(transform: Completable.() -> Completable): CompletableToCompletableTests =
-            object : CompletableToCompletableTests {
-                private val upstream = TestCompletable()
-                private val observer = upstream.transform().test()
+    private val upstream = TestCompletable()
+    private val observer = upstream.transform().test()
 
-                override fun calls_onSubscribe_only_once_WHEN_subscribed() {
-                    observer.assertSubscribed()
-                }
+    override fun completes_WHEN_upstream_completed() {
+        upstream.onComplete()
 
-                override fun completes_WHEN_upstream_completed() {
-                    upstream.onComplete()
+        observer.assertComplete()
+    }
 
-                    observer.assertComplete()
-                }
+    override fun disposes_downstream_disposable_WHEN_upstream_completed() {
+        upstream.onComplete()
 
-                override fun produces_error_WHEN_upstream_produced_error() {
-                    val error = Throwable()
-
-                    upstream.onError(error)
-
-                    observer.assertError(error)
-                }
-
-                override fun unsubscribes_from_upstream_WHEN_disposed() {
-                    observer.dispose()
-
-                    assertFalse(upstream.hasSubscribers)
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_completed() {
-                    upstream.onComplete()
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_produced_error() {
-                    upstream.onError(Throwable())
-
-                    observer.assertDisposed()
-                }
-            }
+        observer.assertDisposed()
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToMaybeTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToMaybeTests.kt
@@ -1,77 +1,50 @@
 package com.badoo.reaktive.completable
 
+import com.badoo.reaktive.base.SourceTests
+import com.badoo.reaktive.base.SourceTestsImpl
 import com.badoo.reaktive.maybe.Maybe
 import com.badoo.reaktive.test.base.assertDisposed
 import com.badoo.reaktive.test.base.assertError
-import com.badoo.reaktive.test.base.assertSubscribed
-import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.maybe.assertComplete
 import com.badoo.reaktive.test.maybe.test
+import kotlin.test.Ignore
 import kotlin.test.Test
-import kotlin.test.assertFalse
 
-interface CompletableToMaybeTests {
-
-    @Test
-    fun calls_onSubscribe_only_once_WHEN_subscribed()
+interface CompletableToMaybeTests : SourceTests {
 
     @Test
     fun completes_WHEN_upstream_completed()
 
     @Test
-    fun produces_error_WHEN_upstream_produced_error()
-
-    @Test
-    fun unsubscribes_from_upstream_WHEN_disposed()
-
-    @Test
     fun disposes_downstream_disposable_WHEN_upstream_completed()
+}
 
-    @Test
-    fun disposes_downstream_disposable_WHEN_upstream_produced_error()
+@Ignore
+class CompletableToMaybeTestsImpl(
+    transform: Completable.() -> Maybe<*>
+) : CompletableToMaybeTests, SourceTests by SourceTestsImpl(TestCompletable(), { transform().test() }) {
 
-    companion object {
-        operator fun invoke(transform: Completable.() -> Maybe<*>): CompletableToMaybeTests =
-            object : CompletableToMaybeTests {
-                private val upstream = TestCompletable()
-                private val observer = upstream.transform().test()
+    private val upstream = TestCompletable()
+    private val observer = upstream.transform().test()
 
-                override fun calls_onSubscribe_only_once_WHEN_subscribed() {
-                    observer.assertSubscribed()
-                }
+    override fun completes_WHEN_upstream_completed() {
+        upstream.onComplete()
 
-                override fun completes_WHEN_upstream_completed() {
-                    upstream.onComplete()
+        observer.assertComplete()
+    }
 
-                    observer.assertComplete()
-                }
+    override fun produces_error_WHEN_upstream_produced_error() {
+        val error = Throwable()
 
-                override fun produces_error_WHEN_upstream_produced_error() {
-                    val error = Throwable()
+        upstream.onError(error)
 
-                    upstream.onError(error)
+        observer.assertError(error)
+    }
 
-                    observer.assertError(error)
-                }
+    override fun disposes_downstream_disposable_WHEN_upstream_completed() {
+        upstream.onComplete()
 
-                override fun unsubscribes_from_upstream_WHEN_disposed() {
-                    observer.dispose()
-
-                    assertFalse(upstream.hasSubscribers)
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_completed() {
-                    upstream.onComplete()
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_produced_error() {
-                    upstream.onError(Throwable())
-
-                    observer.assertDisposed()
-                }
-            }
+        observer.assertDisposed()
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToObservableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToObservableTests.kt
@@ -1,77 +1,40 @@
 package com.badoo.reaktive.completable
 
+import com.badoo.reaktive.base.SourceTests
+import com.badoo.reaktive.base.SourceTestsImpl
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.test.base.assertDisposed
-import com.badoo.reaktive.test.base.assertError
-import com.badoo.reaktive.test.base.assertSubscribed
-import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.observable.assertComplete
 import com.badoo.reaktive.test.observable.test
+import kotlin.test.Ignore
 import kotlin.test.Test
-import kotlin.test.assertFalse
 
-interface CompletableToObservableTests {
-
-    @Test
-    fun calls_onSubscribe_only_once_WHEN_subscribed()
+interface CompletableToObservableTests : SourceTests {
 
     @Test
     fun completes_WHEN_upstream_completed()
 
     @Test
-    fun produces_error_WHEN_upstream_produced_error()
-
-    @Test
-    fun unsubscribes_from_upstream_WHEN_disposed()
-
-    @Test
     fun disposes_downstream_disposable_WHEN_upstream_completed()
+}
 
-    @Test
-    fun disposes_downstream_disposable_WHEN_upstream_produced_error()
+@Ignore
+class CompletableToObservableTestsImpl(
+    transform: Completable.() -> Observable<*>
+) : CompletableToObservableTests, SourceTests by SourceTestsImpl(TestCompletable(), { transform().test() }) {
+    private val upstream = TestCompletable()
+    private val observer = upstream.transform().test()
 
-    companion object {
-        operator fun invoke(transform: Completable.() -> Observable<*>): CompletableToObservableTests =
-            object : CompletableToObservableTests {
-                private val upstream = TestCompletable()
-                private val observer = upstream.transform().test()
+    override fun completes_WHEN_upstream_completed() {
+        upstream.onComplete()
 
-                override fun calls_onSubscribe_only_once_WHEN_subscribed() {
-                    observer.assertSubscribed()
-                }
+        observer.assertComplete()
+    }
 
-                override fun completes_WHEN_upstream_completed() {
-                    upstream.onComplete()
+    override fun disposes_downstream_disposable_WHEN_upstream_completed() {
+        upstream.onComplete()
 
-                    observer.assertComplete()
-                }
-
-                override fun produces_error_WHEN_upstream_produced_error() {
-                    val error = Throwable()
-
-                    upstream.onError(error)
-
-                    observer.assertError(error)
-                }
-
-                override fun unsubscribes_from_upstream_WHEN_disposed() {
-                    observer.dispose()
-
-                    assertFalse(upstream.hasSubscribers)
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_completed() {
-                    upstream.onComplete()
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_produced_error() {
-                    upstream.onError(Throwable())
-
-                    observer.assertDisposed()
-                }
-            }
+        observer.assertDisposed()
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToSingleTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableToSingleTests.kt
@@ -1,67 +1,30 @@
 package com.badoo.reaktive.completable
 
+import com.badoo.reaktive.base.SourceTests
+import com.badoo.reaktive.base.SourceTestsImpl
 import com.badoo.reaktive.single.Single
 import com.badoo.reaktive.test.base.assertDisposed
-import com.badoo.reaktive.test.base.assertError
-import com.badoo.reaktive.test.base.assertSubscribed
-import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.single.test
+import kotlin.test.Ignore
 import kotlin.test.Test
-import kotlin.test.assertFalse
 
-interface CompletableToSingleTests {
-
-    @Test
-    fun calls_onSubscribe_only_once_WHEN_subscribed()
-
-    @Test
-    fun produces_error_WHEN_upstream_produced_error()
-
-    @Test
-    fun unsubscribes_from_upstream_WHEN_disposed()
+interface CompletableToSingleTests : SourceTests {
 
     @Test
     fun disposes_downstream_disposable_WHEN_upstream_completed()
+}
 
-    @Test
-    fun disposes_downstream_disposable_WHEN_upstream_produced_error()
+@Ignore
+class CompletableToSingleTestsImpl(
+    transform: Completable.() -> Single<*>
+) : CompletableToSingleTests, SourceTests by SourceTestsImpl(TestCompletable(), { transform().test() }) {
+    private val upstream = TestCompletable()
+    private val observer = upstream.transform().test()
 
-    companion object {
-        operator fun invoke(transform: Completable.() -> Single<*>): CompletableToSingleTests =
-            object : CompletableToSingleTests {
-                private val upstream = TestCompletable()
-                private val observer = upstream.transform().test()
+    override fun disposes_downstream_disposable_WHEN_upstream_completed() {
+        upstream.onComplete()
 
-                override fun calls_onSubscribe_only_once_WHEN_subscribed() {
-                    observer.assertSubscribed()
-                }
-
-                override fun produces_error_WHEN_upstream_produced_error() {
-                    val error = Throwable()
-
-                    upstream.onError(error)
-
-                    observer.assertError(error)
-                }
-
-                override fun unsubscribes_from_upstream_WHEN_disposed() {
-                    observer.dispose()
-
-                    assertFalse(upstream.hasSubscribers)
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_completed() {
-                    upstream.onComplete()
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_produced_error() {
-                    upstream.onError(Throwable())
-
-                    observer.assertDisposed()
-                }
-            }
+        observer.assertDisposed()
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/ConcatTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/ConcatTests.kt
@@ -10,7 +10,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class ConcatTests : CompletableToCompletableTests by CompletableToCompletableTests({ concat(this) }) {
+class ConcatTests : CompletableToCompletableTests by CompletableToCompletableTestsImpl({ concat(this) }) {
 
     private val upstream1 = TestCompletable()
     private val upstream2 = TestCompletable()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DelayTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DelayTest.kt
@@ -10,7 +10,7 @@ import com.badoo.reaktive.test.scheduler.TestScheduler
 import kotlin.test.Test
 
 class DelayTest :
-    CompletableToCompletableTests by CompletableToCompletableTests({ delay(0L, TestScheduler()) }),
+    CompletableToCompletableTests by CompletableToCompletableTestsImpl({ delay(0L, TestScheduler()) }),
     DelayErrorTests by DelayErrorTests(
         TestCompletable(),
         { delayMillis, scheduler, delayError -> delay(delayMillis, scheduler, delayError).test() }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeCompleteTest.kt
@@ -4,14 +4,14 @@ import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.completable.DefaultCompletableObserver
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.test
-import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import com.badoo.reaktive.utils.SharedList
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class DoOnBeforeCompleteTest
-    : CompletableToCompletableTests by CompletableToCompletableTests({ doOnBeforeComplete {} }) {
+    : CompletableToCompletableTests by CompletableToCompletableTestsImpl({ doOnBeforeComplete {} }) {
 
     private val upstream = TestCompletable()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeDisposeTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DoOnBeforeDisposeTest
-    : CompletableToCompletableTests by CompletableToCompletableTests({ doOnBeforeDispose {} }) {
+    : CompletableToCompletableTests by CompletableToCompletableTestsImpl({ doOnBeforeDispose {} }) {
 
     private val upstream = TestCompletable()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeErrorTest.kt
@@ -4,8 +4,8 @@ import com.badoo.reaktive.base.exceptions.CompositeException
 import com.badoo.reaktive.test.completable.DefaultCompletableObserver
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.test
-import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import com.badoo.reaktive.utils.SharedList
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -13,7 +13,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DoOnBeforeErrorTest
-    : CompletableToCompletableTests by CompletableToCompletableTests({ doOnBeforeError {} }) {
+    : CompletableToCompletableTests by CompletableToCompletableTestsImpl({ doOnBeforeError {} }) {
 
     private val upstream = TestCompletable()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeFinallyTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DoOnBeforeFinallyTest
-    : CompletableToCompletableTests by CompletableToCompletableTests({ doOnBeforeFinally {} }) {
+    : CompletableToCompletableTests by CompletableToCompletableTestsImpl({ doOnBeforeFinally {} }) {
 
     private val upstream = TestCompletable()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeSubscribeTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class DoOnBeforeSubscribeTest
-    : CompletableToCompletableTests by CompletableToCompletableTests({ doOnBeforeSubscribe {} }) {
+    : CompletableToCompletableTests by CompletableToCompletableTestsImpl({ doOnBeforeSubscribe {} }) {
 
     @Test
     fun calls_action_before_downstream_onSubscribe_WHEN_action_does_not_throw_exception() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeTerminateTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DoOnBeforeTerminateTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DoOnBeforeTerminateTest
-    : CompletableToCompletableTests by CompletableToCompletableTests({ doOnBeforeTerminate {} }) {
+    : CompletableToCompletableTests by CompletableToCompletableTestsImpl({ doOnBeforeTerminate {} }) {
 
     private val upstream = TestCompletable()
     private val callOrder = SharedList<String>()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/MergeTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/MergeTests.kt
@@ -10,7 +10,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class MergeTests : CompletableToCompletableTests by CompletableToCompletableTests({ merge(this) }) {
+class MergeTests : CompletableToCompletableTests by CompletableToCompletableTestsImpl({ merge(this) }) {
 
     private val upstream1 = TestCompletable()
     private val upstream2 = TestCompletable()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/ObserveOnTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/ObserveOnTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 
 class ObserveOnTest
-    : CompletableToCompletableTests by CompletableToCompletableTests({ observeOn(TestScheduler()) }) {
+    : CompletableToCompletableTests by CompletableToCompletableTestsImpl({ observeOn(TestScheduler()) }) {
 
     private val scheduler = TestScheduler(isManualProcessing = true)
     private val upstream = TestCompletable()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/OnErrorResumeNextTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/OnErrorResumeNextTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class OnErrorResumeNextTest :
-    CompletableToCompletableTests by CompletableToCompletableTests({ onErrorResumeNext { completableOfEmpty() } }) {
+    CompletableToCompletableTests by CompletableToCompletableTestsImpl({ onErrorResumeNext { completableOfEmpty() } }) {
 
     private val upstream = TestCompletable()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/RetryTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
-class RetryTest : CompletableToCompletableTests by CompletableToCompletableTests({ retry() }) {
+class RetryTest : CompletableToCompletableTests by CompletableToCompletableTestsImpl({ retry() }) {
 
     private val upstream = TestCompletable()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/SubscribeOnTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/SubscribeOnTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class SubscribeOnTest
-    : CompletableToCompletableTests by CompletableToCompletableTests({ subscribeOn(TestScheduler()) }) {
+    : CompletableToCompletableTests by CompletableToCompletableTestsImpl({ subscribeOn(TestScheduler()) }) {
 
     private val scheduler = TestScheduler(isManualProcessing = true)
     private val upstream = TestCompletable()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/AsCompletableTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/AsCompletableTest.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.maybe.TestMaybe
 import kotlin.test.Test
 
-class AsCompletableTest : MaybeToCompletableTests by MaybeToCompletableTests({ asCompletable() }) {
+class AsCompletableTest : MaybeToCompletableTests by MaybeToCompletableTestsImpl({ asCompletable() }) {
 
     private val upstream = TestMaybe<Int?>()
     private val observer = upstream.asCompletable().test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/AsObservableTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/AsObservableTest.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.observable.assertValue
 import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
 
-class AsObservableTest : MaybeToObservableTests by MaybeToObservableTests({ asObservable() }) {
+class AsObservableTest : MaybeToObservableTests by MaybeToObservableTestsImpl({ asObservable() }) {
 
     private val upstream = TestMaybe<Int?>()
     private val observer = upstream.asObservable().test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/AsSingleOrErrorSupplierTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/AsSingleOrErrorSupplierTests.kt
@@ -7,7 +7,7 @@ import com.badoo.reaktive.test.single.assertSuccess
 import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
 
-class AsSingleOrErrorSupplierTests : MaybeToSingleTests by MaybeToSingleTests({ asSingle(::Throwable) }) {
+class AsSingleOrErrorSupplierTests : MaybeToSingleTests by MaybeToSingleTestsImpl({ asSingle(::Throwable) }) {
 
     private val upstream = TestMaybe<Int?>()
     private val error = Exception()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/AsSingleOrErrorValueTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/AsSingleOrErrorValueTests.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.single.assertSuccess
 import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
 
-class AsSingleOrErrorValueTests : MaybeToSingleTests by MaybeToSingleTests({ asSingleOrError(Throwable()) }) {
+class AsSingleOrErrorValueTests : MaybeToSingleTests by MaybeToSingleTestsImpl({ asSingleOrError(Throwable()) }) {
 
     private val upstream = TestMaybe<Int?>()
     private val error = Exception()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/AsSingleSupplierTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/AsSingleSupplierTests.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.single.assertSuccess
 import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
 
-class AsSingleSupplierTests : MaybeToSingleTests by MaybeToSingleTests({ asSingle { Unit } }) {
+class AsSingleSupplierTests : MaybeToSingleTests by MaybeToSingleTestsImpl({ asSingle { Unit } }) {
 
     private val upstream = TestMaybe<Int?>()
     private val observer = upstream.asSingle { -1 }.test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/AsSingleValueTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/AsSingleValueTests.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.test.single.assertSuccess
 import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
 
-class AsSingleValueTests : MaybeToSingleTests by MaybeToSingleTests({ asSingle(Unit) }) {
+class AsSingleValueTests : MaybeToSingleTests by MaybeToSingleTestsImpl({ asSingle(Unit) }) {
 
     private val upstream = TestMaybe<Int?>()
     private val observer = upstream.asSingle(-1).test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DelayTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DelayTest.kt
@@ -12,7 +12,7 @@ import com.badoo.reaktive.test.scheduler.TestScheduler
 import kotlin.test.Test
 
 class DelayTest :
-    MaybeToMaybeTests by MaybeToMaybeTests({ delay(0L, TestScheduler()) }),
+    MaybeToMaybeTests by MaybeToMaybeTestsImpl({ delay(0L, TestScheduler()) }),
     DelayErrorTests by DelayErrorTests<TestMaybe<Int>>(
         TestMaybe(),
         { delayMillis, scheduler, delayError -> delay(delayMillis, scheduler, delayError).test() }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeCompleteTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class DoOnBeforeCompleteTest
-    : MaybeToMaybeTests by MaybeToMaybeTests({ doOnBeforeComplete {} }) {
+    : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ doOnBeforeComplete {} }) {
 
     private val upstream = TestMaybe<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeDisposeTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DoOnBeforeDisposeTest
-    : MaybeToMaybeTests by MaybeToMaybeTests({ doOnBeforeDispose {} }) {
+    : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ doOnBeforeDispose {} }) {
 
     private val upstream = TestMaybe<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeErrorTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DoOnBeforeErrorTest
-    : MaybeToMaybeTests by MaybeToMaybeTests({ doOnBeforeError {} }) {
+    : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ doOnBeforeError {} }) {
 
     private val upstream = TestMaybe<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeFinallyTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DoOnBeforeFinallyTest
-    : MaybeToMaybeTests by MaybeToMaybeTests({ doOnBeforeFinally {} }) {
+    : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ doOnBeforeFinally {} }) {
 
     private val upstream = TestMaybe<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSubscribeTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class DoOnBeforeSubscribeTest
-    : MaybeToMaybeTests by MaybeToMaybeTests({ doOnBeforeSubscribe {} }) {
+    : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ doOnBeforeSubscribe {} }) {
 
     @Test
     fun calls_action_before_downstream_onSubscribe_WHEN_action_does_not_throw_exception() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSuccessTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeSuccessTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class DoOnBeforeSuccessTest
-    : MaybeToMaybeTests by MaybeToMaybeTests({ doOnBeforeSuccess {} }) {
+    : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ doOnBeforeSuccess {} }) {
 
     private val upstream = TestMaybe<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeTerminateTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnBeforeTerminateTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DoOnBeforeTerminateTest
-    : MaybeToMaybeTests by MaybeToMaybeTests({ doOnBeforeTerminate {} }) {
+    : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ doOnBeforeTerminate {} }) {
 
     private val upstream = TestMaybe<Int>()
     private val callOrder = SharedList<String>()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/FilterTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/FilterTest.kt
@@ -7,7 +7,7 @@ import com.badoo.reaktive.test.maybe.assertSuccess
 import com.badoo.reaktive.test.maybe.test
 import kotlin.test.Test
 
-class FilterTest : MaybeToMaybeTests by MaybeToMaybeTests({ filter { true } }) {
+class FilterTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ filter { true } }) {
 
     private val upstream = TestMaybe<Int?>()
     private val observer = upstream.filter { it == null || it > 0 }.test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/FlatMapIterableTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/FlatMapIterableTest.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
 
 class FlatMapIterableTest
-    : MaybeToObservableTests by MaybeToObservableTests({ flatMapIterable { listOf(Unit) } }) {
+    : MaybeToObservableTests by MaybeToObservableTestsImpl({ flatMapIterable { listOf(Unit) } }) {
 
     private val upstream = TestMaybe<List<Int?>>()
     private val observer = upstream.flatMapIterable { it }.test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/FlatMapObservableTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/FlatMapObservableTest.kt
@@ -15,7 +15,7 @@ import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
-class FlatMapObservableTest : MaybeToObservableTests by MaybeToObservableTests({ flatMapObservable { observableOfEmpty<Nothing>() } }) {
+class FlatMapObservableTest : MaybeToObservableTests by MaybeToObservableTestsImpl({ flatMapObservable { observableOfEmpty<Nothing>() } }) {
 
     private val upstream = TestMaybe<Int?>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/FlatMapTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/FlatMapTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class FlatMapTest : MaybeToMaybeTests by MaybeToMaybeTests({ flatMap { TestMaybe<Int>() } }) {
+class FlatMapTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ flatMap { TestMaybe<Int>() } }) {
 
     private val upstream = TestMaybe<Int?>()
     private val inner = TestMaybe<String?>()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MapTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MapTest.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.maybe.assertSuccess
 import com.badoo.reaktive.test.maybe.test
 import kotlin.test.Test
 
-class MapTest : MaybeToMaybeTests by MaybeToMaybeTests({ map {} }) {
+class MapTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ map {} }) {
 
     private val upstream = TestMaybe<String?>()
     private val observer = upstream.map { it?.length }.test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToCompletableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToCompletableTests.kt
@@ -1,86 +1,49 @@
 package com.badoo.reaktive.maybe
 
+import com.badoo.reaktive.base.SourceTests
+import com.badoo.reaktive.base.SourceTestsImpl
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.test.base.assertDisposed
-import com.badoo.reaktive.test.base.assertError
-import com.badoo.reaktive.test.base.assertSubscribed
-import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.completable.assertComplete
 import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.maybe.TestMaybe
+import kotlin.test.Ignore
 import kotlin.test.Test
-import kotlin.test.assertFalse
 
-interface MaybeToCompletableTests {
-
-    @Test
-    fun calls_onSubscribe_only_once_WHEN_subscribed()
+interface MaybeToCompletableTests : SourceTests {
 
     @Test
     fun completes_WHEN_upstream_is_completed()
-
-    @Test
-    fun produces_error_WHEN_upstream_produced_error()
-
-    @Test
-    fun unsubscribes_from_upstream_WHEN_disposed()
 
     @Test
     fun disposes_downstream_disposable_WHEN_upstream_completed()
 
     @Test
     fun disposes_downstream_disposable_WHEN_upstream_succeeded()
+}
 
-    @Test
-    fun disposes_downstream_disposable_WHEN_upstream_produced_error()
+@Ignore
+class MaybeToCompletableTestsImpl(
+    transform: Maybe<Unit>.() -> Completable
+) : MaybeToCompletableTests, SourceTests by SourceTestsImpl(TestMaybe<Nothing>(), { transform().test() }) {
+    private val upstream = TestMaybe<Unit>()
+    private val observer = upstream.transform().test()
 
-    companion object {
-        operator fun invoke(transform: Maybe<Unit>.() -> Completable): MaybeToCompletableTests =
-            object : MaybeToCompletableTests {
-                private val upstream = TestMaybe<Unit>()
-                private val observer = upstream.transform().test()
+    override fun completes_WHEN_upstream_is_completed() {
+        upstream.onComplete()
 
-                override fun calls_onSubscribe_only_once_WHEN_subscribed() {
-                    observer.assertSubscribed()
-                }
+        observer.assertComplete()
+    }
 
-                override fun completes_WHEN_upstream_is_completed() {
-                    upstream.onComplete()
+    override fun disposes_downstream_disposable_WHEN_upstream_completed() {
+        upstream.onComplete()
 
-                    observer.assertComplete()
-                }
+        observer.assertDisposed()
+    }
 
-                override fun produces_error_WHEN_upstream_produced_error() {
-                    val error = Throwable()
+    override fun disposes_downstream_disposable_WHEN_upstream_succeeded() {
+        upstream.onSuccess(Unit)
 
-                    upstream.onError(error)
-
-                    observer.assertError(error)
-                }
-
-                override fun unsubscribes_from_upstream_WHEN_disposed() {
-                    observer.dispose()
-
-                    assertFalse(upstream.hasSubscribers)
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_completed() {
-                    upstream.onComplete()
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_succeeded() {
-                    upstream.onSuccess(Unit)
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_produced_error() {
-                    upstream.onError(Throwable())
-
-                    observer.assertDisposed()
-                }
-            }
+        observer.assertDisposed()
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToMaybeTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToMaybeTests.kt
@@ -1,85 +1,48 @@
 package com.badoo.reaktive.maybe
 
+import com.badoo.reaktive.base.SourceTests
+import com.badoo.reaktive.base.SourceTestsImpl
 import com.badoo.reaktive.test.base.assertDisposed
-import com.badoo.reaktive.test.base.assertError
-import com.badoo.reaktive.test.base.assertSubscribed
-import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.assertComplete
 import com.badoo.reaktive.test.maybe.test
+import kotlin.test.Ignore
 import kotlin.test.Test
-import kotlin.test.assertFalse
 
-interface MaybeToMaybeTests {
-
-    @Test
-    fun calls_onSubscribe_only_once_WHEN_subscribed()
+interface MaybeToMaybeTests : SourceTests {
 
     @Test
     fun completes_WHEN_upstream_is_completed()
-
-    @Test
-    fun produces_error_WHEN_upstream_produced_error()
-
-    @Test
-    fun unsubscribes_from_upstream_WHEN_disposed()
 
     @Test
     fun disposes_downstream_disposable_WHEN_upstream_completed()
 
     @Test
     fun disposes_downstream_disposable_WHEN_upstream_succeeded()
+}
 
-    @Test
-    fun disposes_downstream_disposable_WHEN_upstream_produced_error()
+@Ignore
+class MaybeToMaybeTestsImpl(
+    transform: Maybe<Unit>.() -> Maybe<*>
+) : MaybeToMaybeTests, SourceTests by SourceTestsImpl(TestMaybe<Nothing>(), { transform().test() }) {
+    private val upstream = TestMaybe<Unit>()
+    private val observer = upstream.transform().test()
 
-    companion object {
-        operator fun invoke(transform: Maybe<Unit>.() -> Maybe<*>): MaybeToMaybeTests =
-            object : MaybeToMaybeTests {
-                private val upstream = TestMaybe<Unit>()
-                private val observer = upstream.transform().test()
+    override fun completes_WHEN_upstream_is_completed() {
+        upstream.onComplete()
 
-                override fun calls_onSubscribe_only_once_WHEN_subscribed() {
-                    observer.assertSubscribed()
-                }
+        observer.assertComplete()
+    }
 
-                override fun completes_WHEN_upstream_is_completed() {
-                    upstream.onComplete()
+    override fun disposes_downstream_disposable_WHEN_upstream_completed() {
+        upstream.onComplete()
 
-                    observer.assertComplete()
-                }
+        observer.assertDisposed()
+    }
 
-                override fun produces_error_WHEN_upstream_produced_error() {
-                    val error = Throwable()
+    override fun disposes_downstream_disposable_WHEN_upstream_succeeded() {
+        upstream.onSuccess(Unit)
 
-                    upstream.onError(error)
-
-                    observer.assertError(error)
-                }
-
-                override fun unsubscribes_from_upstream_WHEN_disposed() {
-                    observer.dispose()
-
-                    assertFalse(upstream.hasSubscribers)
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_completed() {
-                    upstream.onComplete()
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_succeeded() {
-                    upstream.onSuccess(Unit)
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_produced_error() {
-                    upstream.onError(Throwable())
-
-                    observer.assertDisposed()
-                }
-            }
+        observer.assertDisposed()
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToObservableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToObservableTests.kt
@@ -1,86 +1,57 @@
 package com.badoo.reaktive.maybe
 
+import com.badoo.reaktive.base.SourceTests
+import com.badoo.reaktive.base.SourceTestsImpl
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.test.base.assertDisposed
-import com.badoo.reaktive.test.base.assertError
-import com.badoo.reaktive.test.base.assertSubscribed
 import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.observable.assertComplete
 import com.badoo.reaktive.test.observable.test
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertFalse
 
-interface MaybeToObservableTests {
-
-    @Test
-    fun calls_onSubscribe_only_once_WHEN_subscribed()
+interface MaybeToObservableTests : SourceTests {
 
     @Test
     fun completes_WHEN_upstream_is_completed()
-
-    @Test
-    fun produces_error_WHEN_upstream_produced_error()
-
-    @Test
-    fun unsubscribes_from_upstream_WHEN_disposed()
 
     @Test
     fun disposes_downstream_disposable_WHEN_upstream_completed()
 
     @Test
     fun disposes_downstream_disposable_WHEN_upstream_succeeded()
+}
 
-    @Test
-    fun disposes_downstream_disposable_WHEN_upstream_produced_error()
+@Ignore
+class MaybeToObservableTestsImpl(
+    transform: Maybe<Unit>.() -> Observable<*>
+) : MaybeToObservableTests, SourceTests by SourceTestsImpl(TestMaybe<Nothing>(), { transform().test() }) {
+    private val upstream = TestMaybe<Unit>()
+    private val observer = upstream.transform().test()
 
-    companion object {
-        operator fun invoke(transform: Maybe<Unit>.() -> Observable<*>): MaybeToObservableTests =
-            object : MaybeToObservableTests {
-                private val upstream = TestMaybe<Unit>()
-                private val observer = upstream.transform().test()
+    override fun completes_WHEN_upstream_is_completed() {
+        upstream.onComplete()
 
-                override fun calls_onSubscribe_only_once_WHEN_subscribed() {
-                    observer.assertSubscribed()
-                }
+        observer.assertComplete()
+    }
 
-                override fun completes_WHEN_upstream_is_completed() {
-                    upstream.onComplete()
+    override fun unsubscribes_from_upstream_WHEN_disposed() {
+        observer.dispose()
 
-                    observer.assertComplete()
-                }
+        assertFalse(upstream.hasSubscribers)
+    }
 
-                override fun produces_error_WHEN_upstream_produced_error() {
-                    val error = Throwable()
+    override fun disposes_downstream_disposable_WHEN_upstream_completed() {
+        upstream.onComplete()
 
-                    upstream.onError(error)
+        observer.assertDisposed()
+    }
 
-                    observer.assertError(error)
-                }
+    override fun disposes_downstream_disposable_WHEN_upstream_succeeded() {
+        upstream.onSuccess(Unit)
 
-                override fun unsubscribes_from_upstream_WHEN_disposed() {
-                    observer.dispose()
-
-                    assertFalse(upstream.hasSubscribers)
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_completed() {
-                    upstream.onComplete()
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_succeeded() {
-                    upstream.onSuccess(Unit)
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_produced_error() {
-                    upstream.onError(Throwable())
-
-                    observer.assertDisposed()
-                }
-            }
+        observer.assertDisposed()
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToSingleTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeToSingleTests.kt
@@ -1,76 +1,39 @@
 package com.badoo.reaktive.maybe
 
+import com.badoo.reaktive.base.SourceTests
+import com.badoo.reaktive.base.SourceTestsImpl
 import com.badoo.reaktive.single.Single
 import com.badoo.reaktive.test.base.assertDisposed
-import com.badoo.reaktive.test.base.assertError
-import com.badoo.reaktive.test.base.assertSubscribed
-import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.single.test
+import kotlin.test.Ignore
 import kotlin.test.Test
-import kotlin.test.assertFalse
 
-interface MaybeToSingleTests {
-
-    @Test
-    fun calls_onSubscribe_only_once_WHEN_subscribed()
-
-    @Test
-    fun produces_error_WHEN_upstream_produced_error()
-
-    @Test
-    fun unsubscribes_from_upstream_WHEN_disposed()
+interface MaybeToSingleTests : SourceTests {
 
     @Test
     fun disposes_downstream_disposable_WHEN_upstream_completed()
 
     @Test
     fun disposes_downstream_disposable_WHEN_upstream_succeeded()
+}
 
-    @Test
-    fun disposes_downstream_disposable_WHEN_upstream_produced_error()
+@Ignore
+class MaybeToSingleTestsImpl(
+    transform: Maybe<Unit>.() -> Single<*>
+) : MaybeToSingleTests, SourceTests by SourceTestsImpl(TestMaybe<Nothing>(), { transform().test() }) {
+    private val upstream = TestMaybe<Unit>()
+    private val observer = upstream.transform().test()
 
-    companion object {
-        operator fun invoke(transform: Maybe<Unit>.() -> Single<*>): MaybeToSingleTests =
-            object : MaybeToSingleTests {
-                private val upstream = TestMaybe<Unit>()
-                private val observer = upstream.transform().test()
+    override fun disposes_downstream_disposable_WHEN_upstream_completed() {
+        upstream.onComplete()
 
-                override fun calls_onSubscribe_only_once_WHEN_subscribed() {
-                    observer.assertSubscribed()
-                }
+        observer.assertDisposed()
+    }
 
-                override fun produces_error_WHEN_upstream_produced_error() {
-                    val error = Throwable()
+    override fun disposes_downstream_disposable_WHEN_upstream_succeeded() {
+        upstream.onSuccess(Unit)
 
-                    upstream.onError(error)
-
-                    observer.assertError(error)
-                }
-
-                override fun unsubscribes_from_upstream_WHEN_disposed() {
-                    observer.dispose()
-
-                    assertFalse(upstream.hasSubscribers)
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_completed() {
-                    upstream.onComplete()
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_succeeded() {
-                    upstream.onSuccess(Unit)
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_produced_error() {
-                    upstream.onError(Throwable())
-
-                    observer.assertDisposed()
-                }
-            }
+        observer.assertDisposed()
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MergeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MergeTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class MergeTest : MaybeToObservableTests by MaybeToObservableTests({ merge(this) }) {
+class MergeTest : MaybeToObservableTests by MaybeToObservableTestsImpl({ merge(this) }) {
 
     private val upstream1 = TestMaybe<Int?>()
     private val upstream2 = TestMaybe<Int?>()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/NotNullTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/NotNullTest.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.maybe.assertSuccess
 import com.badoo.reaktive.test.maybe.test
 import kotlin.test.Test
 
-class NotNullTest : MaybeToMaybeTests by MaybeToMaybeTests({ notNull() }) {
+class NotNullTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ notNull() }) {
 
     private val upstream = TestMaybe<Int?>()
     private val observer = upstream.notNull().test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/ObserveOnTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/ObserveOnTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 
 class ObserveOnTest
-    : MaybeToMaybeTests by MaybeToMaybeTests({ observeOn(TestScheduler()) }) {
+    : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ observeOn(TestScheduler()) }) {
 
     private val scheduler = TestScheduler(isManualProcessing = true)
     private val upstream = TestMaybe<Int?>()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/OnErrorResumeNextTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/OnErrorResumeNextTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class OnErrorResumeNextTest :
-    MaybeToMaybeTests by MaybeToMaybeTests({ onErrorResumeNext { Unit.toMaybe() } }) {
+    MaybeToMaybeTests by MaybeToMaybeTestsImpl({ onErrorResumeNext { Unit.toMaybe() } }) {
 
     private val upstream = TestMaybe<Int?>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/RetryTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
-class RetryTest : MaybeToMaybeTests by MaybeToMaybeTests({ retry() }) {
+class RetryTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ retry() }) {
 
     private val upstream = TestMaybe<Int?>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/SubscribeOnTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/SubscribeOnTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class SubscribeOnTest
-    : MaybeToMaybeTests by MaybeToMaybeTests({ subscribeOn(TestScheduler()) }) {
+    : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ subscribeOn(TestScheduler()) }) {
 
     private val scheduler = TestScheduler(isManualProcessing = true)
     private val upstream = TestMaybe<Int?>()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/SwitchIfEmptyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/SwitchIfEmptyTest.kt
@@ -10,7 +10,7 @@ import com.badoo.reaktive.test.maybe.test
 import kotlin.test.Test
 import kotlin.test.assertFalse
 
-class SwitchIfEmptyTest : MaybeToMaybeTests by MaybeToMaybeTests({ switchIfEmpty(maybeOfEmpty()) }) {
+class SwitchIfEmptyTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ switchIfEmpty(maybeOfEmpty()) }) {
 
     private val upstream = TestMaybe<Int?>()
     private val other = TestMaybe<Int?>()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/AsCompletableTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/AsCompletableTest.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.observable.TestObservable
 import kotlin.test.Test
 
-class AsCompletableTest : ObservableToCompletableTests by ObservableToCompletableTests({ asCompletable() }) {
+class AsCompletableTest : ObservableToCompletableTests by ObservableToCompletableTestsImpl({ asCompletable() }) {
 
     private val upstream = TestObservable<Int>()
     private val observer = upstream.asCompletable().test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/CombineLatestTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/CombineLatestTest.kt
@@ -18,7 +18,7 @@ class CombineLatestTest {
     private val relay1 = TestObservableRelay<String?>()
     private val relay2 = TestObservableRelay<String?>()
     private val relay3 = TestObservableRelay<String?>()
-    private val mapper = AtomicReference<(List<String?>) -> String?>{ it.joinToString(separator = ",") }
+    private val mapper = AtomicReference<(List<String?>) -> String?> { it.joinToString(separator = ",") }
     private val observer = createAndSubscribe(mapper)
 
     private fun createAndSubscribe(mapper: AtomicReference<(List<String?>) -> String?>): TestObservableObserver<String?> =

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ConcatMapTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ConcatMapTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ConcatMapTest
-    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ concatMap { TestObservable<Int>() } }) {
+    : ObservableToObservableTests by ObservableToObservableTestsImpl({ concatMap { TestObservable<Int>() } }) {
 
     private val upstream = TestObservable<Int?>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DebounceTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DebounceTest.kt
@@ -10,7 +10,7 @@ import com.badoo.reaktive.test.scheduler.TestScheduler
 import kotlin.test.Test
 
 class DebounceTest
-    : ObservableToObservableTests by ObservableToObservableTests<Int>({ debounce(0L, TestScheduler()) }) {
+    : ObservableToObservableTests by ObservableToObservableTestsImpl({ debounce(0L, TestScheduler()) }) {
 
     private val upstream = TestObservable<Int?>()
     private val scheduler = TestScheduler()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DebounceWithSelectorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DebounceWithSelectorTest.kt
@@ -21,7 +21,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class DebounceWithSelectorTest :
-    ObservableToObservableTests by ObservableToObservableTests<Int>({ debounce { completableTimer(0L, TestScheduler()) } }) {
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ debounce { completableTimer(0L, TestScheduler()) } }) {
 
     private val upstream = TestObservable<String?>()
     private val scheduler = TestScheduler()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DefaultIfEmptyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DefaultIfEmptyTest.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
 
 class DefaultIfEmptyTest
-    : ObservableToObservableTests by ObservableToObservableTests<Int>({ defaultIfEmpty(10) }) {
+    : ObservableToObservableTests by ObservableToObservableTestsImpl({ defaultIfEmpty(10) }) {
 
     @Test
     fun should_return_default_value_when_source_is_empty() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DelayTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DelayTest.kt
@@ -11,7 +11,7 @@ import com.badoo.reaktive.test.scheduler.TestScheduler
 import kotlin.test.Test
 
 class DelayTest :
-    ObservableToObservableTests by ObservableToObservableTests<Unit>({ delay(0L, TestScheduler()) }),
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ delay(0L, TestScheduler()) }),
     DelayErrorTests by DelayErrorTests<TestObservable<Int>>(
         TestObservable(),
         { delayMillis, scheduler, delayError -> delay(delayMillis, scheduler, delayError).test() }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DistinctUntilChangedTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DistinctUntilChangedTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.assertEquals
 
 
 class DistinctUntilChangedTest
-    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ distinctUntilChanged() }) {
+    : ObservableToObservableTests by ObservableToObservableTestsImpl({ distinctUntilChanged() }) {
 
     private val thirteen = Question(13)
     private val fortyTwo = Question(42)

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeCompleteTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class DoOnBeforeCompleteTest
-    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeComplete {} }) {
+    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeComplete {} }) {
 
     private val upstream = TestObservable<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeDisposeTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DoOnBeforeDisposeTest
-    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeDispose {} }) {
+    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeDispose {} }) {
 
     private val upstream = TestObservable<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeErrorTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DoOnBeforeErrorTest
-    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeError {} }) {
+    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeError {} }) {
 
     private val upstream = TestObservable<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeFinallyTest.kt
@@ -20,7 +20,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DoOnBeforeFinallyTest
-    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeFinally {} }) {
+    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeFinally {} }) {
 
     private val upstream = TestObservable<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeNextTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeNextTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class DoOnBeforeNextTest
-    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeNext {} }) {
+    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeNext {} }) {
 
     private val upstream = TestObservable<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeSubscribeTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class DoOnBeforeSubscribeTest
-    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeSubscribe {} }) {
+    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeSubscribe {} }) {
 
     @Test
     fun calls_action_before_downstream_onSubscribe_WHEN_action_does_not_throw_exception() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeTerminateTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeTerminateTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DoOnBeforeTerminateTest
-    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ doOnBeforeTerminate {} }) {
+    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeTerminate {} }) {
 
     private val upstream = TestObservable<Int>()
     private val callOrder = SharedList<String>()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FilterTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FilterTest.kt
@@ -10,7 +10,7 @@ import com.badoo.reaktive.test.observable.onNext
 import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
 
-class FilterTest : ObservableToObservableTests by ObservableToObservableTests<Unit>({ filter { true } }) {
+class FilterTest : ObservableToObservableTests by ObservableToObservableTestsImpl({ filter { true } }) {
 
     private val upstream = TestObservable<Int?>()
     private val observer = upstream.filter { it == null || it > 0 }.test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrCompleteTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrCompleteTests.kt
@@ -9,7 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class FirstOrCompleteTests : ObservableToMaybeTests by ObservableToMaybeTests<Nothing>({ firstOrComplete() }) {
+class FirstOrCompleteTests : ObservableToMaybeTests by ObservableToMaybeTestsImpl({ firstOrComplete() }) {
 
     private val upstream = TestObservable<Int>()
     private val observer = upstream.firstOrComplete().test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrDefaultSupplierTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrDefaultSupplierTests.kt
@@ -9,7 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class FirstOrDefaultSupplierTests : ObservableToSingleTests by ObservableToSingleTests<Unit>({ firstOrDefault { Unit } }) {
+class FirstOrDefaultSupplierTests : ObservableToSingleTests by ObservableToSingleTestsImpl({ firstOrDefault { Unit } }) {
 
     private val upstream = TestObservable<Int>()
     private val observer = upstream.firstOrDefault { -1 }.test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrDefaultValueTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrDefaultValueTests.kt
@@ -8,7 +8,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class FirstOrDefaultValueTests : ObservableToSingleTests by ObservableToSingleTests<Unit>({ firstOrDefault(Unit) }) {
+class FirstOrDefaultValueTests : ObservableToSingleTests by ObservableToSingleTestsImpl({ firstOrDefault(Unit) }) {
 
     private val upstream = TestObservable<Int>()
     private val observer = upstream.firstOrDefault(-1).test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrErrorSupplierTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrErrorSupplierTests.kt
@@ -10,7 +10,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class FirstOrErrorSupplierTests : ObservableToSingleTests by ObservableToSingleTests<Unit>({ firstOrError(::Throwable) }) {
+class FirstOrErrorSupplierTests : ObservableToSingleTests by ObservableToSingleTestsImpl({ firstOrError(::Throwable) }) {
 
     private val upstream = TestObservable<Int>()
     private val error = Exception()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrErrorValueTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FirstOrErrorValueTests.kt
@@ -9,7 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class FirstOrErrorValueTests : ObservableToSingleTests by ObservableToSingleTests<Unit>({ firstOrError(Throwable()) }) {
+class FirstOrErrorValueTests : ObservableToSingleTests by ObservableToSingleTestsImpl({ firstOrError(Throwable()) }) {
 
     private val upstream = TestObservable<Int>()
     private val error = Exception()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FlatMapCompletableTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FlatMapCompletableTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class FlatMapCompletableTest
-    : ObservableToCompletableTests by ObservableToCompletableTests({ flatMapCompletable { TestCompletable() } }) {
+    : ObservableToCompletableTests by ObservableToCompletableTestsImpl({ flatMapCompletable { TestCompletable() } }) {
 
     private val upstream = TestObservable<Int?>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FlatMapIterableTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FlatMapIterableTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.Test
 
 class FlatMapIterableTest
     :
-    ObservableToObservableTests by ObservableToObservableTests<Unit>({ flatMapIterable { listOf(Unit) } }) {
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ flatMapIterable { listOf(Unit) } }) {
 
     private val upstream = TestObservable<List<Int?>>()
     private val observer = upstream.flatMapIterable { it }.test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FlatMapMaybeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FlatMapMaybeTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class FlatMapMaybeTest
-    : ObservableToObservableTests by ObservableToObservableTests<Nothing>({ flatMapMaybe { TestMaybe<Nothing>() } }) {
+    : ObservableToObservableTests by ObservableToObservableTestsImpl({ flatMapMaybe { TestMaybe<Nothing>() } }) {
 
     private val upstream = TestObservable<Int?>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FlatMapSingleTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FlatMapSingleTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class FlatMapSingleTest
-    : ObservableToObservableTests by ObservableToObservableTests<Nothing>({ flatMapSingle { TestSingle<Nothing>() } }) {
+    : ObservableToObservableTests by ObservableToObservableTestsImpl({ flatMapSingle { TestSingle<Nothing>() } }) {
 
     private val upstream = TestObservable<Int?>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FlatMapTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/FlatMapTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class FlatMapTest
-    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ flatMap { TestObservable<Int>() } }) {
+    : ObservableToObservableTests by ObservableToObservableTestsImpl({ flatMap { TestObservable<Int>() } }) {
 
     private val source = TestObservable<Int?>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/MapTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/MapTest.kt
@@ -8,7 +8,7 @@ import com.badoo.reaktive.test.observable.onNext
 import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
 
-class MapTest : ObservableToObservableTests by ObservableToObservableTests<Unit>({ map {} }) {
+class MapTest : ObservableToObservableTests by ObservableToObservableTestsImpl({ map {} }) {
 
     private val upstream = TestObservable<String?>()
     private val observer = upstream.map { it?.length }.test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableToCompletableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableToCompletableTests.kt
@@ -1,77 +1,40 @@
 package com.badoo.reaktive.observable
 
+import com.badoo.reaktive.base.SourceTests
+import com.badoo.reaktive.base.SourceTestsImpl
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.test.base.assertDisposed
-import com.badoo.reaktive.test.base.assertError
-import com.badoo.reaktive.test.base.assertSubscribed
-import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.completable.assertComplete
 import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.observable.TestObservable
+import kotlin.test.Ignore
 import kotlin.test.Test
-import kotlin.test.assertFalse
 
-interface ObservableToCompletableTests {
-
-    @Test
-    fun calls_onSubscribe_only_once_WHEN_subscribed()
+interface ObservableToCompletableTests : SourceTests {
 
     @Test
     fun completes_WHEN_upstream_is_completed()
 
     @Test
-    fun produces_error_WHEN_upstream_produced_error()
-
-    @Test
-    fun unsubscribes_from_upstream_WHEN_disposed()
-
-    @Test
     fun disposes_downstream_disposable_WHEN_upstream_completed()
+}
 
-    @Test
-    fun disposes_downstream_disposable_WHEN_upstream_produced_error()
+@Ignore
+class ObservableToCompletableTestsImpl(
+    transform: Observable<*>.() -> Completable
+) : ObservableToCompletableTests, SourceTests by SourceTestsImpl(TestObservable<Nothing>(), { transform().test() }) {
+    private val upstream = TestObservable<Nothing>()
+    private val observer = upstream.transform().test()
 
-    companion object {
-        operator fun invoke(transform: Observable<*>.() -> Completable): ObservableToCompletableTests =
-            object : ObservableToCompletableTests {
-                private val upstream = TestObservable<Nothing>()
-                private val observer = upstream.transform().test()
+    override fun completes_WHEN_upstream_is_completed() {
+        upstream.onComplete()
 
-                override fun calls_onSubscribe_only_once_WHEN_subscribed() {
-                    observer.assertSubscribed()
-                }
+        observer.assertComplete()
+    }
 
-                override fun completes_WHEN_upstream_is_completed() {
-                    upstream.onComplete()
+    override fun disposes_downstream_disposable_WHEN_upstream_completed() {
+        upstream.onComplete()
 
-                    observer.assertComplete()
-                }
-
-                override fun produces_error_WHEN_upstream_produced_error() {
-                    val error = Throwable()
-
-                    upstream.onError(error)
-
-                    observer.assertError(error)
-                }
-
-                override fun unsubscribes_from_upstream_WHEN_disposed() {
-                    observer.dispose()
-
-                    assertFalse(upstream.hasSubscribers)
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_completed() {
-                    upstream.onComplete()
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_produced_error() {
-                    upstream.onError(Throwable())
-
-                    observer.assertDisposed()
-                }
-            }
+        observer.assertDisposed()
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableToMaybeTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableToMaybeTests.kt
@@ -1,77 +1,40 @@
 package com.badoo.reaktive.observable
 
+import com.badoo.reaktive.base.SourceTests
+import com.badoo.reaktive.base.SourceTestsImpl
 import com.badoo.reaktive.maybe.Maybe
 import com.badoo.reaktive.test.base.assertDisposed
-import com.badoo.reaktive.test.base.assertError
-import com.badoo.reaktive.test.base.assertSubscribed
-import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.maybe.assertComplete
 import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.observable.TestObservable
+import kotlin.test.Ignore
 import kotlin.test.Test
-import kotlin.test.assertFalse
 
-interface ObservableToMaybeTests {
-
-    @Test
-    fun calls_onSubscribe_only_once_WHEN_subscribed()
+interface ObservableToMaybeTests : SourceTests {
 
     @Test
     fun completes_WHEN_upstream_is_completed()
 
     @Test
-    fun produces_error_WHEN_upstream_produced_error()
-
-    @Test
-    fun unsubscribes_from_upstream_WHEN_disposed()
-
-    @Test
     fun disposes_downstream_disposable_WHEN_upstream_completed()
+}
 
-    @Test
-    fun disposes_downstream_disposable_WHEN_upstream_produced_error()
+@Ignore
+class ObservableToMaybeTestsImpl(
+    transform: Observable<*>.() -> Maybe<*>
+) : ObservableToMaybeTests, SourceTests by SourceTestsImpl(TestObservable<Nothing>(), { transform().test() }) {
+    private val upstream = TestObservable<Nothing>()
+    private val observer = upstream.transform().test()
 
-    companion object {
-        operator fun <T> invoke(transform: Observable<T>.() -> Maybe<*>): ObservableToMaybeTests =
-            object : ObservableToMaybeTests {
-                private val upstream = TestObservable<T>()
-                private val observer = upstream.transform().test()
+    override fun completes_WHEN_upstream_is_completed() {
+        upstream.onComplete()
 
-                override fun calls_onSubscribe_only_once_WHEN_subscribed() {
-                    observer.assertSubscribed()
-                }
+        observer.assertComplete()
+    }
 
-                override fun completes_WHEN_upstream_is_completed() {
-                    upstream.onComplete()
+    override fun disposes_downstream_disposable_WHEN_upstream_completed() {
+        upstream.onComplete()
 
-                    observer.assertComplete()
-                }
-
-                override fun produces_error_WHEN_upstream_produced_error() {
-                    val error = Throwable()
-
-                    upstream.onError(error)
-
-                    observer.assertError(error)
-                }
-
-                override fun unsubscribes_from_upstream_WHEN_disposed() {
-                    observer.dispose()
-
-                    assertFalse(upstream.hasSubscribers)
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_completed() {
-                    upstream.onComplete()
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_produced_error() {
-                    upstream.onError(Throwable())
-
-                    observer.assertDisposed()
-                }
-            }
+        observer.assertDisposed()
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableToSingleTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableToSingleTests.kt
@@ -1,67 +1,30 @@
 package com.badoo.reaktive.observable
 
+import com.badoo.reaktive.base.SourceTests
+import com.badoo.reaktive.base.SourceTestsImpl
 import com.badoo.reaktive.single.Single
 import com.badoo.reaktive.test.base.assertDisposed
-import com.badoo.reaktive.test.base.assertError
-import com.badoo.reaktive.test.base.assertSubscribed
-import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.single.test
+import kotlin.test.Ignore
 import kotlin.test.Test
-import kotlin.test.assertFalse
 
-interface ObservableToSingleTests {
-
-    @Test
-    fun calls_onSubscribe_only_once_WHEN_subscribed()
-
-    @Test
-    fun produces_error_WHEN_upstream_produced_error()
-
-    @Test
-    fun unsubscribes_from_upstream_WHEN_disposed()
+interface ObservableToSingleTests : SourceTests {
 
     @Test
     fun disposes_downstream_disposable_WHEN_upstream_completed()
+}
 
-    @Test
-    fun disposes_downstream_disposable_WHEN_upstream_produced_error()
+@Ignore
+class ObservableToSingleTestsImpl(
+    transform: Observable<*>.() -> Single<*>
+) : ObservableToSingleTests, SourceTests by SourceTestsImpl(TestObservable<Nothing>(), { transform().test() }) {
+    private val upstream = TestObservable<Nothing>()
+    private val observer = upstream.transform().test()
 
-    companion object {
-        operator fun <T> invoke(transform: Observable<T>.() -> Single<*>): ObservableToSingleTests =
-            object : ObservableToSingleTests {
-                private val upstream = TestObservable<T>()
-                private val observer = upstream.transform().test()
+    override fun disposes_downstream_disposable_WHEN_upstream_completed() {
+        upstream.onComplete()
 
-                override fun calls_onSubscribe_only_once_WHEN_subscribed() {
-                    observer.assertSubscribed()
-                }
-
-                override fun produces_error_WHEN_upstream_produced_error() {
-                    val error = Throwable()
-
-                    upstream.onError(error)
-
-                    observer.assertError(error)
-                }
-
-                override fun unsubscribes_from_upstream_WHEN_disposed() {
-                    observer.dispose()
-
-                    assertFalse(upstream.hasSubscribers)
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_completed() {
-                    upstream.onComplete()
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_produced_error() {
-                    upstream.onError(Throwable())
-
-                    observer.assertDisposed()
-                }
-            }
+        observer.assertDisposed()
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObserveOnTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObserveOnTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 
 class ObserveOnTest
-    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ observeOn(TestScheduler()) }) {
+    : ObservableToObservableTests by ObservableToObservableTestsImpl({ observeOn(TestScheduler()) }) {
 
     private val scheduler = TestScheduler(isManualProcessing = true)
     private val upstream = TestObservable<Int?>()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/OnErrorResumeNextTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/OnErrorResumeNextTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class OnErrorResumeNextTest :
-    ObservableToObservableTests by ObservableToObservableTests<Unit>({ onErrorResumeNext { Unit.toObservable() } }) {
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ onErrorResumeNext { Unit.toObservable() } }) {
 
     private val upstream = TestObservable<Int?>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ReduceTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ReduceTest.kt
@@ -8,7 +8,7 @@ import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.onNext
 import kotlin.test.Test
 
-class ReduceTest : ObservableToMaybeTests by ObservableToMaybeTests<Unit>({ reduce { _, _ -> Unit } }) {
+class ReduceTest : ObservableToMaybeTests by ObservableToMaybeTestsImpl({ reduce { _, _ -> Unit } }) {
 
     private val upstream = TestObservable<Int?>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RepeatTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RepeatTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class RepeatTest : ObservableToObservableTests by ObservableToObservableTests<Nothing>({ repeat(count = 0) }) {
+class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImpl({ repeat(count = 0) }) {
 
     @Test
     fun emits_all_values_of_first_iteration_WHEN_count_is_positive() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RepeatUntilTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RepeatUntilTest.kt
@@ -4,11 +4,11 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.observable.TestObservable
+import com.badoo.reaktive.test.observable.assertComplete
+import com.badoo.reaktive.test.observable.assertNotComplete
 import com.badoo.reaktive.test.observable.assertValues
 import com.badoo.reaktive.test.observable.onNext
 import com.badoo.reaktive.test.observable.test
-import com.badoo.reaktive.test.observable.assertComplete
-import com.badoo.reaktive.test.observable.assertNotComplete
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import com.badoo.reaktive.utils.atomic.AtomicInt
 import com.badoo.reaktive.utils.atomic.AtomicReference
@@ -17,7 +17,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class RepeatUntilTest : ObservableToObservableTests by ObservableToObservableTests<Nothing>({ repeatUntil { true } }) {
+class RepeatUntilTest : ObservableToObservableTests by ObservableToObservableTestsImpl({ repeatUntil { true } }) {
     @Test
     fun resubscribes_on_complete_till_predicate_is_true() {
         val count = AtomicInt(0)

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RetryTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
-class RetryTest : ObservableToObservableTests by ObservableToObservableTests<Unit>({ retry() }) {
+class RetryTest : ObservableToObservableTests by ObservableToObservableTestsImpl({ retry() }) {
 
     private val upstream = TestObservable<Int?>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SkipTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SkipTest.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.test.observable.assertValues
 import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
 
-class SkipTest : ObservableToObservableTests by ObservableToObservableTests<Unit>({ skip(0) }) {
+class SkipTest : ObservableToObservableTests by ObservableToObservableTestsImpl({ skip(0) }) {
 
     @Test
     fun should_skip_n_values() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SubscribeOnTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SubscribeOnTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class SubscribeOnTest
-    : ObservableToObservableTests by ObservableToObservableTests<Unit>({ subscribeOn(TestScheduler()) }) {
+    : ObservableToObservableTests by ObservableToObservableTestsImpl({ subscribeOn(TestScheduler()) }) {
 
     private val scheduler = TestScheduler(isManualProcessing = true)
     private val upstream = TestObservable<Int?>()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SwitchIfEmptyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SwitchIfEmptyTest.kt
@@ -9,7 +9,7 @@ import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
 
 class SwitchIfEmptyTest :
-    ObservableToObservableTests by ObservableToObservableTests<Int>({ switchIfEmpty(observableOf(10)) }) {
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ switchIfEmpty(observableOf(10)) }) {
 
     @Test
     fun should_switch_streams_when_source_is_empty() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SwitchMapTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SwitchMapTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class SwitchMapTest :
-    ObservableToObservableTests by ObservableToObservableTests<Unit>({ switchMap { TestObservable<Int>() } }) {
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ switchMap { TestObservable<Int>() } }) {
 
     private val source = TestObservable<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/TakeObservableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/TakeObservableTests.kt
@@ -12,7 +12,7 @@ import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 class TakeObservableTests :
-    ObservableToObservableTests by ObservableToObservableTests<Unit>({ take(1) }) {
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ take(1) }) {
 
     private val upstream = TestObservable<Int?>()
     private val observer = upstream.take(10).test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/TakeUntilObservableTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/TakeUntilObservableTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 
 class TakeUntilObservableTest :
-    ObservableToObservableTests by ObservableToObservableTests<Unit>({ takeUntil(observableOfNever<Nothing>()) }) {
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ takeUntil(observableOfNever<Nothing>()) }) {
 
     private val upstream = TestObservable<Int?>()
     private val other = TestObservable<Unit?>()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/TakeUntilPredicateTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/TakeUntilPredicateTest.kt
@@ -8,7 +8,7 @@ import com.badoo.reaktive.test.observable.onNext
 import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
 
-class TakeUntilPredicateTest : ObservableToObservableTests by ObservableToObservableTests<Unit>({ takeUntil { false } }) {
+class TakeUntilPredicateTest : ObservableToObservableTests by ObservableToObservableTestsImpl({ takeUntil { false } }) {
 
     private val upstream = TestObservable<Int?>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ThrottleTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ThrottleTest.kt
@@ -10,7 +10,7 @@ import com.badoo.reaktive.utils.atomic.AtomicLong
 import com.badoo.reaktive.utils.clock.Clock
 import kotlin.test.Test
 
-class ThrottleTest : ObservableToObservableTests by ObservableToObservableTests<Unit>({ throttle(0L) }) {
+class ThrottleTest : ObservableToObservableTests by ObservableToObservableTestsImpl({ throttle(0L) }) {
 
     private val clock = TestClock()
     private val upstream = TestObservable<Int>()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ToListTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ToListTest.kt
@@ -8,7 +8,7 @@ import com.badoo.reaktive.utils.isFrozen
 import kotlin.test.Test
 import kotlin.test.assertFalse
 
-class ToListTest : ObservableToSingleTests by ObservableToSingleTests<Nothing>({ toList() }) {
+class ToListTest : ObservableToSingleTests by ObservableToSingleTestsImpl({ toList() }) {
 
     @Test
     fun collects_all_items_without_freezing() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ToMapTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ToMapTest.kt
@@ -8,7 +8,7 @@ import com.badoo.reaktive.utils.isFrozen
 import kotlin.test.Test
 import kotlin.test.assertFalse
 
-class ToMapTest : ObservableToSingleTests by ObservableToSingleTests<Nothing>({ toMap { it } }) {
+class ToMapTest : ObservableToSingleTests by ObservableToSingleTestsImpl({ toMap { it } }) {
 
     @Test
     fun collects_all_items_without_freezing() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/AsCompletableTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/AsCompletableTest.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.single.TestSingle
 import kotlin.test.Test
 
-class AsCompletableTest : SingleToCompletableTests by SingleToCompletableTests({ asCompletable() }) {
+class AsCompletableTest : SingleToCompletableTests by SingleToCompletableTestsImpl({ asCompletable() }) {
 
     private val upstream = TestSingle<Int?>()
     private val observer = upstream.asCompletable().test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/AsMaybeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/AsMaybeTest.kt
@@ -5,7 +5,7 @@ import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.single.TestSingle
 import kotlin.test.Test
 
-class AsMaybeTest : SingleToMaybeTests by SingleToMaybeTests({ asMaybe() }) {
+class AsMaybeTest : SingleToMaybeTests by SingleToMaybeTestsImpl({ asMaybe() }) {
 
     private val upstream = TestSingle<Int?>()
     private val observer = upstream.asMaybe().test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/AsObservableTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/AsObservableTest.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.single.TestSingle
 import kotlin.test.Test
 
-class AsObservableTest : SingleToObservableTests by SingleToObservableTests({ asObservable() }) {
+class AsObservableTest : SingleToObservableTests by SingleToObservableTestsImpl({ asObservable() }) {
 
     private val upstream = TestSingle<Int?>()
     private val observer = upstream.asObservable().test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DelayTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DelayTest.kt
@@ -10,7 +10,7 @@ import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
 
 class DelayTest :
-    SingleToSingleTests by SingleToSingleTests({ delay(0L, TestScheduler()) }),
+    SingleToSingleTests by SingleToSingleTestsImpl({ delay(0L, TestScheduler()) }),
     DelayErrorTests by DelayErrorTests<TestSingle<Int>>(
         TestSingle(),
         { delayMillis, scheduler, delayError -> delay(delayMillis, scheduler, delayError).test() }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeDisposeTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DoOnBeforeDisposeTest
-    : SingleToSingleTests by SingleToSingleTests({ doOnBeforeDispose {} }) {
+    : SingleToSingleTests by SingleToSingleTestsImpl({ doOnBeforeDispose {} }) {
 
     private val upstream = TestSingle<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeErrorTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DoOnBeforeErrorTest
-    : SingleToSingleTests by SingleToSingleTests({ doOnBeforeError {} }) {
+    : SingleToSingleTests by SingleToSingleTestsImpl({ doOnBeforeError {} }) {
 
     private val upstream = TestSingle<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeFinallyTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DoOnBeforeFinallyTest
-    : SingleToSingleTests by SingleToSingleTests({ doOnBeforeFinally {} }) {
+    : SingleToSingleTests by SingleToSingleTestsImpl({ doOnBeforeFinally {} }) {
 
     private val upstream = TestSingle<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSubscribeTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class DoOnBeforeSubscribeTest
-    : SingleToSingleTests by SingleToSingleTests({ doOnBeforeSubscribe {} }) {
+    : SingleToSingleTests by SingleToSingleTestsImpl({ doOnBeforeSubscribe {} }) {
 
     @Test
     fun calls_action_before_downstream_onSubscribe_WHEN_action_does_not_throw_exception() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSuccessTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeSuccessTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class DoOnBeforeSuccessTest
-    : SingleToSingleTests by SingleToSingleTests({ doOnBeforeSuccess {} }) {
+    : SingleToSingleTests by SingleToSingleTestsImpl({ doOnBeforeSuccess {} }) {
 
     private val upstream = TestSingle<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeTerminateTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DoOnBeforeTerminateTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DoOnBeforeTerminateTest
-    : SingleToSingleTests by SingleToSingleTests({ doOnBeforeTerminate {} }) {
+    : SingleToSingleTests by SingleToSingleTestsImpl({ doOnBeforeTerminate {} }) {
 
     private val upstream = TestSingle<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/FilterTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/FilterTest.kt
@@ -8,7 +8,7 @@ import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
 
-class FilterTest : SingleToMaybeTests by SingleToMaybeTests.Companion({ filter { true } }) {
+class FilterTest : SingleToMaybeTests by SingleToMaybeTestsImpl({ filter { true } }) {
 
     private val upstream = TestSingle<Int?>()
     private val observer = upstream.filter { it == null || it > 0 }.test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/FlatMapIterableTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/FlatMapIterableTest.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.single.TestSingle
 import kotlin.test.Test
 
 class FlatMapIterableTest
-    : SingleToObservableTests by SingleToObservableTests({ flatMapIterable { listOf(Unit) } }) {
+    : SingleToObservableTests by SingleToObservableTestsImpl({ flatMapIterable { listOf(Unit) } }) {
 
     private val upstream = TestSingle<List<Int?>>()
     private val observer = upstream.flatMapIterable { it }.test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/FlatMapObservableTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/FlatMapObservableTest.kt
@@ -15,7 +15,7 @@ import com.badoo.reaktive.test.single.TestSingle
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
-class FlatMapObservableTest : SingleToObservableTests by SingleToObservableTests({ flatMapObservable { observableOfEmpty<Nothing>() } }) {
+class FlatMapObservableTest : SingleToObservableTests by SingleToObservableTestsImpl({ flatMapObservable { observableOfEmpty<Nothing>() } }) {
 
     private val upstream = TestSingle<Int?>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/FlatMapTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/FlatMapTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class FlatMapTest : SingleToSingleTests by SingleToSingleTests({ flatMap { TestSingle<Int>() } }) {
+class FlatMapTest : SingleToSingleTests by SingleToSingleTestsImpl({ flatMap { TestSingle<Int>() } }) {
 
     private val upstream = TestSingle<Int?>()
     private val inner = TestSingle<String?>()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/MapTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/MapTest.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.single.assertSuccess
 import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
 
-class MapTest : SingleToSingleTests by SingleToSingleTests({ map {} }) {
+class MapTest : SingleToSingleTests by SingleToSingleTestsImpl({ map {} }) {
 
     private val upstream = TestSingle<String?>()
     private val observer = upstream.map { it?.length }.test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/MergeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/MergeTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class MergeTest : SingleToObservableTests by SingleToObservableTests({ merge(this) }) {
+class MergeTest : SingleToObservableTests by SingleToObservableTestsImpl({ merge(this) }) {
 
     private val upstream1 = TestSingle<Int?>()
     private val upstream2 = TestSingle<Int?>()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/NotNullTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/NotNullTest.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.single.TestSingle
 import kotlin.test.Test
 
-class NotNullTest : SingleToMaybeTests by SingleToMaybeTests.Companion({ notNull() }) {
+class NotNullTest : SingleToMaybeTests by SingleToMaybeTestsImpl({ notNull() }) {
 
     private val upstream = TestSingle<Int?>()
     private val observer = upstream.notNull().test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/ObserveOnTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/ObserveOnTest.kt
@@ -11,7 +11,7 @@ import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
-class ObserveOnTest : SingleToSingleTests by SingleToSingleTests({ observeOn(TestScheduler()) }) {
+class ObserveOnTest : SingleToSingleTests by SingleToSingleTestsImpl({ observeOn(TestScheduler()) }) {
 
     private val scheduler = TestScheduler(isManualProcessing = true)
     private val upstream = TestSingle<Int>()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/OnErrorResumeNextTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/OnErrorResumeNextTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class OnErrorResumeNextTest :
-    SingleToSingleTests by SingleToSingleTests({ onErrorResumeNext { Unit.toSingle() } }) {
+    SingleToSingleTests by SingleToSingleTestsImpl({ onErrorResumeNext { Unit.toSingle() } }) {
 
     private val upstream = TestSingle<Int?>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/RepeatUntilTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/RepeatUntilTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class RepeatUntilTest : SingleToObservableTests by SingleToObservableTests({ repeatUntil { true } }) {
+class RepeatUntilTest : SingleToObservableTests by SingleToObservableTestsImpl({ repeatUntil { true } }) {
     private val upstream = TestSingle<Int?>()
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/RetryTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
-class RetryTest : SingleToSingleTests by SingleToSingleTests({ retry() }) {
+class RetryTest : SingleToSingleTests by SingleToSingleTestsImpl({ retry() }) {
 
     private val upstream = TestSingle<Int?>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/SingleToCompletableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/SingleToCompletableTests.kt
@@ -1,67 +1,30 @@
 package com.badoo.reaktive.single
 
+import com.badoo.reaktive.base.SourceTests
+import com.badoo.reaktive.base.SourceTestsImpl
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.test.base.assertDisposed
-import com.badoo.reaktive.test.base.assertError
-import com.badoo.reaktive.test.base.assertSubscribed
-import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.single.TestSingle
+import kotlin.test.Ignore
 import kotlin.test.Test
-import kotlin.test.assertFalse
 
-interface SingleToCompletableTests {
-
-    @Test
-    fun calls_onSubscribe_only_once_WHEN_subscribed()
-
-    @Test
-    fun produces_error_WHEN_upstream_produced_error()
-
-    @Test
-    fun unsubscribes_from_upstream_WHEN_disposed()
+interface SingleToCompletableTests : SourceTests {
 
     @Test
     fun disposes_downstream_disposable_WHEN_upstream_succeeded()
+}
 
-    @Test
-    fun disposes_downstream_disposable_WHEN_upstream_produced_error()
+@Ignore
+class SingleToCompletableTestsImpl(
+    transform: Single<Unit>.() -> Completable
+) : SingleToCompletableTests, SourceTests by SourceTestsImpl(TestSingle<Nothing>(), { transform().test() }) {
+    private val upstream = TestSingle<Unit>()
+    private val observer = upstream.transform().test()
 
-    companion object {
-        operator fun invoke(transform: Single<Unit>.() -> Completable): SingleToCompletableTests =
-            object : SingleToCompletableTests {
-                private val upstream = TestSingle<Unit>()
-                private val observer = upstream.transform().test()
+    override fun disposes_downstream_disposable_WHEN_upstream_succeeded() {
+        upstream.onSuccess(Unit)
 
-                override fun calls_onSubscribe_only_once_WHEN_subscribed() {
-                    observer.assertSubscribed()
-                }
-
-                override fun produces_error_WHEN_upstream_produced_error() {
-                    val error = Throwable()
-
-                    upstream.onError(error)
-
-                    observer.assertError(error)
-                }
-
-                override fun unsubscribes_from_upstream_WHEN_disposed() {
-                    observer.dispose()
-
-                    assertFalse(upstream.hasSubscribers)
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_succeeded() {
-                    upstream.onSuccess(Unit)
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_produced_error() {
-                    upstream.onError(Throwable())
-
-                    observer.assertDisposed()
-                }
-            }
+        observer.assertDisposed()
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/SingleToMaybeTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/SingleToMaybeTests.kt
@@ -1,67 +1,30 @@
 package com.badoo.reaktive.single
 
+import com.badoo.reaktive.base.SourceTests
+import com.badoo.reaktive.base.SourceTestsImpl
 import com.badoo.reaktive.maybe.Maybe
 import com.badoo.reaktive.test.base.assertDisposed
-import com.badoo.reaktive.test.base.assertError
-import com.badoo.reaktive.test.base.assertSubscribed
-import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.single.TestSingle
+import kotlin.test.Ignore
 import kotlin.test.Test
-import kotlin.test.assertFalse
 
-interface SingleToMaybeTests {
-
-    @Test
-    fun calls_onSubscribe_only_once_WHEN_subscribed()
-
-    @Test
-    fun produces_error_WHEN_upstream_produced_error()
-
-    @Test
-    fun unsubscribes_from_upstream_WHEN_disposed()
+interface SingleToMaybeTests : SourceTests {
 
     @Test
     fun disposes_downstream_disposable_WHEN_upstream_succeeded()
+}
 
-    @Test
-    fun disposes_downstream_disposable_WHEN_upstream_produced_error()
+@Ignore
+class SingleToMaybeTestsImpl(
+    transform: Single<Unit>.() -> Maybe<*>
+) : SingleToMaybeTests, SourceTests by SourceTestsImpl(TestSingle<Nothing>(), { transform().test() }) {
+    private val upstream = TestSingle<Unit>()
+    private val observer = upstream.transform().test()
 
-    companion object {
-        operator fun invoke(transform: Single<Unit>.() -> Maybe<*>): SingleToMaybeTests =
-            object : SingleToMaybeTests {
-                private val upstream = TestSingle<Unit>()
-                private val observer = upstream.transform().test()
+    override fun disposes_downstream_disposable_WHEN_upstream_succeeded() {
+        upstream.onSuccess(Unit)
 
-                override fun calls_onSubscribe_only_once_WHEN_subscribed() {
-                    observer.assertSubscribed()
-                }
-
-                override fun produces_error_WHEN_upstream_produced_error() {
-                    val error = Throwable()
-
-                    upstream.onError(error)
-
-                    observer.assertError(error)
-                }
-
-                override fun unsubscribes_from_upstream_WHEN_disposed() {
-                    observer.dispose()
-
-                    assertFalse(upstream.hasSubscribers)
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_succeeded() {
-                    upstream.onSuccess(Unit)
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_produced_error() {
-                    upstream.onError(Throwable())
-
-                    observer.assertDisposed()
-                }
-            }
+        observer.assertDisposed()
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/SingleToObservableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/SingleToObservableTests.kt
@@ -1,67 +1,30 @@
 package com.badoo.reaktive.single
 
+import com.badoo.reaktive.base.SourceTests
+import com.badoo.reaktive.base.SourceTestsImpl
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.test.base.assertDisposed
-import com.badoo.reaktive.test.base.assertError
-import com.badoo.reaktive.test.base.assertSubscribed
-import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.single.TestSingle
+import kotlin.test.Ignore
 import kotlin.test.Test
-import kotlin.test.assertFalse
 
-interface SingleToObservableTests {
-
-    @Test
-    fun calls_onSubscribe_only_once_WHEN_subscribed()
-
-    @Test
-    fun produces_error_WHEN_upstream_produced_error()
-
-    @Test
-    fun unsubscribes_from_upstream_WHEN_disposed()
+interface SingleToObservableTests : SourceTests {
 
     @Test
     fun disposes_downstream_disposable_WHEN_upstream_succeeded()
+}
 
-    @Test
-    fun disposes_downstream_disposable_WHEN_upstream_produced_error()
+@Ignore
+class SingleToObservableTestsImpl(
+    transform: Single<Unit>.() -> Observable<*>
+) : SingleToObservableTests, SourceTests by SourceTestsImpl(TestSingle<Nothing>(), { transform().test() }) {
+    private val upstream = TestSingle<Unit>()
+    private val observer = upstream.transform().test()
 
-    companion object {
-        operator fun invoke(transform: Single<Unit>.() -> Observable<*>): SingleToObservableTests =
-            object : SingleToObservableTests {
-                private val upstream = TestSingle<Unit>()
-                private val observer = upstream.transform().test()
+    override fun disposes_downstream_disposable_WHEN_upstream_succeeded() {
+        upstream.onSuccess(Unit)
 
-                override fun calls_onSubscribe_only_once_WHEN_subscribed() {
-                    observer.assertSubscribed()
-                }
-
-                override fun produces_error_WHEN_upstream_produced_error() {
-                    val error = Throwable()
-
-                    upstream.onError(error)
-
-                    observer.assertError(error)
-                }
-
-                override fun unsubscribes_from_upstream_WHEN_disposed() {
-                    observer.dispose()
-
-                    assertFalse(upstream.hasSubscribers)
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_succeeded() {
-                    upstream.onSuccess(Unit)
-
-                    observer.assertDisposed()
-                }
-
-                override fun disposes_downstream_disposable_WHEN_upstream_produced_error() {
-                    upstream.onError(Throwable())
-
-                    observer.assertDisposed()
-                }
-            }
+        observer.assertDisposed()
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/SubscribeOnTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/SubscribeOnTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class SubscribeOnTest : SingleToSingleTests by SingleToSingleTests({ subscribeOn(TestScheduler()) }) {
+class SubscribeOnTest : SingleToSingleTests by SingleToSingleTestsImpl({ subscribeOn(TestScheduler()) }) {
 
     private val scheduler = TestScheduler(isManualProcessing = true)
     private val upstream = TestSingle<Int>()


### PR DESCRIPTION
1. Extracted all generic tests to a separate interface + impl, this significantly reduces amount of boilerplate
2. Added two more generic tests