### PR TITLE
Rename RxJava2 interop converters to avoid clashing

### DIFF
--- a/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Completable.kt
+++ b/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Completable.kt
@@ -5,49 +5,64 @@ import com.badoo.reaktive.completable.CompletableObserver
 import com.badoo.reaktive.completable.completableUnsafe
 import com.badoo.reaktive.disposable.Disposable
 
-fun Completable.asRxJava2Source(): io.reactivex.CompletableSource =
+fun Completable.asRxJava2CompletableSource(): io.reactivex.CompletableSource =
     io.reactivex.CompletableSource { observer ->
-        subscribe(observer.asReaktive())
+        subscribe(observer.asReaktiveCompletableObserver())
     }
 
-fun Completable.asRxJava2(): io.reactivex.Completable =
+@Deprecated(message = "Use asRxJava2CompletableSource", replaceWith = ReplaceWith("asRxJava2CompletableSource()"))
+fun Completable.asRxJava2Source(): io.reactivex.CompletableSource = asRxJava2CompletableSource()
+
+fun Completable.asRxJava2Completable(): io.reactivex.Completable =
     object : io.reactivex.Completable() {
         override fun subscribeActual(observer: io.reactivex.CompletableObserver) {
-            this@asRxJava2.subscribe(observer.asReaktive())
+            this@asRxJava2Completable.subscribe(observer.asReaktiveCompletableObserver())
         }
     }
 
-fun io.reactivex.CompletableSource.asReaktive(): Completable =
+@Deprecated(message = "Use asRxJava2Completable", replaceWith = ReplaceWith("asRxJava2Completable()"))
+fun Completable.asRxJava2(): io.reactivex.Completable = asRxJava2Completable()
+
+fun io.reactivex.CompletableSource.asReaktiveCompletable(): Completable =
     completableUnsafe { observer ->
-        subscribe(observer.asRxJava2())
+        subscribe(observer.asRxJava2CompletableObserver())
     }
 
-fun io.reactivex.CompletableObserver.asReaktive(): CompletableObserver =
+@Deprecated(message = "Use asReaktiveCompletable", replaceWith = ReplaceWith("asReaktiveCompletable()"))
+fun io.reactivex.CompletableSource.asReaktive(): Completable = asReaktiveCompletable()
+
+fun io.reactivex.CompletableObserver.asReaktiveCompletableObserver(): CompletableObserver =
     object : CompletableObserver {
         override fun onSubscribe(disposable: Disposable) {
-            this@asReaktive.onSubscribe(disposable.asRxJava2())
+            this@asReaktiveCompletableObserver.onSubscribe(disposable.asRxJava2Disposable())
         }
 
         override fun onComplete() {
-            this@asReaktive.onComplete()
+            this@asReaktiveCompletableObserver.onComplete()
         }
 
         override fun onError(error: Throwable) {
-            this@asReaktive.onError(error)
+            this@asReaktiveCompletableObserver.onError(error)
         }
     }
 
-fun CompletableObserver.asRxJava2(): io.reactivex.CompletableObserver =
+@Deprecated(message = "Use asReaktiveCompletableObserver", replaceWith = ReplaceWith("asReaktiveCompletableObserver()"))
+fun io.reactivex.CompletableObserver.asReaktive(): CompletableObserver = asReaktiveCompletableObserver()
+
+fun CompletableObserver.asRxJava2CompletableObserver(): io.reactivex.CompletableObserver =
     object : io.reactivex.CompletableObserver {
         override fun onSubscribe(disposable: io.reactivex.disposables.Disposable) {
-            this@asRxJava2.onSubscribe(disposable.asReaktive())
+            this@asRxJava2CompletableObserver.onSubscribe(disposable.asReaktiveDisposable())
         }
 
         override fun onComplete() {
-            this@asRxJava2.onComplete()
+            this@asRxJava2CompletableObserver.onComplete()
         }
 
         override fun onError(error: Throwable) {
-            this@asRxJava2.onError(error)
+            this@asRxJava2CompletableObserver.onError(error)
         }
     }
+
+@Deprecated(message = "Use asRxJava2CompletableObserver", replaceWith = ReplaceWith("asRxJava2CompletableObserver()"))
+fun CompletableObserver.asRxJava2(): io.reactivex.CompletableObserver = asRxJava2CompletableObserver()

--- a/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Disposable.kt
+++ b/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Disposable.kt
@@ -2,20 +2,26 @@ package com.badoo.reaktive.rxjavainterop
 
 import com.badoo.reaktive.disposable.Disposable
 
-fun Disposable.asRxJava2(): io.reactivex.disposables.Disposable =
+fun Disposable.asRxJava2Disposable(): io.reactivex.disposables.Disposable =
     object : io.reactivex.disposables.Disposable {
-        override fun isDisposed(): Boolean = this@asRxJava2.isDisposed
+        override fun isDisposed(): Boolean = this@asRxJava2Disposable.isDisposed
 
         override fun dispose() {
-            this@asRxJava2.dispose()
+            this@asRxJava2Disposable.dispose()
         }
     }
 
-fun io.reactivex.disposables.Disposable.asReaktive(): Disposable =
+@Deprecated(message = "Use asRxJava2Disposable", replaceWith = ReplaceWith("asRxJava2Disposable()"))
+fun Disposable.asRxJava2(): io.reactivex.disposables.Disposable = asRxJava2Disposable()
+
+fun io.reactivex.disposables.Disposable.asReaktiveDisposable(): Disposable =
     object : Disposable {
-        override val isDisposed: Boolean get() = this@asReaktive.isDisposed
+        override val isDisposed: Boolean get() = this@asReaktiveDisposable.isDisposed
 
         override fun dispose() {
-            this@asReaktive.dispose()
+            this@asReaktiveDisposable.dispose()
         }
     }
+
+@Deprecated(message = "Use asReaktiveDisposable", replaceWith = ReplaceWith("asReaktiveDisposable()"))
+fun io.reactivex.disposables.Disposable.asReaktive(): Disposable = asReaktiveDisposable()

--- a/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Maybe.kt
+++ b/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Maybe.kt
@@ -5,57 +5,72 @@ import com.badoo.reaktive.maybe.Maybe
 import com.badoo.reaktive.maybe.MaybeObserver
 import com.badoo.reaktive.maybe.maybeUnsafe
 
-fun <T> Maybe<T>.asRxJava2Source(): io.reactivex.MaybeSource<T> =
+fun <T> Maybe<T>.asRxJava2MaybeSource(): io.reactivex.MaybeSource<T> =
     io.reactivex.MaybeSource { observer ->
-        subscribe(observer.asReaktive())
+        subscribe(observer.asReaktiveMaybeObserver())
     }
 
-fun <T> Maybe<T>.asRxJava2(): io.reactivex.Maybe<T> =
+@Deprecated(message = "Use asRxJava2MaybeSource", replaceWith = ReplaceWith("asRxJava2MaybeSource()"))
+fun <T> Maybe<T>.asRxJava2Source(): io.reactivex.MaybeSource<T> = asRxJava2MaybeSource()
+
+fun <T> Maybe<T>.asRxJava2Maybe(): io.reactivex.Maybe<T> =
     object : io.reactivex.Maybe<T>() {
         override fun subscribeActual(observer: io.reactivex.MaybeObserver<in T>) {
-            this@asRxJava2.subscribe(observer.asReaktive())
+            this@asRxJava2Maybe.subscribe(observer.asReaktiveMaybeObserver())
         }
     }
 
-fun <T> io.reactivex.MaybeSource<out T>.asReaktive(): Maybe<T> =
+@Deprecated(message = "Use asRxJava2Maybe", replaceWith = ReplaceWith("asRxJava2Maybe()"))
+fun <T> Maybe<T>.asRxJava2(): io.reactivex.Maybe<T> = asRxJava2Maybe()
+
+fun <T> io.reactivex.MaybeSource<out T>.asReaktiveMaybe(): Maybe<T> =
     maybeUnsafe { observer ->
-        subscribe(observer.asRxJava2())
+        subscribe(observer.asRxJava2MaybeObserver())
     }
 
-fun <T> io.reactivex.MaybeObserver<in T>.asReaktive(): MaybeObserver<T> =
+@Deprecated(message = "Use asReaktiveMaybe", replaceWith = ReplaceWith("asReaktiveMaybe()"))
+fun <T> io.reactivex.MaybeSource<out T>.asReaktive(): Maybe<T> = asReaktiveMaybe()
+
+fun <T> io.reactivex.MaybeObserver<in T>.asReaktiveMaybeObserver(): MaybeObserver<T> =
     object : MaybeObserver<T> {
         override fun onSubscribe(disposable: Disposable) {
-            this@asReaktive.onSubscribe(disposable.asRxJava2())
+            this@asReaktiveMaybeObserver.onSubscribe(disposable.asRxJava2Disposable())
         }
 
         override fun onSuccess(value: T) {
-            this@asReaktive.onSuccess(value)
+            this@asReaktiveMaybeObserver.onSuccess(value)
         }
 
         override fun onComplete() {
-            this@asReaktive.onComplete()
+            this@asReaktiveMaybeObserver.onComplete()
         }
 
         override fun onError(error: Throwable) {
-            this@asReaktive.onError(error)
+            this@asReaktiveMaybeObserver.onError(error)
         }
     }
 
-fun <T> MaybeObserver<T>.asRxJava2(): io.reactivex.MaybeObserver<T> =
+@Deprecated(message = "Use asReaktiveMaybeObserver", replaceWith = ReplaceWith("asReaktiveMaybeObserver()"))
+fun <T> io.reactivex.MaybeObserver<in T>.asReaktive(): MaybeObserver<T> = asReaktiveMaybeObserver()
+
+fun <T> MaybeObserver<T>.asRxJava2MaybeObserver(): io.reactivex.MaybeObserver<T> =
     object : io.reactivex.MaybeObserver<T> {
         override fun onSubscribe(disposable: io.reactivex.disposables.Disposable) {
-            this@asRxJava2.onSubscribe(disposable.asReaktive())
+            this@asRxJava2MaybeObserver.onSubscribe(disposable.asReaktiveDisposable())
         }
 
         override fun onSuccess(value: T) {
-            this@asRxJava2.onSuccess(value)
+            this@asRxJava2MaybeObserver.onSuccess(value)
         }
 
         override fun onComplete() {
-            this@asRxJava2.onComplete()
+            this@asRxJava2MaybeObserver.onComplete()
         }
 
         override fun onError(error: Throwable) {
-            this@asRxJava2.onError(error)
+            this@asRxJava2MaybeObserver.onError(error)
         }
     }
+
+@Deprecated(message = "Use asRxJava2MaybeObserver", replaceWith = ReplaceWith("asRxJava2MaybeObserver()"))
+fun <T> MaybeObserver<T>.asRxJava2(): io.reactivex.MaybeObserver<T> = asRxJava2MaybeObserver()

--- a/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Observable.kt
+++ b/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Observable.kt
@@ -5,57 +5,72 @@ import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.observable.ObservableObserver
 import com.badoo.reaktive.observable.observableUnsafe
 
-fun <T> Observable<T>.asRxJava2Source(): io.reactivex.ObservableSource<T> =
+fun <T> Observable<T>.asRxJava2ObservableSource(): io.reactivex.ObservableSource<T> =
     io.reactivex.ObservableSource { observer ->
-        subscribe(observer.asReaktive())
+        subscribe(observer.asReaktiveObservableObserver())
     }
 
-fun <T> Observable<T>.asRxJava2(): io.reactivex.Observable<T> =
+@Deprecated(message = "Use asRxJava2ObservableSource", replaceWith = ReplaceWith("asRxJava2ObservableSource()"))
+fun <T> Observable<T>.asRxJava2Source(): io.reactivex.ObservableSource<T> = asRxJava2ObservableSource()
+
+fun <T> Observable<T>.asRxJava2Observable(): io.reactivex.Observable<T> =
     object : io.reactivex.Observable<T>() {
         override fun subscribeActual(observer: io.reactivex.Observer<in T>) {
-            this@asRxJava2.subscribe(observer.asReaktive())
+            this@asRxJava2Observable.subscribe(observer.asReaktiveObservableObserver())
         }
     }
 
-fun <T> io.reactivex.ObservableSource<out T>.asReaktive(): Observable<T> =
+@Deprecated(message = "Use asRxJava2Observable", replaceWith = ReplaceWith("asRxJava2Observable()"))
+fun <T> Observable<T>.asRxJava2(): io.reactivex.Observable<T> = asRxJava2Observable()
+
+fun <T> io.reactivex.ObservableSource<out T>.asReaktiveObservable(): Observable<T> =
     observableUnsafe { observer ->
-        subscribe(observer.asRxJava2())
+        subscribe(observer.asRxJava2Observer())
     }
 
-fun <T> io.reactivex.Observer<in T>.asReaktive(): ObservableObserver<T> =
+@Deprecated(message = "Use asReaktiveObservable", replaceWith = ReplaceWith("asReaktiveObservable()"))
+fun <T> io.reactivex.ObservableSource<out T>.asReaktive(): Observable<T> = asReaktiveObservable()
+
+fun <T> io.reactivex.Observer<in T>.asReaktiveObservableObserver(): ObservableObserver<T> =
     object : ObservableObserver<T> {
         override fun onSubscribe(disposable: Disposable) {
-            this@asReaktive.onSubscribe(disposable.asRxJava2())
+            this@asReaktiveObservableObserver.onSubscribe(disposable.asRxJava2Disposable())
         }
 
         override fun onNext(value: T) {
-            this@asReaktive.onNext(value)
+            this@asReaktiveObservableObserver.onNext(value)
         }
 
         override fun onComplete() {
-            this@asReaktive.onComplete()
+            this@asReaktiveObservableObserver.onComplete()
         }
 
         override fun onError(error: Throwable) {
-            this@asReaktive.onError(error)
+            this@asReaktiveObservableObserver.onError(error)
         }
     }
 
-fun <T> ObservableObserver<T>.asRxJava2(): io.reactivex.Observer<T> =
+@Deprecated(message = "Use asReaktiveObservableObserver", replaceWith = ReplaceWith("asReaktiveObservableObserver()"))
+fun <T> io.reactivex.Observer<in T>.asReaktive(): ObservableObserver<T> = asReaktiveObservableObserver()
+
+fun <T> ObservableObserver<T>.asRxJava2Observer(): io.reactivex.Observer<T> =
     object : io.reactivex.Observer<T> {
         override fun onSubscribe(disposable: io.reactivex.disposables.Disposable) {
-            this@asRxJava2.onSubscribe(disposable.asReaktive())
+            this@asRxJava2Observer.onSubscribe(disposable.asReaktiveDisposable())
         }
 
         override fun onNext(value: T) {
-            this@asRxJava2.onNext(value)
+            this@asRxJava2Observer.onNext(value)
         }
 
         override fun onComplete() {
-            this@asRxJava2.onComplete()
+            this@asRxJava2Observer.onComplete()
         }
 
         override fun onError(error: Throwable) {
-            this@asRxJava2.onError(error)
+            this@asRxJava2Observer.onError(error)
         }
     }
+
+@Deprecated(message = "Use asRxJava2Observer", replaceWith = ReplaceWith("asRxJava2Observer()"))
+fun <T> ObservableObserver<T>.asRxJava2(): io.reactivex.Observer<T> = asRxJava2Observer()

--- a/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Scheduler.kt
+++ b/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Scheduler.kt
@@ -6,20 +6,23 @@ import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
 import java.util.concurrent.TimeUnit
 
-fun io.reactivex.Scheduler.asReaktive(): Scheduler =
+fun io.reactivex.Scheduler.asReaktiveScheduler(): Scheduler =
     object : Scheduler {
         private val disposables = CompositeDisposable()
 
         override fun newExecutor(): Scheduler.Executor =
-            this@asReaktive
+            this@asReaktiveScheduler
                 .createWorker()
                 .asExecutor(disposables)
 
         override fun destroy() {
             disposables.dispose()
-            this@asReaktive.shutdown()
+            this@asReaktiveScheduler.shutdown()
         }
     }
+
+@Deprecated(message = "Use asReaktiveScheduler", replaceWith = ReplaceWith("asReaktiveScheduler()"))
+fun io.reactivex.Scheduler.asReaktive(): Scheduler = asReaktiveScheduler()
 
 private fun io.reactivex.Scheduler.Worker.asExecutor(disposables: CompositeDisposable): Scheduler.Executor =
     object : Scheduler.Executor {
@@ -42,7 +45,7 @@ private fun io.reactivex.Scheduler.Worker.asExecutor(disposables: CompositeDispo
             taskDisposables +=
                 this@asExecutor
                     .schedule(task, delayMillis, TimeUnit.MILLISECONDS)
-                    .asReaktive()
+                    .asReaktiveDisposable()
         }
 
         override fun submitRepeating(startDelayMillis: Long, periodMillis: Long, task: () -> Unit) {
@@ -51,7 +54,7 @@ private fun io.reactivex.Scheduler.Worker.asExecutor(disposables: CompositeDispo
             taskDisposables +=
                 this@asExecutor
                     .schedulePeriodically(task, startDelayMillis, periodMillis, TimeUnit.MILLISECONDS)
-                    .asReaktive()
+                    .asReaktiveDisposable()
         }
 
         override fun cancel() {

--- a/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Single.kt
+++ b/rxjava2-interop/src/main/kotlin/com/badoo/reaktive/rxjavainterop/Single.kt
@@ -5,49 +5,64 @@ import com.badoo.reaktive.single.Single
 import com.badoo.reaktive.single.SingleObserver
 import com.badoo.reaktive.single.singleUnsafe
 
-fun <T> Single<T>.asRxJava2Source(): io.reactivex.SingleSource<T> =
+fun <T> Single<T>.asRxJava2SingleSource(): io.reactivex.SingleSource<T> =
     io.reactivex.SingleSource { observer ->
-        subscribe(observer.asReaktive())
+        subscribe(observer.asReaktiveSingleObserver())
     }
 
-fun <T> Single<T>.asRxJava2(): io.reactivex.Single<T> =
+@Deprecated(message = "Use asRxJava2SingleSource", replaceWith = ReplaceWith("asRxJava2SingleSource()"))
+fun <T> Single<T>.asRxJava2Source(): io.reactivex.SingleSource<T> = asRxJava2SingleSource()
+
+fun <T> Single<T>.asRxJava2Single(): io.reactivex.Single<T> =
     object : io.reactivex.Single<T>() {
         override fun subscribeActual(observer: io.reactivex.SingleObserver<in T>) {
-            this@asRxJava2.subscribe(observer.asReaktive())
+            this@asRxJava2Single.subscribe(observer.asReaktiveSingleObserver())
         }
     }
 
-fun <T> io.reactivex.SingleSource<out T>.asReaktive(): Single<T> =
+@Deprecated(message = "Use asRxJava2Single", replaceWith = ReplaceWith("asRxJava2Single()"))
+fun <T> Single<T>.asRxJava2(): io.reactivex.Single<T> = asRxJava2Single()
+
+fun <T> io.reactivex.SingleSource<out T>.asReaktiveSingle(): Single<T> =
     singleUnsafe { observer ->
-        subscribe(observer.asRxJava2())
+        subscribe(observer.asRxJava2SingleObserver())
     }
 
-fun <T> io.reactivex.SingleObserver<in T>.asReaktive(): SingleObserver<T> =
+@Deprecated(message = "Use asReaktiveSingle", replaceWith = ReplaceWith("asReaktiveSingle()"))
+fun <T> io.reactivex.SingleSource<out T>.asReaktive(): Single<T> = asReaktiveSingle()
+
+fun <T> io.reactivex.SingleObserver<in T>.asReaktiveSingleObserver(): SingleObserver<T> =
     object : SingleObserver<T> {
         override fun onSubscribe(disposable: Disposable) {
-            this@asReaktive.onSubscribe(disposable.asRxJava2())
+            this@asReaktiveSingleObserver.onSubscribe(disposable.asRxJava2Disposable())
         }
 
         override fun onSuccess(value: T) {
-            this@asReaktive.onSuccess(value)
+            this@asReaktiveSingleObserver.onSuccess(value)
         }
 
         override fun onError(error: Throwable) {
-            this@asReaktive.onError(error)
+            this@asReaktiveSingleObserver.onError(error)
         }
     }
 
-fun <T> SingleObserver<T>.asRxJava2(): io.reactivex.SingleObserver<T> =
+@Deprecated(message = "Use asReaktiveSingleObserver", replaceWith = ReplaceWith("asReaktiveSingleObserver()"))
+fun <T> io.reactivex.SingleObserver<in T>.asReaktive(): SingleObserver<T> = asReaktiveSingleObserver()
+
+fun <T> SingleObserver<T>.asRxJava2SingleObserver(): io.reactivex.SingleObserver<T> =
     object : io.reactivex.SingleObserver<T> {
         override fun onSubscribe(disposable: io.reactivex.disposables.Disposable) {
-            this@asRxJava2.onSubscribe(disposable.asReaktive())
+            this@asRxJava2SingleObserver.onSubscribe(disposable.asReaktiveDisposable())
         }
 
         override fun onSuccess(value: T) {
-            this@asRxJava2.onSuccess(value)
+            this@asRxJava2SingleObserver.onSuccess(value)
         }
 
         override fun onError(error: Throwable) {
-            this@asRxJava2.onError(error)
+            this@asRxJava2SingleObserver.onError(error)
         }
     }
+
+@Deprecated(message = "Use asRxJava2SingleObserver", replaceWith = ReplaceWith("asRxJava2SingleObserver()"))
+fun <T> SingleObserver<T>.asRxJava2(): io.reactivex.SingleObserver<T> = asRxJava2SingleObserver()

--- a/tools/binary-compatibility/reference-public-api/rxjava2-interop.txt
+++ b/tools/binary-compatibility/reference-public-api/rxjava2-interop.txt
@@ -1,41 +1,64 @@
 public final class com/badoo/reaktive/rxjavainterop/CompletableKt {
 	public static final fun asReaktive (Lio/reactivex/CompletableObserver;)Lcom/badoo/reaktive/completable/CompletableObserver;
 	public static final fun asReaktive (Lio/reactivex/CompletableSource;)Lcom/badoo/reaktive/completable/Completable;
+	public static final fun asReaktiveCompletable (Lio/reactivex/CompletableSource;)Lcom/badoo/reaktive/completable/Completable;
+	public static final fun asReaktiveCompletableObserver (Lio/reactivex/CompletableObserver;)Lcom/badoo/reaktive/completable/CompletableObserver;
 	public static final fun asRxJava2 (Lcom/badoo/reaktive/completable/Completable;)Lio/reactivex/Completable;
 	public static final fun asRxJava2 (Lcom/badoo/reaktive/completable/CompletableObserver;)Lio/reactivex/CompletableObserver;
+	public static final fun asRxJava2Completable (Lcom/badoo/reaktive/completable/Completable;)Lio/reactivex/Completable;
+	public static final fun asRxJava2CompletableObserver (Lcom/badoo/reaktive/completable/CompletableObserver;)Lio/reactivex/CompletableObserver;
+	public static final fun asRxJava2CompletableSource (Lcom/badoo/reaktive/completable/Completable;)Lio/reactivex/CompletableSource;
 	public static final fun asRxJava2Source (Lcom/badoo/reaktive/completable/Completable;)Lio/reactivex/CompletableSource;
 }
 
 public final class com/badoo/reaktive/rxjavainterop/DisposableKt {
 	public static final fun asReaktive (Lio/reactivex/disposables/Disposable;)Lcom/badoo/reaktive/disposable/Disposable;
+	public static final fun asReaktiveDisposable (Lio/reactivex/disposables/Disposable;)Lcom/badoo/reaktive/disposable/Disposable;
 	public static final fun asRxJava2 (Lcom/badoo/reaktive/disposable/Disposable;)Lio/reactivex/disposables/Disposable;
+	public static final fun asRxJava2Disposable (Lcom/badoo/reaktive/disposable/Disposable;)Lio/reactivex/disposables/Disposable;
 }
 
 public final class com/badoo/reaktive/rxjavainterop/MaybeKt {
 	public static final fun asReaktive (Lio/reactivex/MaybeObserver;)Lcom/badoo/reaktive/maybe/MaybeObserver;
 	public static final fun asReaktive (Lio/reactivex/MaybeSource;)Lcom/badoo/reaktive/maybe/Maybe;
+	public static final fun asReaktiveMaybe (Lio/reactivex/MaybeSource;)Lcom/badoo/reaktive/maybe/Maybe;
+	public static final fun asReaktiveMaybeObserver (Lio/reactivex/MaybeObserver;)Lcom/badoo/reaktive/maybe/MaybeObserver;
 	public static final fun asRxJava2 (Lcom/badoo/reaktive/maybe/Maybe;)Lio/reactivex/Maybe;
 	public static final fun asRxJava2 (Lcom/badoo/reaktive/maybe/MaybeObserver;)Lio/reactivex/MaybeObserver;
+	public static final fun asRxJava2Maybe (Lcom/badoo/reaktive/maybe/Maybe;)Lio/reactivex/Maybe;
+	public static final fun asRxJava2MaybeObserver (Lcom/badoo/reaktive/maybe/MaybeObserver;)Lio/reactivex/MaybeObserver;
+	public static final fun asRxJava2MaybeSource (Lcom/badoo/reaktive/maybe/Maybe;)Lio/reactivex/MaybeSource;
 	public static final fun asRxJava2Source (Lcom/badoo/reaktive/maybe/Maybe;)Lio/reactivex/MaybeSource;
 }
 
 public final class com/badoo/reaktive/rxjavainterop/ObservableKt {
 	public static final fun asReaktive (Lio/reactivex/ObservableSource;)Lcom/badoo/reaktive/observable/Observable;
 	public static final fun asReaktive (Lio/reactivex/Observer;)Lcom/badoo/reaktive/observable/ObservableObserver;
+	public static final fun asReaktiveObservable (Lio/reactivex/ObservableSource;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun asReaktiveObservableObserver (Lio/reactivex/Observer;)Lcom/badoo/reaktive/observable/ObservableObserver;
 	public static final fun asRxJava2 (Lcom/badoo/reaktive/observable/Observable;)Lio/reactivex/Observable;
 	public static final fun asRxJava2 (Lcom/badoo/reaktive/observable/ObservableObserver;)Lio/reactivex/Observer;
+	public static final fun asRxJava2Observable (Lcom/badoo/reaktive/observable/Observable;)Lio/reactivex/Observable;
+	public static final fun asRxJava2ObservableSource (Lcom/badoo/reaktive/observable/Observable;)Lio/reactivex/ObservableSource;
+	public static final fun asRxJava2Observer (Lcom/badoo/reaktive/observable/ObservableObserver;)Lio/reactivex/Observer;
 	public static final fun asRxJava2Source (Lcom/badoo/reaktive/observable/Observable;)Lio/reactivex/ObservableSource;
 }
 
 public final class com/badoo/reaktive/rxjavainterop/SchedulerKt {
 	public static final fun asReaktive (Lio/reactivex/Scheduler;)Lcom/badoo/reaktive/scheduler/Scheduler;
+	public static final fun asReaktiveScheduler (Lio/reactivex/Scheduler;)Lcom/badoo/reaktive/scheduler/Scheduler;
 }
 
 public final class com/badoo/reaktive/rxjavainterop/SingleKt {
 	public static final fun asReaktive (Lio/reactivex/SingleObserver;)Lcom/badoo/reaktive/single/SingleObserver;
 	public static final fun asReaktive (Lio/reactivex/SingleSource;)Lcom/badoo/reaktive/single/Single;
+	public static final fun asReaktiveSingle (Lio/reactivex/SingleSource;)Lcom/badoo/reaktive/single/Single;
+	public static final fun asReaktiveSingleObserver (Lio/reactivex/SingleObserver;)Lcom/badoo/reaktive/single/SingleObserver;
 	public static final fun asRxJava2 (Lcom/badoo/reaktive/single/Single;)Lio/reactivex/Single;
 	public static final fun asRxJava2 (Lcom/badoo/reaktive/single/SingleObserver;)Lio/reactivex/SingleObserver;
+	public static final fun asRxJava2Single (Lcom/badoo/reaktive/single/Single;)Lio/reactivex/Single;
+	public static final fun asRxJava2SingleObserver (Lcom/badoo/reaktive/single/SingleObserver;)Lio/reactivex/SingleObserver;
+	public static final fun asRxJava2SingleSource (Lcom/badoo/reaktive/single/Single;)Lio/reactivex/SingleSource;
 	public static final fun asRxJava2Source (Lcom/badoo/reaktive/single/Single;)Lio/reactivex/SingleSource;
 }
 


### PR DESCRIPTION
As part of #428 