### PR TITLE
Automate nmtc

### DIFF
--- a/.github/workflows/release-nmtc.yml
+++ b/.github/workflows/release-nmtc.yml
@@ -1,11 +1,7 @@
 name: Release nmtc
 
 on:
-  push:
-    branches:
-      - 'mt-coroutines'
-    tags:
-      - '*'
+  workflow_dispatch
 
 jobs:
   linux-host-publish:

--- a/.github/workflows/release-nmtc.yml
+++ b/.github/workflows/release-nmtc.yml
@@ -1,0 +1,39 @@
+name: Release nmtc
+
+on:
+  push:
+    branches:
+      - 'mt-coroutines'
+    tags:
+      - '*'
+
+jobs:
+  linux-host-publish:
+    name: Release on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Release JVM, Android, JS, Linux
+        run: ./gradlew :coroutines-interop:bintrayUpload -Ptarget=all_linux_hosted -Pbintray_user=${{ secrets.BINTRAY_USER }} -Pbintray_key=${{ secrets.BINTRAY_KEY }}
+      - name: Release Metadata
+        run: ./gradlew :coroutines-interop:bintrayUpload -Ptarget=meta -Pbintray_user=${{ secrets.BINTRAY_USER }} -Pbintray_key=${{ secrets.BINTRAY_KEY }}
+  macos-host-publish:
+    name: Release on macOS
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Release iOS, MacOS
+        run: ./gradlew :coroutines-interop:bintrayUpload -Ptarget=all_macos_hosted -Pbintray_user=${{ secrets.BINTRAY_USER }} -Pbintray_key=${{ secrets.BINTRAY_KEY }}
+


### PR DESCRIPTION
I think we'll need to publish mt coroutines interop multiple times, so would be nice to automate. The idea is to create a tag in the `mt-cotourines` branch every time after a release and have this workflow executed. Not sure about the yaml filter.