### PR TITLE
Reduce DisposableWrapper deprecation level to WARNING

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/DisposableWrapper.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/disposable/DisposableWrapper.kt
@@ -6,6 +6,6 @@ package com.badoo.reaktive.disposable
 @Deprecated(
     message = "Please use SerialDisposable",
     replaceWith = ReplaceWith("SerialDisposable"),
-    level = DeprecationLevel.ERROR
+    level = DeprecationLevel.WARNING
 )
 open class DisposableWrapper : SerialDisposable()


### PR DESCRIPTION
It should be WARNING in this release, and ERROR in the next minor release.