### PR TITLE
kotlin.native.disableCompilerDaemon

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,10 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
       - name: Build Linux
         if: matrix.os == 'ubuntu-latest'
-        run: ./gradlew build -Ptarget=all_linux_hosted --no-parallel
+        run: ./gradlew build -Ptarget=all_linux_hosted
       - name: Build macOS
         if: matrix.os == 'macOS-latest'
-        run: ./gradlew :reaktive-annotations:build :utils:build :reaktive-testing:build :reaktive:build :coroutines-interop:build :sample-mpp-module:build :sample-ios-app:build :sample-macos-app:build -Ptarget=all_macos_hosted --no-parallel
+        run: ./gradlew :reaktive-annotations:build :utils:build :reaktive-testing:build :reaktive:build :coroutines-interop:build :sample-mpp-module:build :sample-ios-app:build :sample-macos-app:build -Ptarget=all_macos_hosted
       - name: Bundle the build report
         if: failure()
         run: find . -type d -name 'reports' | zip -@ -r build-reports.zip

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 kotlin.code.style=official
+kotlin.native.disableCompilerDaemon=true
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
Probably fixes https://github.com/badoo/Reaktive/issues/479

`--no-parallel` affects multi-module projects a lot.