### PR TITLE
[2.0.0] Small api changes

### DIFF
--- a/reaktive/api/android/reaktive.api
+++ b/reaktive/api/android/reaktive.api
@@ -747,7 +747,7 @@ public final class com/badoo/reaktive/observable/FlattenKt {
 
 public final class com/badoo/reaktive/observable/IntervalKt {
 	public static final fun observableInterval (JJLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
-	public static final fun observableInterval (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun observableInterval$default (JJLcom/badoo/reaktive/scheduler/Scheduler;ILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/MapIterableKt {
@@ -857,8 +857,8 @@ public final class com/badoo/reaktive/observable/RepeatWhenKt {
 }
 
 public final class com/badoo/reaktive/observable/ReplayKt {
-	public static final fun replay (Lcom/badoo/reaktive/observable/Observable;)Lcom/badoo/reaktive/observable/ConnectableObservable;
 	public static final fun replay (Lcom/badoo/reaktive/observable/Observable;I)Lcom/badoo/reaktive/observable/ConnectableObservable;
+	public static synthetic fun replay$default (Lcom/badoo/reaktive/observable/Observable;IILjava/lang/Object;)Lcom/badoo/reaktive/observable/ConnectableObservable;
 }
 
 public final class com/badoo/reaktive/observable/RetryKt {

--- a/reaktive/api/jvm/reaktive.api
+++ b/reaktive/api/jvm/reaktive.api
@@ -740,7 +740,7 @@ public final class com/badoo/reaktive/observable/FlattenKt {
 
 public final class com/badoo/reaktive/observable/IntervalKt {
 	public static final fun observableInterval (JJLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
-	public static final fun observableInterval (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun observableInterval$default (JJLcom/badoo/reaktive/scheduler/Scheduler;ILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/MapIterableKt {
@@ -850,8 +850,8 @@ public final class com/badoo/reaktive/observable/RepeatWhenKt {
 }
 
 public final class com/badoo/reaktive/observable/ReplayKt {
-	public static final fun replay (Lcom/badoo/reaktive/observable/Observable;)Lcom/badoo/reaktive/observable/ConnectableObservable;
 	public static final fun replay (Lcom/badoo/reaktive/observable/Observable;I)Lcom/badoo/reaktive/observable/ConnectableObservable;
+	public static synthetic fun replay$default (Lcom/badoo/reaktive/observable/Observable;IILjava/lang/Object;)Lcom/badoo/reaktive/observable/ConnectableObservable;
 }
 
 public final class com/badoo/reaktive/observable/RetryKt {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsMaybe.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsMaybe.kt
@@ -10,7 +10,7 @@ import com.badoo.reaktive.maybe.maybe
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Completable.html#toMaybe--).
  */
-fun <T> Completable.asMaybe(): Maybe<T> =
+fun Completable.asMaybe(): Maybe<Nothing> =
     maybe { emitter ->
         subscribeSafe(
             object : CompletableObserver, CompletableCallbacks by emitter {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/AsObservable.kt
@@ -9,7 +9,7 @@ import com.badoo.reaktive.observable.observable
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Completable.html#toObservable--).
  */
-fun <T> Completable.asObservable(): Observable<T> =
+fun Completable.asObservable(): Observable<Nothing> =
     observable { emitter ->
         subscribe(
             object : CompletableObserver, CompletableCallbacks by emitter {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/BlockingAwait.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/BlockingAwait.kt
@@ -13,5 +13,5 @@ import com.badoo.reaktive.maybe.blockingGet
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Completable.html#blockingAwait--).
  */
 fun Completable.blockingAwait() {
-    asMaybe<Unit>().blockingGet()
+    asMaybe().blockingGet()
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Concat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Concat.kt
@@ -11,7 +11,7 @@ import com.badoo.reaktive.observable.concatMap
  */
 fun Iterable<Completable>.concat(): Completable =
     asObservable()
-        .concatMap { it.asObservable<Nothing>() }
+        .concatMap { it.asObservable() }
         .asCompletable()
 
 /**

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Repeat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Repeat.kt
@@ -9,6 +9,6 @@ import com.badoo.reaktive.observable.repeat
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Completable.html#repeat-long-).
  */
 fun Completable.repeat(count: Int = -1): Completable =
-    asObservable<Nothing>()
+    asObservable()
         .repeat(count = count)
         .asCompletable()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/RepeatUntil.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/RepeatUntil.kt
@@ -9,6 +9,6 @@ import com.badoo.reaktive.observable.repeatUntil
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Completable.html#repeatUntil-io.reactivex.functions.BooleanSupplier-).
  */
 fun <T> Completable.repeatUntil(predicate: () -> Boolean): Completable =
-    asObservable<Nothing>()
+    asObservable()
         .repeatUntil(predicate)
         .asCompletable()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/RepeatWhen.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/RepeatWhen.kt
@@ -10,6 +10,6 @@ import com.badoo.reaktive.observable.repeatWhen
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Completable.html#repeatWhen-io.reactivex.functions.Function-).
  */
 fun Completable.repeatWhen(handler: (repeatNumber: Int) -> Maybe<*>): Completable =
-    asObservable<Nothing>()
+    asObservable()
         .repeatWhen(handler)
         .asCompletable()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DoOnAfter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DoOnAfter.kt
@@ -58,10 +58,10 @@ fun <T> Maybe<T>.doOnAfterSubscribe(action: (Disposable) -> Unit): Maybe<T> =
     }
 
 /**
- * Calls the [action] with the emitted value when the [Maybe] signals `onSuccess`.
- * The [action] is called **after** the observer is called.
+ * Calls the [consumer] with the emitted value when the [Maybe] signals `onSuccess`.
+ * The [consumer] is called **after** the observer is called.
  */
-fun <T> Maybe<T>.doOnAfterSuccess(action: (T) -> Unit): Maybe<T> =
+fun <T> Maybe<T>.doOnAfterSuccess(consumer: (T) -> Unit): Maybe<T> =
     maybe { emitter ->
         subscribe(
             object : MaybeObserver<T>, CompletableCallbacks by emitter {
@@ -73,17 +73,17 @@ fun <T> Maybe<T>.doOnAfterSuccess(action: (T) -> Unit): Maybe<T> =
                     emitter.onSuccess(value)
 
                     // Can't send error to downstream, already terminated with onComplete
-                    tryCatchAndHandle { action(value) }
+                    tryCatchAndHandle { consumer(value) }
                 }
             }
         )
     }
 
 /**
- * Calls the [action] when the [Maybe] signals `onComplete`.
- * The [action] is called **after** the observer is called.
+ * Calls the [consumer] when the [Maybe] signals `onComplete`.
+ * The [consumer] is called **after** the observer is called.
  */
-fun <T> Maybe<T>.doOnAfterComplete(action: () -> Unit): Maybe<T> =
+fun <T> Maybe<T>.doOnAfterComplete(consumer: () -> Unit): Maybe<T> =
     maybe { emitter ->
         subscribe(
             object : MaybeObserver<T>, SuccessCallback<T> by emitter, ErrorCallback by emitter {
@@ -95,7 +95,7 @@ fun <T> Maybe<T>.doOnAfterComplete(action: () -> Unit): Maybe<T> =
                     emitter.onComplete()
 
                     // Can't send error to downstream, already terminated with onComplete
-                    tryCatchAndHandle(block = action)
+                    tryCatchAndHandle(block = consumer)
                 }
             }
         )

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DoOnAfter.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DoOnAfter.kt
@@ -80,10 +80,10 @@ fun <T> Maybe<T>.doOnAfterSuccess(consumer: (T) -> Unit): Maybe<T> =
     }
 
 /**
- * Calls the [consumer] when the [Maybe] signals `onComplete`.
- * The [consumer] is called **after** the observer is called.
+ * Calls the [action] when the [Maybe] signals `onComplete`.
+ * The [action] is called **after** the observer is called.
  */
-fun <T> Maybe<T>.doOnAfterComplete(consumer: () -> Unit): Maybe<T> =
+fun <T> Maybe<T>.doOnAfterComplete(action: () -> Unit): Maybe<T> =
     maybe { emitter ->
         subscribe(
             object : MaybeObserver<T>, SuccessCallback<T> by emitter, ErrorCallback by emitter {
@@ -95,7 +95,7 @@ fun <T> Maybe<T>.doOnAfterComplete(consumer: () -> Unit): Maybe<T> =
                     emitter.onComplete()
 
                     // Can't send error to downstream, already terminated with onComplete
-                    tryCatchAndHandle(block = consumer)
+                    tryCatchAndHandle(block = action)
                 }
             }
         )

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/FlatMapCompletable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/FlatMapCompletable.kt
@@ -10,6 +10,6 @@ import com.badoo.reaktive.completable.asMaybe
  */
 fun <T> Maybe<T>.flatMapCompletable(mapper: (T) -> Completable): Completable =
     flatMap {
-        mapper(it).asMaybe<Nothing>()
+        mapper(it).asMaybe()
     }
         .asCompletable()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMapCompletable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/FlatMapCompletable.kt
@@ -19,5 +19,5 @@ fun <T> Observable<T>.flatMapCompletable(mapper: (T) -> Completable): Completabl
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#flatMapCompletable-io.reactivex.functions.Function-).
  */
 fun <T> Observable<T>.flatMapCompletable(maxConcurrency: Int, mapper: (T) -> Completable): Completable =
-    flatMap(maxConcurrency = maxConcurrency) { mapper(it).asObservable<Nothing>() }
+    flatMap(maxConcurrency = maxConcurrency) { mapper(it).asObservable() }
         .asCompletable()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Interval.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Interval.kt
@@ -7,9 +7,11 @@ import com.badoo.reaktive.utils.atomic.AtomicLong
  * Returns an [Observable] that emits `0L` after [startDelayMillis] and
  * ever increasing numbers after each period of time specified by [periodMillis], on a specified [Scheduler].
  *
+ * Default start delay is equal to the specified period
+ *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#interval-long-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).
  */
-fun observableInterval(startDelayMillis: Long, periodMillis: Long, scheduler: Scheduler): Observable<Long> =
+fun observableInterval(periodMillis: Long, startDelayMillis: Long = periodMillis,  scheduler: Scheduler): Observable<Long> =
     observable { emitter ->
         val executor = scheduler.newExecutor()
         emitter.setDisposable(executor)
@@ -19,12 +21,3 @@ fun observableInterval(startDelayMillis: Long, periodMillis: Long, scheduler: Sc
             emitter.onNext(count.addAndGet(1L))
         }
     }
-
-/**
- * Returns an [Observable] that emits a sequential number every interval of time specified by [periodMillis],
- * on a specified [Scheduler].
- *
- * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#interval-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).
- */
-fun observableInterval(periodMillis: Long, scheduler: Scheduler): Observable<Long> =
-    observableInterval(periodMillis, periodMillis, scheduler)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Interval.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Interval.kt
@@ -11,7 +11,7 @@ import com.badoo.reaktive.utils.atomic.AtomicLong
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#interval-long-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).
  */
-fun observableInterval(periodMillis: Long, startDelayMillis: Long = periodMillis,  scheduler: Scheduler): Observable<Long> =
+fun observableInterval(periodMillis: Long, startDelayMillis: Long = periodMillis, scheduler: Scheduler): Observable<Long> =
     observable { emitter ->
         val executor = scheduler.newExecutor()
         emitter.setDisposable(executor)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Replay.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Replay.kt
@@ -5,19 +5,13 @@ import com.badoo.reaktive.subject.replay.ReplaySubject
 
 /**
  * Returns a [ConnectableObservable] that shares a single subscription to the source [Observable]
- * and replays all of its signals to any future subscriber.
- *
- * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#replay--).
- */
-fun <T> Observable<T>.replay(): ConnectableObservable<T> = replay(bufferSize = Int.MAX_VALUE)
-
-/**
- * Returns a [ConnectableObservable] that shares a single subscription to the source [Observable]
  * and replays at most [bufferSize] elements emitted by the source [Observable] to any future subscriber.
+ *
+ * Default buffer size is unlimited
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#replay-int-).
  */
-fun <T> Observable<T>.replay(bufferSize: Int): ConnectableObservable<T> {
+fun <T> Observable<T>.replay(bufferSize: Int = Int.MAX_VALUE): ConnectableObservable<T> {
     require(bufferSize > 0) { "Buffer size must be a positive value" }
 
     return publish { ReplaySubject(bufferSize = bufferSize) }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SwitchMapCompletable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SwitchMapCompletable.kt
@@ -11,6 +11,6 @@ import com.badoo.reaktive.completable.asObservable
  */
 fun <T> Observable<T>.switchMapCompletable(mapper: (T) -> Completable): Completable =
     switchMap {
-        mapper(it).asObservable<Nothing>()
+        mapper(it).asObservable()
     }
         .asCompletable()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AsMaybeTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AsMaybeTests.kt
@@ -1,3 +1,3 @@
 package com.badoo.reaktive.completable
 
-class AsMaybeTests : CompletableToMaybeTests by CompletableToMaybeTestsImpl({ asMaybe<Nothing>() })
+class AsMaybeTests : CompletableToMaybeTests by CompletableToMaybeTestsImpl({ asMaybe() })

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AsObservableTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/AsObservableTests.kt
@@ -1,3 +1,3 @@
 package com.badoo.reaktive.completable
 
-class AsObservableTests : CompletableToObservableTests by CompletableToObservableTestsImpl({ asObservable<Nothing>() })
+class AsObservableTests : CompletableToObservableTests by CompletableToObservableTestsImpl({ asObservable() })

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnAfterCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnAfterCompleteTest.kt
@@ -17,7 +17,7 @@ class DoOnAfterCompleteTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ doOnA
 
     @Test
     fun does_not_call_action_WHEN_upstream_succeeded() {
-        val isCalled = AtomicBoolean()
+        val isCalled = AtomicBoolean(false)
 
         upstream
             .doOnAfterComplete {
@@ -53,7 +53,7 @@ class DoOnAfterCompleteTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ doOnA
 
     @Test
     fun does_not_call_action_WHEN_upstream_produced_error() {
-        val isCalled = AtomicBoolean()
+        val isCalled = AtomicBoolean(false)
 
         upstream
             .doOnAfterComplete {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnAfterCompleteTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DoOnAfterCompleteTest.kt
@@ -17,7 +17,7 @@ class DoOnAfterCompleteTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ doOnA
 
     @Test
     fun does_not_call_action_WHEN_upstream_succeeded() {
-        val isCalled = AtomicBoolean(false)
+        val isCalled = AtomicBoolean()
 
         upstream
             .doOnAfterComplete {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/IntervalTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/IntervalTest.kt
@@ -19,7 +19,11 @@ class IntervalTest {
 
     private val scheduler = TestScheduler()
     private val timer = scheduler.timer
-    private val upstream = observableInterval(50L, 100L, scheduler)
+    private val upstream = observableInterval(
+        periodMillis = 100L,
+        startDelayMillis = 50L,
+        scheduler = scheduler
+    )
     private val observer = upstream.test()
 
     @Test


### PR DESCRIPTION
## Task
Part of the #620 

## Changes
* Remove generics from `Completable.asMaybe` and `Completeable.asObservable`
* Rename parameter `action` to `consumer` (See notes)
* Swap parameters for the observable interval and make default for delay as period value
* Add default parameter values and remove overridden versions

## Notes
* There are more `action` named parameters
* IDE shows me unused function warning - should we suppress it?