### PR TITLE
Prevent recursive termination in XxxByEmitter

### DIFF
--- a/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/base/TestObserver.kt
+++ b/reaktive-testing/src/commonMain/kotlin/com/badoo/reaktive/test/base/TestObserver.kt
@@ -3,6 +3,7 @@ package com.badoo.reaktive.test.base
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.Observer
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import com.badoo.reaktive.utils.atomic.AtomicReference
 
 open class TestObserver : Observer, Disposable, ErrorCallback {
@@ -13,6 +14,7 @@ open class TestObserver : Observer, Disposable, ErrorCallback {
     val error: Throwable? get() = _error.value
     val isError: Boolean get() = error != null
     override val isDisposed: Boolean get() = _disposable.value?.isDisposed == true
+    private val isDisposeCalled = AtomicBoolean()
 
     override fun onSubscribe(disposable: Disposable) {
         if (this.disposable != null) {
@@ -23,6 +25,7 @@ open class TestObserver : Observer, Disposable, ErrorCallback {
     }
 
     override fun dispose() {
+        isDisposeCalled.value = true
         disposable?.dispose()
     }
 
@@ -39,6 +42,6 @@ open class TestObserver : Observer, Disposable, ErrorCallback {
     protected open fun checkActive() {
         checkNotNull(disposable) { "Not subscribed" }
         check(error == null) { "Already failed" }
-        check(!isDisposed) { "Already disposed" }
+        check(!isDisposeCalled.value) { "Already disposed" }
     }
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/CompletableByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/CompletableByEmitter.kt
@@ -24,11 +24,8 @@ inline fun completable(crossinline onSubscribe: (emitter: CompletableEmitter) ->
 
                 private inline fun doIfNotDisposedAndDispose(block: () -> Unit) {
                     if (!isDisposed) {
-                        try {
-                            block()
-                        } finally {
-                            dispose()
-                        }
+                        dispose()
+                        block()
                     }
                 }
             }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/MaybeByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/MaybeByEmitter.kt
@@ -30,11 +30,8 @@ inline fun <T> maybe(crossinline onSubscribe: (emitter: MaybeEmitter<T>) -> Unit
 
                 private inline fun doIfNotDisposedAndDispose(block: () -> Unit) {
                     if (!isDisposed) {
-                        try {
-                            block()
-                        } finally {
-                            dispose()
-                        }
+                        dispose()
+                        block()
                     }
                 }
             }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObservableByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ObservableByEmitter.kt
@@ -30,11 +30,8 @@ inline fun <T> observable(crossinline onSubscribe: (emitter: ObservableEmitter<T
 
                 private inline fun doIfNotDisposedAndDispose(block: () -> Unit) {
                     if (!isDisposed) {
-                        try {
-                            block()
-                        } finally {
-                            dispose()
-                        }
+                        dispose()
+                        block()
                     }
                 }
             }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SingleByEmitter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/SingleByEmitter.kt
@@ -26,11 +26,8 @@ inline fun <T> single(crossinline onSubscribe: (emitter: SingleEmitter<T>) -> Un
 
                 private inline fun doIfNotDisposedAndDispose(block: () -> Unit) {
                     if (!isDisposed) {
-                        try {
-                            block()
-                        } finally {
-                            dispose()
-                        }
+                        dispose()
+                        block()
                     }
                 }
             }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableByEmitterTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/CompletableByEmitterTest.kt
@@ -5,10 +5,10 @@ import com.badoo.reaktive.test.base.assertDisposed
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertNotError
 import com.badoo.reaktive.test.base.assertSubscribed
-import com.badoo.reaktive.test.completable.TestCompletableObserver
 import com.badoo.reaktive.test.completable.assertComplete
 import com.badoo.reaktive.test.completable.assertNotComplete
 import com.badoo.reaktive.test.completable.test
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertFalse
@@ -18,10 +18,11 @@ class CompletableByEmitterTest {
 
     private val emitterRef = AtomicReference<CompletableEmitter?>(null)
     private val emitter: CompletableEmitter get() = requireNotNull(emitterRef.value)
-    private val observer = createCompletableAndSubscribe(emitterRef)
+    private val completable = createCompletable(emitterRef)
+    private val observer = completable.test()
 
-    private fun createCompletableAndSubscribe(emitterReference: AtomicReference<CompletableEmitter?>): TestCompletableObserver =
-        completable { emitterReference.value = it }.test()
+    private fun createCompletable(emitterReference: AtomicReference<CompletableEmitter?>): Completable =
+        completable { emitterReference.value = it }
 
     @Test
     fun onSubscribe_called_WHEN_subscribe() {
@@ -170,4 +171,99 @@ class CompletableByEmitterTest {
 
         assertTrue(emitter.isDisposed)
     }
+
+    @Test
+    fun does_not_complete_recursively_WHEN_completing() {
+        val isCompletedRecursively = AtomicBoolean()
+        val isCompleted = AtomicBoolean()
+
+        completable.subscribe(
+            observer(
+                onComplete = {
+                    if (!isCompleted.value) {
+                        isCompleted.value = true
+                        emitter.onComplete()
+                    } else {
+                        isCompletedRecursively.value = true
+                    }
+                }
+            )
+        )
+
+        emitter.onComplete()
+
+        assertFalse(isCompletedRecursively.value)
+    }
+
+    @Test
+    fun does_not_complete_recursively_WHEN_producing_error() {
+        val isCompletedRecursively = AtomicBoolean()
+
+        completable.subscribe(
+            observer(
+                onComplete = { isCompletedRecursively.value = true },
+                onError = { emitter.onComplete() }
+            )
+        )
+
+        emitter.onError(Exception())
+
+        assertFalse(isCompletedRecursively.value)
+    }
+
+    @Test
+    fun does_not_produce_error_recursively_WHEN_completing() {
+        val isErrorRecursively = AtomicBoolean()
+
+        completable.subscribe(
+            observer(
+                onComplete = { emitter.onError(Exception()) },
+                onError = { isErrorRecursively.value = true }
+            )
+        )
+
+        emitter.onComplete()
+
+        assertFalse(isErrorRecursively.value)
+    }
+
+    @Test
+    fun does_not_produce_error_recursively_WHEN_producing_error() {
+        val isErrorRecursively = AtomicBoolean()
+        val hasError = AtomicBoolean()
+
+        completable.subscribe(
+            observer(
+                onError = {
+                    if (!hasError.value) {
+                        hasError.value = true
+                        emitter.onError(Exception())
+                    } else {
+                        isErrorRecursively.value = true
+                    }
+                }
+            )
+        )
+
+        emitter.onError(Exception())
+
+        assertFalse(isErrorRecursively.value)
+    }
+
+    private fun observer(
+        onComplete: () -> Unit = {},
+        onError: (Throwable) -> Unit = {}
+    ): CompletableObserver =
+        object : CompletableObserver {
+            override fun onSubscribe(disposable: Disposable) {
+            }
+
+            override fun onComplete() {
+                onComplete.invoke()
+            }
+
+            override fun onError(error: Throwable) {
+                onError.invoke(error)
+            }
+        }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeByEmitterTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/MaybeByEmitterTest.kt
@@ -5,12 +5,12 @@ import com.badoo.reaktive.test.base.assertDisposed
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertNotError
 import com.badoo.reaktive.test.base.assertSubscribed
-import com.badoo.reaktive.test.maybe.TestMaybeObserver
 import com.badoo.reaktive.test.maybe.assertComplete
 import com.badoo.reaktive.test.maybe.assertNotComplete
 import com.badoo.reaktive.test.maybe.assertNotSuccess
 import com.badoo.reaktive.test.maybe.assertSuccess
 import com.badoo.reaktive.test.maybe.test
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertFalse
@@ -20,10 +20,12 @@ class MaybeByEmitterTest {
 
     private val emitterRef = AtomicReference<MaybeEmitter<Int?>?>(null)
     private val emitter: MaybeEmitter<Int?> get() = requireNotNull(emitterRef.value)
-    private val observer = createMaybeAndSubscribe(emitterRef)
+    private val maybe = createMaybe(emitterRef)
+    private val observer = maybe.test()
 
-    private fun createMaybeAndSubscribe(emitterReference: AtomicReference<MaybeEmitter<Int?>?>): TestMaybeObserver<Int?> =
-        maybe<Int?> { emitterReference.value = it }.test()
+    // To avoid freezing of the test class
+    private fun createMaybe(emitterReference: AtomicReference<MaybeEmitter<Int?>?>): Maybe<Int?> =
+        maybe { emitterReference.value = it }
 
     @Test
     fun onSubscribe_called_WHEN_subscribe() {
@@ -71,7 +73,7 @@ class MaybeByEmitterTest {
 
     @Test
     fun onSuccess_ignored_AFTER_onComplete_is_signalled() {
-        emitter.onError(Throwable())
+        emitter.onComplete()
         observer.reset()
         emitter.onSuccess(1)
 
@@ -274,4 +276,191 @@ class MaybeByEmitterTest {
 
         assertTrue(emitter.isDisposed)
     }
+
+    @Test
+    fun does_not_success_recursively_WHEN_succeeding() {
+        val isSucceededRecursively = AtomicBoolean()
+        val isSucceeded = AtomicBoolean()
+
+        maybe.subscribe(
+            observer(
+                onSuccess = {
+                    if (!isSucceeded.value) {
+                        isSucceeded.value = true
+                        emitter.onSuccess(0)
+                    } else {
+                        isSucceededRecursively.value = true
+                    }
+                }
+            )
+        )
+
+        emitter.onSuccess(0)
+
+        assertFalse(isSucceededRecursively.value)
+    }
+
+    @Test
+    fun does_not_success_recursively_WHEN_completing() {
+        val isSucceededRecursively = AtomicBoolean()
+
+        maybe.subscribe(
+            observer(
+                onSuccess = { isSucceededRecursively.value = true },
+                onComplete = { emitter.onSuccess(0) }
+            )
+        )
+
+        emitter.onComplete()
+
+        assertFalse(isSucceededRecursively.value)
+    }
+
+    @Test
+    fun does_not_success_recursively_WHEN_producing_error() {
+        val isSucceededRecursively = AtomicBoolean()
+
+        maybe.subscribe(
+            observer(
+                onSuccess = { isSucceededRecursively.value = true },
+                onError = { emitter.onSuccess(0) }
+            )
+        )
+
+        emitter.onError(Exception())
+
+        assertFalse(isSucceededRecursively.value)
+    }
+
+    @Test
+    fun does_not_complete_recursively_WHEN_succeeding() {
+        val isCompletedRecursively = AtomicBoolean()
+
+        maybe.subscribe(
+            observer(
+                onSuccess = { emitter.onComplete() },
+                onComplete = { isCompletedRecursively.value = true }
+            )
+        )
+
+        emitter.onSuccess(0)
+
+        assertFalse(isCompletedRecursively.value)
+    }
+
+    @Test
+    fun does_not_complete_recursively_WHEN_completing() {
+        val isCompletedRecursively = AtomicBoolean()
+        val isCompleted = AtomicBoolean()
+
+        maybe.subscribe(
+            observer(
+                onComplete = {
+                    if (!isCompleted.value) {
+                        isCompleted.value = true
+                        emitter.onComplete()
+                    } else {
+                        isCompletedRecursively.value = true
+                    }
+                }
+            )
+        )
+
+        emitter.onComplete()
+
+        assertFalse(isCompletedRecursively.value)
+    }
+
+    @Test
+    fun does_not_complete_recursively_WHEN_producing_error() {
+        val isCompletedRecursively = AtomicBoolean()
+
+        maybe.subscribe(
+            observer(
+                onComplete = { isCompletedRecursively.value = true },
+                onError = { emitter.onComplete() }
+            )
+        )
+
+        emitter.onError(Exception())
+
+        assertFalse(isCompletedRecursively.value)
+    }
+
+    @Test
+    fun does_not_produce_error_recursively_WHEN_succeeding() {
+        val isErrorRecursively = AtomicBoolean()
+
+        maybe.subscribe(
+            observer(
+                onSuccess = { emitter.onError(Exception()) },
+                onError = { isErrorRecursively.value = true }
+            )
+        )
+
+        emitter.onSuccess(0)
+
+        assertFalse(isErrorRecursively.value)
+    }
+
+    @Test
+    fun does_not_produce_error_recursively_WHEN_completing() {
+        val isErrorRecursively = AtomicBoolean()
+
+        maybe.subscribe(
+            observer(
+                onComplete = { emitter.onError(Exception()) },
+                onError = { isErrorRecursively.value = true }
+            )
+        )
+
+        emitter.onComplete()
+
+        assertFalse(isErrorRecursively.value)
+    }
+
+    @Test
+    fun does_not_produce_error_recursively_WHEN_producing_error() {
+        val isErrorRecursively = AtomicBoolean()
+        val hasError = AtomicBoolean()
+
+        maybe.subscribe(
+            observer(
+                onError = {
+                    if (!hasError.value) {
+                        hasError.value = true
+                        emitter.onError(Exception())
+                    } else {
+                        isErrorRecursively.value = true
+                    }
+                }
+            )
+        )
+
+        emitter.onError(Exception())
+
+        assertFalse(isErrorRecursively.value)
+    }
+
+    private fun observer(
+        onSuccess: (Int?) -> Unit = {},
+        onComplete: () -> Unit = {},
+        onError: (Throwable) -> Unit = {}
+    ): MaybeObserver<Int?> =
+        object : MaybeObserver<Int?> {
+            override fun onSubscribe(disposable: Disposable) {
+            }
+
+            override fun onSuccess(value: Int?) {
+                onSuccess.invoke(value)
+            }
+
+            override fun onComplete() {
+                onComplete.invoke()
+            }
+
+            override fun onError(error: Throwable) {
+                onError.invoke(error)
+            }
+        }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableByEmitterTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ObservableByEmitterTest.kt
@@ -5,12 +5,12 @@ import com.badoo.reaktive.test.base.assertDisposed
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertNotError
 import com.badoo.reaktive.test.base.assertSubscribed
-import com.badoo.reaktive.test.observable.TestObservableObserver
 import com.badoo.reaktive.test.observable.assertComplete
 import com.badoo.reaktive.test.observable.assertNoValues
 import com.badoo.reaktive.test.observable.assertNotComplete
 import com.badoo.reaktive.test.observable.assertValues
 import com.badoo.reaktive.test.observable.test
+import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertFalse
@@ -20,10 +20,12 @@ class ObservableByEmitterTest {
 
     private val emitterRef = AtomicReference<ObservableEmitter<Int?>?>(null)
     private val emitter: ObservableEmitter<Int?> get() = requireNotNull(emitterRef.value)
-    private val observer = createObservableAndSubscribe(emitterRef)
+    private val observable = createObservable(emitterRef)
+    private val observer = observable.test()
 
-    private fun createObservableAndSubscribe(emitterReference: AtomicReference<ObservableEmitter<Int?>?>): TestObservableObserver<Int?> =
-        observable<Int?> { emitterReference.value = it }.test()
+    // To avoid freezing of the test class
+    private fun createObservable(emitterReference: AtomicReference<ObservableEmitter<Int?>?>): Observable<Int?> =
+        observable { emitterReference.value = it }
 
     @Test
     fun onSubscribe_called_WHEN_subscribe() {
@@ -250,4 +252,137 @@ class ObservableByEmitterTest {
 
         assertTrue(emitter.isDisposed)
     }
+
+    @Test
+    fun does_not_emit_values_recursively_WHEN_completing() {
+        val isEmittedRecursively = AtomicBoolean()
+
+        observable.subscribe(
+            observer(
+                onNext = { isEmittedRecursively.value = true },
+                onComplete = { emitter.onNext(0) }
+            )
+        )
+
+        emitter.onComplete()
+
+        assertFalse(isEmittedRecursively.value)
+    }
+
+    @Test
+    fun does_not_emit_values_recursively_WHEN_producing_error() {
+        val isEmittedRecursively = AtomicBoolean()
+
+        observable.subscribe(
+            observer(
+                onNext = { isEmittedRecursively.value = true },
+                onError = { emitter.onNext(0) }
+            )
+        )
+
+        emitter.onError(Exception())
+
+        assertFalse(isEmittedRecursively.value)
+    }
+
+    @Test
+    fun does_not_complete_recursively_WHEN_completing() {
+        val isCompletedRecursively = AtomicBoolean()
+        val isCompleted = AtomicBoolean()
+
+        observable.subscribe(
+            observer(
+                onComplete = {
+                    if (!isCompleted.value) {
+                        isCompleted.value = true
+                        emitter.onComplete()
+                    } else {
+                        isCompletedRecursively.value = true
+                    }
+                }
+            )
+        )
+
+        emitter.onComplete()
+
+        assertFalse(isCompletedRecursively.value)
+    }
+
+    @Test
+    fun does_not_complete_recursively_WHEN_producing_error() {
+        val isCompletedRecursively = AtomicBoolean()
+
+        observable.subscribe(
+            observer(
+                onComplete = { isCompletedRecursively.value = true },
+                onError = { emitter.onComplete() }
+            )
+        )
+
+        emitter.onError(Exception())
+
+        assertFalse(isCompletedRecursively.value)
+    }
+
+    @Test
+    fun does_not_produce_error_recursively_WHEN_completing() {
+        val isErrorRecursively = AtomicBoolean()
+
+        observable.subscribe(
+            observer(
+                onComplete = { emitter.onError(Exception()) },
+                onError = { isErrorRecursively.value = true }
+            )
+        )
+
+        emitter.onComplete()
+
+        assertFalse(isErrorRecursively.value)
+    }
+
+
+    @Test
+    fun does_not_produce_error_recursively_WHEN_producing_error() {
+        val isErrorRecursively = AtomicBoolean()
+        val hasError = AtomicBoolean()
+
+        observable.subscribe(
+            observer(
+                onError = {
+                    if (!hasError.value) {
+                        hasError.value = true
+                        emitter.onError(Exception())
+                    } else {
+                        isErrorRecursively.value = true
+                    }
+                }
+            )
+        )
+
+        emitter.onError(Exception())
+
+        assertFalse(isErrorRecursively.value)
+    }
+
+    private fun observer(
+        onNext: (Int?) -> Unit = {},
+        onComplete: () -> Unit = {},
+        onError: (Throwable) -> Unit = {}
+    ): ObservableObserver<Int?> =
+        object : ObservableObserver<Int?> {
+            override fun onSubscribe(disposable: Disposable) {
+            }
+
+            override fun onNext(value: Int?) {
+                onNext.invoke(value)
+            }
+
+            override fun onComplete() {
+                onComplete.invoke()
+            }
+
+            override fun onError(error: Throwable) {
+                onError.invoke(error)
+            }
+        }
 }


### PR DESCRIPTION
Found a bug - if you call terminal callbacks of an emitter recursively then the stream terminates twice.
Solution - dispose before call downstream's terminal callbacks.