### PR TITLE
Introduce ObservableToObservableForwardTests

### DIFF
--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DefaultIfEmptyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DefaultIfEmptyTest.kt
@@ -5,8 +5,9 @@ import com.badoo.reaktive.test.observable.assertValue
 import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
 
-class DefaultIfEmptyTest
-    : ObservableToObservableTests by ObservableToObservableTestsImpl({ defaultIfEmpty(10) }) {
+class DefaultIfEmptyTest :
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ defaultIfEmpty(10) }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ defaultIfEmpty(10) }) {
 
     @Test
     fun should_return_default_value_when_source_is_empty() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DelaySubscriptionTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DelaySubscriptionTest.kt
@@ -12,7 +12,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class DelaySubscriptionTest :
-    ObservableToObservableTests by ObservableToObservableTestsImpl({ delaySubscription(0L, TestScheduler()) }) {
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ delaySubscription(0L, TestScheduler()) }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ delaySubscription(0L, TestScheduler()) }) {
 
     private val upstream = TestObservable<Int?>()
     private val scheduler = TestScheduler()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnAfterCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnAfterCompleteTest.kt
@@ -11,8 +11,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
 
-class DoOnAfterCompleteTest
-    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnAfterComplete {} }) {
+class DoOnAfterCompleteTest :
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnAfterComplete {} }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ doOnAfterComplete {} }) {
 
     private val upstream = TestObservable<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnAfterDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnAfterDisposeTest.kt
@@ -13,10 +13,10 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
-import kotlin.test.assertTrue
 
-class DoOnAfterDisposeTest
-    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnAfterDispose {} }) {
+class DoOnAfterDisposeTest :
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnAfterDispose {} }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ doOnAfterDispose {} }) {
 
     private val upstream = TestObservable<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnAfterErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnAfterErrorTest.kt
@@ -13,8 +13,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
-class DoOnAfterErrorTest
-    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnAfterError {} }) {
+class DoOnAfterErrorTest :
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnAfterError {} }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ doOnAfterError {} }) {
 
     private val upstream = TestObservable<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnAfterFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnAfterFinallyTest.kt
@@ -3,7 +3,6 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.base.exceptions.CompositeException
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.test.base.assertDisposed
-import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.mockUncaughtExceptionHandler
 import com.badoo.reaktive.test.observable.DefaultObservableObserver
 import com.badoo.reaktive.test.observable.TestObservable
@@ -19,8 +18,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
-class DoOnAfterFinallyTest
-    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnAfterFinally {} }) {
+class DoOnAfterFinallyTest :
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnAfterFinally {} }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ doOnAfterFinally {} }) {
 
     private val upstream = TestObservable<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnAfterNextTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnAfterNextTest.kt
@@ -12,8 +12,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
-class DoOnAfterNextTest
-    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnAfterNext {} }) {
+class DoOnAfterNextTest :
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnAfterNext {} }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ doOnAfterNext {} }) {
 
     private val upstream = TestObservable<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnAfterSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnAfterSubscribeTest.kt
@@ -11,8 +11,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
-class DoOnAfterSubscribeTest
-    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnAfterSubscribe {} }) {
+class DoOnAfterSubscribeTest :
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnAfterSubscribe {} }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ doOnAfterSubscribe {} }) {
 
     @Test
     fun calls_action_after_downstream_onSubscribe_WHEN_action_does_not_throw_exception() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnAfterTerminateTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnAfterTerminateTest.kt
@@ -13,8 +13,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
-class DoOnAfterTerminateTest
-    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnAfterTerminate {} }) {
+class DoOnAfterTerminateTest :
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnAfterTerminate {} }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ doOnAfterTerminate {} }) {
 
     private val upstream = TestObservable<Int>()
     private val callOrder = SharedList<String>()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeCompleteTest.kt
@@ -10,8 +10,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
-class DoOnBeforeCompleteTest
-    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeComplete {} }) {
+class DoOnBeforeCompleteTest :
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeComplete {} }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ doOnBeforeComplete {} }) {
 
     private val upstream = TestObservable<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeDisposeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeDisposeTest.kt
@@ -15,8 +15,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
-class DoOnBeforeDisposeTest
-    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeDispose {} }) {
+class DoOnBeforeDisposeTest :
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeDispose {} }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ doOnBeforeDispose {} }) {
 
     private val upstream = TestObservable<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeErrorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeErrorTest.kt
@@ -12,8 +12,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
-class DoOnBeforeErrorTest
-    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeError {} }) {
+class DoOnBeforeErrorTest :
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeError {} }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ doOnBeforeError {} }) {
 
     private val upstream = TestObservable<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeFinallyTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeFinallyTest.kt
@@ -19,8 +19,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
-class DoOnBeforeFinallyTest
-    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeFinally {} }) {
+class DoOnBeforeFinallyTest :
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeFinally {} }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ doOnBeforeFinally {} }) {
 
     private val upstream = TestObservable<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeNextTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeNextTest.kt
@@ -12,8 +12,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
-class DoOnBeforeNextTest
-    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeNext {} }) {
+class DoOnBeforeNextTest :
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeNext {} }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ doOnBeforeNext {} }) {
 
     private val upstream = TestObservable<Int>()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeSubscribeTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeSubscribeTest.kt
@@ -11,8 +11,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
-class DoOnBeforeSubscribeTest
-    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeSubscribe {} }) {
+class DoOnBeforeSubscribeTest :
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeSubscribe {} }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ doOnBeforeSubscribe {} }) {
 
     @Test
     fun calls_action_before_downstream_onSubscribe_WHEN_action_does_not_throw_exception() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeTerminateTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DoOnBeforeTerminateTest.kt
@@ -13,8 +13,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
-class DoOnBeforeTerminateTest
-    : ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeTerminate {} }) {
+class DoOnBeforeTerminateTest :
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ doOnBeforeTerminate {} }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ doOnBeforeTerminate {} }) {
 
     private val upstream = TestObservable<Int>()
     private val callOrder = SharedList<String>()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/OnErrorResumeNextTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/OnErrorResumeNextTest.kt
@@ -17,7 +17,8 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class OnErrorResumeNextTest :
-    ObservableToObservableTests by ObservableToObservableTestsImpl({ onErrorResumeNext { Unit.toObservable() } }) {
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ onErrorResumeNext { Unit.toObservable() } }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ onErrorResumeNext { observableOfNever() } }) {
 
     private val upstream = TestObservable<Int?>()
 


### PR DESCRIPTION
We can share tests for simple operators that should just forward all values from the upstream.