### PR TITLE
Remove "apt get install" from check publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Install dependencies
-        run: sudo apt-get install nodejs chromium-browser
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Check JVM, Android, JS, Linux


### PR DESCRIPTION
The job fails without "apt get update", but I think we don't need these packages at all.