### PR TITLE
Fix TestScheduler advanceTime

### DIFF
--- a/reaktive-testing/api/reaktive-testing.api
+++ b/reaktive-testing/api/reaktive-testing.api
@@ -172,22 +172,9 @@ public final class com/badoo/reaktive/test/scheduler/TestScheduler : com/badoo/r
 	public final fun process ()V
 }
 
-public final class com/badoo/reaktive/test/scheduler/TestScheduler$Executor : com/badoo/reaktive/scheduler/Scheduler$Executor {
-	public fun <init> (Lcom/badoo/reaktive/test/scheduler/TestScheduler$Timer;Z)V
-	public fun cancel ()V
-	public fun dispose ()V
-	public fun isDisposed ()Z
-	public final fun process ()V
-	public fun submit (JLkotlin/jvm/functions/Function0;)V
-	public fun submitRepeating (JJLkotlin/jvm/functions/Function0;)V
-}
-
-public final class com/badoo/reaktive/test/scheduler/TestScheduler$Timer {
-	public fun <init> ()V
-	public final fun addOnChangeListener (Lkotlin/jvm/functions/Function0;)V
-	public final fun advanceBy (J)V
-	public final fun getMillis ()J
-	public final fun removeOnChangeListener (Lkotlin/jvm/functions/Function0;)V
+public abstract interface class com/badoo/reaktive/test/scheduler/TestScheduler$Timer {
+	public abstract fun advanceBy (J)V
+	public abstract fun getMillis ()J
 }
 
 public final class com/badoo/reaktive/test/scheduler/TestSchedulerExtKt {


### PR DESCRIPTION
Advancing time does not account for resubscriptions for example in `retry` or `repeat` when it's conditional
Reason is the scheduler will just advance time and check if any current tasks are scheduled, it will just execute

But in case any of these tasks will cause a resubscription that should run inside the time frame of the advanced time

For example,
If we have a repeatUntil that will delay 10 seconds for 5 times (based on a network call that will return the number of repeats and interval)

If we advance time by 50 seconds, it is expected to have 5 emissions but that's not the case, we will just get 1.

Proposed fix:
Applying what was suggested in https://github.com/badoo/Reaktive/pull/470#issuecomment-636376085
Instead of blindly advancing time, it will advance time and update task list till no more tasks are expected to be executed

Try running this test which passes using RxJava's TestScheduler, it will fail with Reaktive's TestScheduler.

```    
    private val repeatCounter = AtomicInt(0)

    private fun getRepeatObservable(repeats: Int): Single<Repeater> =
        singleFromFunction {
            val repeatCount = repeatCounter.addAndGet(1)
            Repeater(repeatInterval = 10000L, shouldRepeat = repeatCount < repeats)
        }

    @Test
    fun test_custom_repeat_scheduler() {
        val testScheduler = TestScheduler()
        val repeats = 5
        val testObservable: TestObservableObserver<Long> =
            getRepeatObservable(repeats).flatMap {
                val interval = if (it.shouldRepeat) {
                    it.repeatInterval
                } else 0L
                singleTimer(interval, testScheduler)
            }.repeatUntil { interval -> interval == 0L }
                .subscribeOn(testScheduler)
                .test()

        testScheduler.timer.advanceBy(50000)
        assertEquals(repeats, testObservable.values.size)
    }

    private data class Repeater(val repeatInterval: Long, val shouldRepeat: Boolean)
```