### PR TITLE
Extract read only interfaces for BehaviorSubject

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/behavior/BehaviorObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/behavior/BehaviorObservable.kt
@@ -1,0 +1,8 @@
+package com.badoo.reaktive.subject.behavior
+
+import com.badoo.reaktive.observable.Observable
+
+interface BehaviorObservable<out T> : Observable<T> {
+
+    val value: T
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/behavior/BehaviorRelay.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/behavior/BehaviorRelay.kt
@@ -1,0 +1,5 @@
+package com.badoo.reaktive.subject.behavior
+
+import com.badoo.reaktive.subject.Relay
+
+interface BehaviorRelay<T> : Relay<T>, BehaviorObservable<T>

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/behavior/BehaviorSubject.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/behavior/BehaviorSubject.kt
@@ -2,7 +2,4 @@ package com.badoo.reaktive.subject.behavior
 
 import com.badoo.reaktive.subject.Subject
 
-interface BehaviorSubject<T> : Subject<T> {
-
-    val value: T
-}
+interface BehaviorSubject<T> : Subject<T>, BehaviorRelay<T>

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/subject/BehaviorSubjectTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/subject/BehaviorSubjectTest.kt
@@ -4,6 +4,7 @@ import com.badoo.reaktive.subject.behavior.BehaviorSubject
 import com.badoo.reaktive.test.observable.assertValue
 import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class BehaviorSubjectTest : SubjectGenericTests by SubjectGenericTests(BehaviorSubject(0)) {
 
@@ -25,5 +26,25 @@ class BehaviorSubjectTest : SubjectGenericTests by SubjectGenericTests(BehaviorS
         val observer = subject.test()
 
         observer.assertValue(2)
+    }
+
+    @Test
+    fun returns_default_value() {
+        val subject = BehaviorSubject(0)
+
+        val value = subject.value
+
+        assertEquals(0, value)
+    }
+
+    @Test
+    fun returns_latest_value() {
+        val subject = BehaviorSubject(0)
+        subject.onNext(1)
+        subject.onNext(2)
+
+        val value = subject.value
+
+        assertEquals(2, value)
     }
 }

--- a/tools/binary-compatibility/reference-public-api/reaktive.txt
+++ b/tools/binary-compatibility/reference-public-api/reaktive.txt
@@ -1249,8 +1249,14 @@ public final class com/badoo/reaktive/subject/SubjectExtKt {
 	public static final fun isActive (Lcom/badoo/reaktive/subject/Subject;)Z
 }
 
-public abstract interface class com/badoo/reaktive/subject/behavior/BehaviorSubject : com/badoo/reaktive/subject/Subject {
+public abstract interface class com/badoo/reaktive/subject/behavior/BehaviorObservable : com/badoo/reaktive/observable/Observable {
 	public abstract fun getValue ()Ljava/lang/Object;
+}
+
+public abstract interface class com/badoo/reaktive/subject/behavior/BehaviorRelay : com/badoo/reaktive/subject/Relay, com/badoo/reaktive/subject/behavior/BehaviorObservable {
+}
+
+public abstract interface class com/badoo/reaktive/subject/behavior/BehaviorSubject : com/badoo/reaktive/subject/Subject, com/badoo/reaktive/subject/behavior/BehaviorRelay {
 }
 
 public final class com/badoo/reaktive/subject/behavior/BehaviorSubjectBuilderKt {


### PR DESCRIPTION
Fixes #456 

Extracted `BehaviorRelay` and `BehaviorObservable` interfaces. Please check the binary compatibility files change as well, looks like it should not break anything.