### PR TITLE
Include harfbuzz lib to linuxX64 sample app

### DIFF
--- a/sample-linuxx64-app/build.gradle
+++ b/sample-linuxx64-app/build.gradle
@@ -29,7 +29,8 @@ kotlin {
                             "$it/cairo",
                             "$it/pango-1.0",
                             "$it/gtk-3.0",
-                            "$it/glib-2.0"
+                            "$it/glib-2.0",
+                            "$it/harfbuzz"
                 }
 
                 includeDirs '/opt/local/lib/glib-2.0/include',

--- a/sample-linuxx64-app/src/linuxMain/kotlin/com/badoo/reaktive/sample/linux/MainScheduler.kt
+++ b/sample-linuxx64-app/src/linuxMain/kotlin/com/badoo/reaktive/sample/linux/MainScheduler.kt
@@ -9,6 +9,7 @@ import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import com.badoo.reaktive.utils.atomic.getAndUpdate
 import com.badoo.reaktive.utils.atomic.update
+import com.badoo.reaktive.utils.freeze
 import kotlinx.cinterop.StableRef
 import kotlinx.cinterop.asStableRef
 import kotlinx.cinterop.reinterpret
@@ -53,7 +54,7 @@ private class ExecutorImpl(
     }
 
     override fun submitRepeating(startDelayMillis: Long, periodMillis: Long, task: () -> Unit) {
-        val taskRef = StableRef.create(TaskHolder(this, periodMillis, task))
+        val taskRef = StableRef.create(TaskHolder(this, periodMillis, task).freeze())
         taskRefs.update { it + taskRef }
         g_timeout_add(startDelayMillis.toUInt(), staticCFunction(::callbackOneShotTask).reinterpret(), taskRef.asCPointer())
     }

--- a/sample-linuxx64-app/src/nativeInterop/cinterop/gtk3.def
+++ b/sample-linuxx64-app/src/nativeInterop/cinterop/gtk3.def
@@ -1,5 +1,5 @@
 package = libgtk3
 headers = gtk/gtk.h gtk/gtkx.h gdk-pixbuf/gdk-pixbuf.h
 headerFilter = gtk/* gdk/* gdk-pixbuf/* gobject/* gio/* glib/*
-compilerOpts = -I/usr/include -I/usr/include/gtk-3.0 -I/usr/include/glib-2.0 -I/usr/include/pango-1.0 -I/usr/include/atk-1.0 -I/usr/include/cairo -I/usr/include/x86_64-linux-gnu/ -I/usr/include/gdk-pixbuf-2.0/ -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/local/lib/glib-2.0/include -I/usr/lib64/glib-2.0/include
+compilerOpts = -I/usr/include -I/usr/include/gtk-3.0 -I/usr/include/glib-2.0 -I/usr/include/pango-1.0 -I/usr/include/atk-1.0 -I/usr/include/cairo -I/usr/include/x86_64-linux-gnu/ -I/usr/include/gdk-pixbuf-2.0/ -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/local/lib/glib-2.0/include -I/usr/lib64/glib-2.0/include -I/usr/include/harfbuzz
 linkerOpts = -L/usr/lib64 -L/usr/lib/x86_64-linux-gnu -lglib-2.0 -lgdk-3 -lgtk-3 -lgio-2.0 -lgobject-2.0 -lgdk_pixbuf-2.0


### PR DESCRIPTION
CI `ubuntu-latest` now uses Ubuntu 20.04.2 and the linuxX64 sample app compilation fails. We need to also include `harfbuff` lib.
Also fixed `IncorrectDerefeceException` crash in the sample app's custom `MainScheduler`.