### PR TITLE
Give Gradle more memory and enable caching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 kotlin.code.style=official
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
+org.gradle.caching=true


### PR DESCRIPTION
Probably 512 MB is not enough.
Can't check, I use OpenJ9 because it consumes 2x less memory than default JRE.