### PR TITLE
Add getValue and setValue extensions for Atomics

### DIFF
--- a/utils/api/utils.api
+++ b/utils/api/utils.api
@@ -42,6 +42,11 @@ public final class com/badoo/reaktive/utils/atomic/AtomicBoolean {
 	public final fun setValue (Z)V
 }
 
+public final class com/badoo/reaktive/utils/atomic/AtomicBooleanExtKt {
+	public static final fun getValue (Lcom/badoo/reaktive/utils/atomic/AtomicBoolean;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Z
+	public static final fun setValue (Lcom/badoo/reaktive/utils/atomic/AtomicBoolean;Ljava/lang/Object;Lkotlin/reflect/KProperty;Z)V
+}
+
 public final class com/badoo/reaktive/utils/atomic/AtomicInt {
 	public fun <init> ()V
 	public fun <init> (I)V
@@ -50,6 +55,11 @@ public final class com/badoo/reaktive/utils/atomic/AtomicInt {
 	public final fun compareAndSet (II)Z
 	public final fun getValue ()I
 	public final fun setValue (I)V
+}
+
+public final class com/badoo/reaktive/utils/atomic/AtomicIntExtKt {
+	public static final fun getValue (Lcom/badoo/reaktive/utils/atomic/AtomicInt;Ljava/lang/Object;Lkotlin/reflect/KProperty;)I
+	public static final fun setValue (Lcom/badoo/reaktive/utils/atomic/AtomicInt;Ljava/lang/Object;Lkotlin/reflect/KProperty;I)V
 }
 
 public final class com/badoo/reaktive/utils/atomic/AtomicLong {
@@ -62,6 +72,11 @@ public final class com/badoo/reaktive/utils/atomic/AtomicLong {
 	public final fun setValue (J)V
 }
 
+public final class com/badoo/reaktive/utils/atomic/AtomicLongExtKt {
+	public static final fun getValue (Lcom/badoo/reaktive/utils/atomic/AtomicLong;Ljava/lang/Object;Lkotlin/reflect/KProperty;)J
+	public static final fun setValue (Lcom/badoo/reaktive/utils/atomic/AtomicLong;Ljava/lang/Object;Lkotlin/reflect/KProperty;J)V
+}
+
 public final class com/badoo/reaktive/utils/atomic/AtomicReference {
 	public fun <init> (Ljava/lang/Object;)V
 	public final fun compareAndSet (Ljava/lang/Object;Ljava/lang/Object;)Z
@@ -72,6 +87,8 @@ public final class com/badoo/reaktive/utils/atomic/AtomicReference {
 public final class com/badoo/reaktive/utils/atomic/AtomicReferenceExtKt {
 	public static final fun getAndSet (Lcom/badoo/reaktive/utils/atomic/AtomicReference;Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun getAndUpdate (Lcom/badoo/reaktive/utils/atomic/AtomicReference;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun getValue (Lcom/badoo/reaktive/utils/atomic/AtomicReference;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public static final fun setValue (Lcom/badoo/reaktive/utils/atomic/AtomicReference;Ljava/lang/Object;Lkotlin/reflect/KProperty;Ljava/lang/Object;)V
 	public static final fun update (Lcom/badoo/reaktive/utils/atomic/AtomicReference;Lkotlin/jvm/functions/Function1;)V
 	public static final fun updateAndGet (Lcom/badoo/reaktive/utils/atomic/AtomicReference;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }

--- a/utils/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicBooleanExt.kt
+++ b/utils/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicBooleanExt.kt
@@ -1,0 +1,9 @@
+package com.badoo.reaktive.utils.atomic
+
+import kotlin.reflect.KProperty
+
+operator fun <R> AtomicBoolean.getValue(thisRef: R, property: KProperty<*>): Boolean = value
+
+operator fun <R> AtomicBoolean.setValue(thisRef: R, property: KProperty<*>, value: Boolean) {
+    this.value = value
+}

--- a/utils/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicIntExt.kt
+++ b/utils/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicIntExt.kt
@@ -1,0 +1,9 @@
+package com.badoo.reaktive.utils.atomic
+
+import kotlin.reflect.KProperty
+
+operator fun <R> AtomicInt.getValue(thisRef: R, property: KProperty<*>): Int = value
+
+operator fun <R> AtomicInt.setValue(thisRef: R, property: KProperty<*>, value: Int) {
+    this.value = value
+}

--- a/utils/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLongExt.kt
+++ b/utils/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicLongExt.kt
@@ -1,0 +1,9 @@
+package com.badoo.reaktive.utils.atomic
+
+import kotlin.reflect.KProperty
+
+operator fun <R> AtomicLong.getValue(thisRef: R, property: KProperty<*>): Long = value
+
+operator fun <R> AtomicLong.setValue(thisRef: R, property: KProperty<*>, value: Long) {
+    this.value = value
+}

--- a/utils/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicReferenceExt.kt
+++ b/utils/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicReferenceExt.kt
@@ -1,5 +1,7 @@
 package com.badoo.reaktive.utils.atomic
 
+import kotlin.reflect.KProperty
+
 fun <T> AtomicReference<T>.getAndSet(value: T): T = getAndUpdate { value }
 
 inline fun <T> AtomicReference<T>.getAndUpdate(update: (T) -> T): T {
@@ -23,4 +25,10 @@ inline fun <T, R : T> AtomicReference<T>.updateAndGet(update: (T) -> R): R {
 
 inline fun <T> AtomicReference<T>.update(update: (T) -> T) {
     getAndUpdate(update)
+}
+
+operator fun <R, T> AtomicReference<T>.getValue(thisRef: R, property: KProperty<*>): T = value
+
+operator fun <R, T> AtomicReference<T>.setValue(thisRef: R, property: KProperty<*>, value: T) {
+    this.value = value
 }


### PR DESCRIPTION
This allows to use property delegation:
```kotlin
class MyClass {
    private val _string = AtomicReference<String?>(null)
    var string: String? by _string
}
```

Closes #492 