### PR TITLE
Use abort() instead of exitProcess() in native reaktiveUncaughtErrorHandler

### DIFF
--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/CreateDefaultUncaughtErrorHandler.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/CreateDefaultUncaughtErrorHandler.kt
@@ -1,10 +1,9 @@
 package com.badoo.reaktive.utils
 
-import platform.posix.EXIT_FAILURE
-import kotlin.system.exitProcess
+import platform.posix.abort
 
 internal actual fun createDefaultUncaughtErrorHandler(): (Throwable) -> Unit = { e ->
     printError("Uncaught exception: $e")
     e.printStackTrace()
-    exitProcess(EXIT_FAILURE)
+    abort()
 }


### PR DESCRIPTION
Closes #565 