### PR TITLE
Increase Gradle memory limit

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
 # AndroidX package structure to make it clearer which packages are bundled with the


### PR DESCRIPTION
One of the failures of https://github.com/badoo/Reaktive/pull/466 was OutOfMemoryError.