### PR TITLE
Stabilize DisposableScope API

### DIFF
--- a/reaktive/api/reaktive.api
+++ b/reaktive/api/reaktive.api
@@ -260,8 +260,8 @@ public final class com/badoo/reaktive/disposable/VariousJvm {
 }
 
 public abstract interface class com/badoo/reaktive/disposable/scope/DisposableScope : com/badoo/reaktive/disposable/Disposable {
-	public abstract fun scope (Lcom/badoo/reaktive/base/CompleteCallback;)Lcom/badoo/reaktive/base/CompleteCallback;
 	public abstract fun scope (Lcom/badoo/reaktive/disposable/Disposable;)Lcom/badoo/reaktive/disposable/Disposable;
+	public abstract fun scope (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun subscribeScoped (Lcom/badoo/reaktive/completable/Completable;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Lcom/badoo/reaktive/disposable/Disposable;
 	public abstract fun subscribeScoped (Lcom/badoo/reaktive/maybe/Maybe;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/badoo/reaktive/disposable/Disposable;
 	public abstract fun subscribeScoped (Lcom/badoo/reaktive/observable/Observable;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/badoo/reaktive/disposable/Disposable;

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/scope/DisposableScope.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/scope/DisposableScope.kt
@@ -1,7 +1,5 @@
 package com.badoo.reaktive.disposable.scope
 
-import com.badoo.reaktive.annotations.ExperimentalReaktiveApi
-import com.badoo.reaktive.base.CompleteCallback
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.maybe.Maybe
@@ -11,25 +9,18 @@ import com.badoo.reaktive.single.Single
 /**
  * Represents a scope of [Disposable]s. All scoped [Disposable]s are disposed when the [DisposableScope] is disposed.
  */
-@ExperimentalReaktiveApi
 interface DisposableScope : Disposable {
 
     /**
      * Adds this [Disposable] to the scope
      */
-    @ExperimentalReaktiveApi
     fun <T : Disposable> T.scope(): T
 
-    /**
-     * Adds this [CompleteCallback] to the scope and calls its [CompleteCallback.onComplete] callback when disposed
-     */
-    @ExperimentalReaktiveApi
-    fun <T : CompleteCallback> T.scope(): T
+    fun <T> T.scope(onDispose: (T) -> Unit): T
 
     /**
      * Same as [Observable.subscribe][com.badoo.reaktive.observable.subscribe] but also adds the [Disposable] to the scope
      */
-    @ExperimentalReaktiveApi
     fun <T> Observable<T>.subscribeScoped(
         isThreadLocal: Boolean = false,
         onSubscribe: ((Disposable) -> Unit)? = null,
@@ -41,7 +32,6 @@ interface DisposableScope : Disposable {
     /**
      * Same as [Single.subscribe][com.badoo.reaktive.single.subscribe] but also adds the [Disposable] to the scope
      */
-    @ExperimentalReaktiveApi
     fun <T> Single<T>.subscribeScoped(
         isThreadLocal: Boolean = false,
         onSubscribe: ((Disposable) -> Unit)? = null,
@@ -52,7 +42,6 @@ interface DisposableScope : Disposable {
     /**
      * Same as [Maybe.subscribe][com.badoo.reaktive.maybe.subscribe] but also adds the [Disposable] to the scope
      */
-    @ExperimentalReaktiveApi
     fun <T> Maybe<T>.subscribeScoped(
         isThreadLocal: Boolean = false,
         onSubscribe: ((Disposable) -> Unit)? = null,
@@ -64,7 +53,6 @@ interface DisposableScope : Disposable {
     /**
      * Same as [Completable.subscribe][com.badoo.reaktive.completable.subscribe] but also adds the [Disposable] to the scope
      */
-    @ExperimentalReaktiveApi
     fun Completable.subscribeScoped(
         isThreadLocal: Boolean = false,
         onSubscribe: ((Disposable) -> Unit)? = null,

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/scope/DisposableScopeBuilder.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/scope/DisposableScopeBuilder.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.disposable.scope
 
-import com.badoo.reaktive.annotations.ExperimentalReaktiveApi
 import com.badoo.reaktive.annotations.UseReturnValue
 import kotlin.js.JsName
 
@@ -8,7 +7,6 @@ import kotlin.js.JsName
  * Creates a new instance of [DisposableScope]
  */
 @Suppress("FunctionName")
-@ExperimentalReaktiveApi
 @JsName("disposableScope")
 @UseReturnValue
 fun DisposableScope(): DisposableScope = DisposableScopeImpl()
@@ -16,7 +14,6 @@ fun DisposableScope(): DisposableScope = DisposableScopeImpl()
 /**
  * Creates a new instance of [DisposableScope] and calls the provided `block` on it
  */
-@ExperimentalReaktiveApi
 @UseReturnValue
 inline fun disposableScope(block: DisposableScope.() -> Unit): DisposableScope =
     DisposableScope().apply(block)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/scope/DisposableScopeExt.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/scope/DisposableScopeExt.kt
@@ -1,13 +1,11 @@
 package com.badoo.reaktive.disposable.scope
 
-import com.badoo.reaktive.annotations.ExperimentalReaktiveApi
 import com.badoo.reaktive.disposable.Disposable
 
 /**
  * Adds the provided `block` callback to the scope.
  * The callback will be called when the scope is disposed.
  */
-@ExperimentalReaktiveApi
 inline fun DisposableScope.doOnDispose(crossinline block: () -> Unit) {
     Disposable(block).scope()
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/scope/DisposableScopeImpl.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/scope/DisposableScopeImpl.kt
@@ -1,7 +1,5 @@
 package com.badoo.reaktive.disposable.scope
 
-import com.badoo.reaktive.annotations.ExperimentalReaktiveApi
-import com.badoo.reaktive.base.CompleteCallback
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.completable.subscribe
 import com.badoo.reaktive.disposable.CompositeDisposable
@@ -13,7 +11,6 @@ import com.badoo.reaktive.observable.subscribe
 import com.badoo.reaktive.single.Single
 import com.badoo.reaktive.single.subscribe
 
-@OptIn(ExperimentalReaktiveApi::class)
 internal class DisposableScopeImpl : DisposableScope, CompositeDisposable() {
 
     override fun <T : Disposable> T.scope(): T {
@@ -23,8 +20,8 @@ internal class DisposableScopeImpl : DisposableScope, CompositeDisposable() {
         return this
     }
 
-    override fun <T : CompleteCallback> T.scope(): T {
-        Disposable(::onComplete).scope()
+    override fun <T> T.scope(dispose: (T) -> Unit): T {
+        Disposable { dispose(this) }.scope()
 
         return this
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/disposable/scope/DisposableScopeImplTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/disposable/scope/DisposableScopeImplTest.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.disposable.scope
 
-import com.badoo.reaktive.base.CompleteCallback
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.completable.TestCompletable
@@ -26,20 +25,15 @@ class DisposableScopeImplTest {
     }
 
     @Test
-    fun completes_scoped_CompleteCallback_WHEN_disposed() {
-        val completeCallback =
-            object : CompleteCallback {
-                var isComplete: Boolean = false
+    fun disposes_scoped_object_WHEN_disposed() {
+        var isDisposed = false
 
-                override fun onComplete() {
-                    isComplete = true
-                }
-            }
-
-        scope.run { completeCallback.scope() }
+        scope.run {
+            Unit.scope { isDisposed = true }
+        }
         scope.dispose()
 
-        assertTrue(completeCallback.isComplete)
+        assertTrue(isDisposed)
     }
 
     @Test

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/binder/KittenBinder.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/binder/KittenBinder.kt
@@ -1,13 +1,11 @@
 package com.badoo.reaktive.samplemppmodule.binder
 
-import com.badoo.reaktive.annotations.ExperimentalReaktiveApi
 import com.badoo.reaktive.disposable.scope.DisposableScope
 import com.badoo.reaktive.disposable.scope.disposableScope
 import com.badoo.reaktive.observable.map
 import com.badoo.reaktive.samplemppmodule.store.KittenStoreBuilder
 import com.badoo.reaktive.samplemppmodule.view.KittenView
 
-@OptIn(ExperimentalReaktiveApi::class)
 class KittenBinder(
     storeBuilder: KittenStoreBuilder
 ) {

--- a/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/store/KittenStoreImpl.kt
+++ b/sample-mpp-module/src/commonMain/kotlin/com/badoo/reaktive/samplemppmodule/store/KittenStoreImpl.kt
@@ -1,6 +1,6 @@
 package com.badoo.reaktive.samplemppmodule.store
 
-import com.badoo.reaktive.annotations.ExperimentalReaktiveApi
+import com.badoo.reaktive.base.CompleteCallback
 import com.badoo.reaktive.disposable.scope.DisposableScope
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.samplemppmodule.store.KittenStore.Intent
@@ -12,12 +12,11 @@ import com.badoo.reaktive.single.observeOn
 import com.badoo.reaktive.subject.behavior.BehaviorSubject
 import com.badoo.reaktive.utils.ensureNeverFrozen
 
-@OptIn(ExperimentalReaktiveApi::class)
 internal class KittenStoreImpl(
     private val loader: KittenLoader
 ) : KittenStore, DisposableScope by DisposableScope() {
 
-    private val _states = BehaviorSubject(State()).ensureNeverFrozen().scope()
+    private val _states = BehaviorSubject(State()).ensureNeverFrozen().scope(CompleteCallback::onComplete)
     override val states: Observable<State> = _states
     private val state: State get() = _states.value
 


### PR DESCRIPTION
- Removed `fun <T : CompleteCallback> T.scope(): T`
- Added `fun <T> T.scope(onDispose: (T) -> Unit): T`
- Removed `ExperimentalReaktiveApi` annotations
- Updated tests
- Updated samples

Closes #459 