### PR TITLE
Removed MaxMetaspaceSize setting

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
-org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
 # AndroidX package structure to make it clearer which packages are bundled with the


### PR DESCRIPTION
Currently the build often fails with random errors, including `java.lang.OutOfMemoryError: Metaspace` errors. It seems that removing the `XX:MaxMetaspaceSize=512m` setting fixes the issue.