### PR TITLE
[2.0.0] Retry and repeat changes

### DIFF
--- a/reaktive/api/android/reaktive.api
+++ b/reaktive/api/android/reaktive.api
@@ -191,8 +191,8 @@ public final class com/badoo/reaktive/completable/OnErrorResumeNextKt {
 }
 
 public final class com/badoo/reaktive/completable/RepeatKt {
-	public static final fun repeat (Lcom/badoo/reaktive/completable/Completable;I)Lcom/badoo/reaktive/completable/Completable;
-	public static synthetic fun repeat$default (Lcom/badoo/reaktive/completable/Completable;IILjava/lang/Object;)Lcom/badoo/reaktive/completable/Completable;
+	public static final fun repeat (Lcom/badoo/reaktive/completable/Completable;J)Lcom/badoo/reaktive/completable/Completable;
+	public static synthetic fun repeat$default (Lcom/badoo/reaktive/completable/Completable;JILjava/lang/Object;)Lcom/badoo/reaktive/completable/Completable;
 }
 
 public final class com/badoo/reaktive/completable/RepeatUntilKt {
@@ -204,7 +204,7 @@ public final class com/badoo/reaktive/completable/RepeatWhenKt {
 }
 
 public final class com/badoo/reaktive/completable/RetryKt {
-	public static final fun retry (Lcom/badoo/reaktive/completable/Completable;I)Lcom/badoo/reaktive/completable/Completable;
+	public static final fun retry (Lcom/badoo/reaktive/completable/Completable;J)Lcom/badoo/reaktive/completable/Completable;
 	public static final fun retry (Lcom/badoo/reaktive/completable/Completable;Lkotlin/jvm/functions/Function2;)Lcom/badoo/reaktive/completable/Completable;
 	public static synthetic fun retry$default (Lcom/badoo/reaktive/completable/Completable;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/badoo/reaktive/completable/Completable;
 }
@@ -483,8 +483,8 @@ public final class com/badoo/reaktive/maybe/OnErrorReturnKt {
 }
 
 public final class com/badoo/reaktive/maybe/RepeatKt {
-	public static final fun repeat (Lcom/badoo/reaktive/maybe/Maybe;I)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun repeat$default (Lcom/badoo/reaktive/maybe/Maybe;IILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun repeat (Lcom/badoo/reaktive/maybe/Maybe;J)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun repeat$default (Lcom/badoo/reaktive/maybe/Maybe;JILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/maybe/RepeatUntilKt {
@@ -839,8 +839,8 @@ public final class com/badoo/reaktive/observable/RefCountKt {
 }
 
 public final class com/badoo/reaktive/observable/RepeatKt {
-	public static final fun repeat (Lcom/badoo/reaktive/observable/Observable;I)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun repeat$default (Lcom/badoo/reaktive/observable/Observable;IILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun repeat (Lcom/badoo/reaktive/observable/Observable;J)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun repeat$default (Lcom/badoo/reaktive/observable/Observable;JILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/RepeatUntilKt {
@@ -1231,8 +1231,8 @@ public final class com/badoo/reaktive/single/OnErrorReturnKt {
 }
 
 public final class com/badoo/reaktive/single/RepeatKt {
-	public static final fun repeat (Lcom/badoo/reaktive/single/Single;I)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun repeat$default (Lcom/badoo/reaktive/single/Single;IILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun repeat (Lcom/badoo/reaktive/single/Single;J)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun repeat$default (Lcom/badoo/reaktive/single/Single;JILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/single/RepeatUntilKt {

--- a/reaktive/api/jvm/reaktive.api
+++ b/reaktive/api/jvm/reaktive.api
@@ -184,8 +184,8 @@ public final class com/badoo/reaktive/completable/OnErrorResumeNextKt {
 }
 
 public final class com/badoo/reaktive/completable/RepeatKt {
-	public static final fun repeat (Lcom/badoo/reaktive/completable/Completable;I)Lcom/badoo/reaktive/completable/Completable;
-	public static synthetic fun repeat$default (Lcom/badoo/reaktive/completable/Completable;IILjava/lang/Object;)Lcom/badoo/reaktive/completable/Completable;
+	public static final fun repeat (Lcom/badoo/reaktive/completable/Completable;J)Lcom/badoo/reaktive/completable/Completable;
+	public static synthetic fun repeat$default (Lcom/badoo/reaktive/completable/Completable;JILjava/lang/Object;)Lcom/badoo/reaktive/completable/Completable;
 }
 
 public final class com/badoo/reaktive/completable/RepeatUntilKt {
@@ -197,7 +197,7 @@ public final class com/badoo/reaktive/completable/RepeatWhenKt {
 }
 
 public final class com/badoo/reaktive/completable/RetryKt {
-	public static final fun retry (Lcom/badoo/reaktive/completable/Completable;I)Lcom/badoo/reaktive/completable/Completable;
+	public static final fun retry (Lcom/badoo/reaktive/completable/Completable;J)Lcom/badoo/reaktive/completable/Completable;
 	public static final fun retry (Lcom/badoo/reaktive/completable/Completable;Lkotlin/jvm/functions/Function2;)Lcom/badoo/reaktive/completable/Completable;
 	public static synthetic fun retry$default (Lcom/badoo/reaktive/completable/Completable;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/badoo/reaktive/completable/Completable;
 }
@@ -476,8 +476,8 @@ public final class com/badoo/reaktive/maybe/OnErrorReturnKt {
 }
 
 public final class com/badoo/reaktive/maybe/RepeatKt {
-	public static final fun repeat (Lcom/badoo/reaktive/maybe/Maybe;I)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun repeat$default (Lcom/badoo/reaktive/maybe/Maybe;IILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun repeat (Lcom/badoo/reaktive/maybe/Maybe;J)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun repeat$default (Lcom/badoo/reaktive/maybe/Maybe;JILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/maybe/RepeatUntilKt {
@@ -832,8 +832,8 @@ public final class com/badoo/reaktive/observable/RefCountKt {
 }
 
 public final class com/badoo/reaktive/observable/RepeatKt {
-	public static final fun repeat (Lcom/badoo/reaktive/observable/Observable;I)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun repeat$default (Lcom/badoo/reaktive/observable/Observable;IILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun repeat (Lcom/badoo/reaktive/observable/Observable;J)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun repeat$default (Lcom/badoo/reaktive/observable/Observable;JILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/RepeatUntilKt {
@@ -1224,8 +1224,8 @@ public final class com/badoo/reaktive/single/OnErrorReturnKt {
 }
 
 public final class com/badoo/reaktive/single/RepeatKt {
-	public static final fun repeat (Lcom/badoo/reaktive/single/Single;I)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun repeat$default (Lcom/badoo/reaktive/single/Single;IILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun repeat (Lcom/badoo/reaktive/single/Single;J)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun repeat$default (Lcom/badoo/reaktive/single/Single;JILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/single/RepeatUntilKt {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/operator/Retry.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/operator/Retry.kt
@@ -3,13 +3,13 @@ package com.badoo.reaktive.base.operator
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.exceptions.CompositeException
 import com.badoo.reaktive.base.tryCatch
-import com.badoo.reaktive.utils.atomic.AtomicInt
+import com.badoo.reaktive.utils.atomic.AtomicLong
 
 internal class Retry(
     private val emitter: ErrorCallback,
-    private val predicate: (attempt: Int, Throwable) -> Boolean
+    private val predicate: (attempt: Long, Throwable) -> Boolean
 ) {
-    private val attempt = AtomicInt(0)
+    private val attempt = AtomicLong(0)
 
     fun onError(error: Throwable, resubscribe: () -> Unit) {
         emitter.tryCatch(

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Repeat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Repeat.kt
@@ -4,11 +4,11 @@ import com.badoo.reaktive.observable.asCompletable
 import com.badoo.reaktive.observable.repeat
 
 /**
- * When the [Completable] signals `onComplete`, re-subscribes to the [Completable], [count] times.
+ * When the [Completable] signals `onComplete`, re-subscribes to the [Completable], [times] times.
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Completable.html#repeat-long-).
  */
-fun Completable.repeat(count: Int = -1): Completable =
+fun Completable.repeat(times: Long = Long.MAX_VALUE): Completable =
     asObservable()
-        .repeat(count = count)
+        .repeat(times = times)
         .asCompletable()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Retry.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Retry.kt
@@ -9,7 +9,7 @@ import com.badoo.reaktive.disposable.Disposable
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Completable.html#retry-io.reactivex.functions.BiPredicate-).
  */
-fun Completable.retry(predicate: (attempt: Int, Throwable) -> Boolean = { _, _ -> true }): Completable =
+fun Completable.retry(predicate: (attempt: Long, Throwable) -> Boolean = { _, _ -> true }): Completable =
     completable { emitter ->
         subscribe(
             object : CompletableObserver, CompletableCallbacks by emitter {
@@ -31,5 +31,5 @@ fun Completable.retry(predicate: (attempt: Int, Throwable) -> Boolean = { _, _ -
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Completable.html#retry-long-).
  */
-fun Completable.retry(times: Int): Completable =
+fun Completable.retry(times: Long): Completable =
     retry { attempt, _ -> attempt < times }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Repeat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Repeat.kt
@@ -4,8 +4,8 @@ import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.observable.repeat
 
 /**
- * When the [Maybe] signals `onSuccess` or `onComplete`, re-subscribes to the [Maybe], [count] times.
+ * When the [Maybe] signals `onSuccess` or `onComplete`, re-subscribes to the [Maybe], [times] times.
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Maybe.html#repeat-long-).
  */
-fun <T> Maybe<T>.repeat(count: Int = -1): Observable<T> = asObservable().repeat(count = count)
+fun <T> Maybe<T>.repeat(times: Long = Long.MAX_VALUE): Observable<T> = asObservable().repeat(times = times)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Retry.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Retry.kt
@@ -11,7 +11,7 @@ import com.badoo.reaktive.disposable.Disposable
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Maybe.html#retry-io.reactivex.functions.BiPredicate-).
  */
-fun <T> Maybe<T>.retry(predicate: (attempt: Int, Throwable) -> Boolean = { _, _ -> true }): Maybe<T> =
+fun <T> Maybe<T>.retry(predicate: (attempt: Long, Throwable) -> Boolean = { _, _ -> true }): Maybe<T> =
     maybe { emitter ->
         subscribe(
             object : MaybeObserver<T>, SuccessCallback<T> by emitter, CompleteCallback by emitter {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Repeat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Repeat.kt
@@ -17,7 +17,7 @@ fun <T> Observable<T>.repeat(times: Long = Long.MAX_VALUE): Observable<T> {
     return observable { emitter ->
         val observer =
             object : ObservableObserver<T>, ValueCallback<T> by emitter, ErrorCallback by emitter {
-                private val counter: AtomicLong? = if (times >= 0) AtomicLong(times) else null
+                private val counter: AtomicLong? = if (times < Long.MAX_VALUE) AtomicLong(times) else null
 
                 // Prevents recursive subscriptions
                 private val serializer =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Repeat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Repeat.kt
@@ -4,18 +4,19 @@ import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.ValueCallback
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.utils.atomic.AtomicInt
+import com.badoo.reaktive.utils.atomic.AtomicLong
 import com.badoo.reaktive.utils.serializer.serializer
 
 /**
- * Returns an [Observable] that automatically resubscribes to this [Observable] at most [count] times.
+ * Returns an [Observable] that automatically resubscribes to this [Observable] at most [times] times.
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#repeat-long-).
  */
-fun <T> Observable<T>.repeat(count: Int = -1): Observable<T> =
+fun <T> Observable<T>.repeat(times: Long = Long.MAX_VALUE): Observable<T> =
     observable { emitter ->
         val observer =
             object : ObservableObserver<T>, ValueCallback<T> by emitter, ErrorCallback by emitter {
-                private val counter: AtomicInt? = if (count >= 0) AtomicInt(count) else null
+                private val counter: AtomicLong? = if (times >= 0) AtomicLong(times) else null
 
                 // Prevents recursive subscriptions
                 private val serializer =

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Repeat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Repeat.kt
@@ -3,7 +3,6 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.ValueCallback
 import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.utils.atomic.AtomicInt
 import com.badoo.reaktive.utils.atomic.AtomicLong
 import com.badoo.reaktive.utils.serializer.serializer
 
@@ -12,8 +11,10 @@ import com.badoo.reaktive.utils.serializer.serializer
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#repeat-long-).
  */
-fun <T> Observable<T>.repeat(times: Long = Long.MAX_VALUE): Observable<T> =
-    observable { emitter ->
+fun <T> Observable<T>.repeat(times: Long = Long.MAX_VALUE): Observable<T> {
+    require(times >= 0L) { "Number of times must not be negative" }
+
+    return observable { emitter ->
         val observer =
             object : ObservableObserver<T>, ValueCallback<T> by emitter, ErrorCallback by emitter {
                 private val counter: AtomicLong? = if (times >= 0) AtomicLong(times) else null
@@ -46,3 +47,4 @@ fun <T> Observable<T>.repeat(times: Long = Long.MAX_VALUE): Observable<T> =
 
         observer.subscribeToUpstream()
     }
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Retry.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Retry.kt
@@ -12,7 +12,7 @@ import com.badoo.reaktive.disposable.Disposable
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#retry-io.reactivex.functions.BiPredicate-).
  */
-fun <T> Observable<T>.retry(predicate: (attempt: Int, Throwable) -> Boolean = { _, _ -> true }): Observable<T> =
+fun <T> Observable<T>.retry(predicate: (attempt: Long, Throwable) -> Boolean = { _, _ -> true }): Observable<T> =
     observable { emitter ->
         subscribe(
             object : ObservableObserver<T>, ValueCallback<T> by emitter, CompleteCallback by emitter {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Repeat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Repeat.kt
@@ -4,8 +4,8 @@ import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.observable.repeat
 
 /**
- * When the [Single] signals `onSuccess`, re-subscribes to the [Single], [count] times.
+ * When the [Single] signals `onSuccess`, re-subscribes to the [Single], [times] times.
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Single.html#repeat-long-).
  */
-fun <T> Single<T>.repeat(count: Int = -1): Observable<T> = asObservable().repeat(count = count)
+fun <T> Single<T>.repeat(times: Long = Long.MAX_VALUE): Observable<T> = asObservable().repeat(times = times)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Retry.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Retry.kt
@@ -10,7 +10,7 @@ import com.badoo.reaktive.disposable.Disposable
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Single.html#retry-io.reactivex.functions.BiPredicate-).
  */
-fun <T> Single<T>.retry(predicate: (attempt: Int, Throwable) -> Boolean = { _, _ -> true }): Single<T> =
+fun <T> Single<T>.retry(predicate: (attempt: Long, Throwable) -> Boolean = { _, _ -> true }): Single<T> =
     single { emitter ->
         subscribe(
             object : SingleObserver<T>, SuccessCallback<T> by emitter {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/RetryTest.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.completable.TestCompletable
 import com.badoo.reaktive.test.completable.assertComplete
 import com.badoo.reaktive.test.completable.test
-import com.badoo.reaktive.utils.atomic.AtomicInt
+import com.badoo.reaktive.utils.atomic.AtomicLong
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import kotlin.test.Ignore
 import kotlin.test.Test
@@ -79,7 +79,7 @@ class RetryTest : CompletableToCompletableTests by CompletableToCompletableTests
 
     @Test
     fun predicate_receives_valid_counter_WHEN_upstream_produces_error() {
-        val timeRef = AtomicInt()
+        val timeRef = AtomicLong(0)
         upstream
             .retry { time, _ ->
                 timeRef.value = time

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/RetryTest.kt
@@ -79,7 +79,7 @@ class RetryTest : CompletableToCompletableTests by CompletableToCompletableTests
 
     @Test
     fun predicate_receives_valid_counter_WHEN_upstream_produces_error() {
-        val timeRef = AtomicLong(0)
+        val timeRef = AtomicLong()
         upstream
             .retry { time, _ ->
                 timeRef.value = time

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/RetryTest.kt
@@ -87,9 +87,9 @@ class RetryTest : CompletableToCompletableTests by CompletableToCompletableTests
             }
             .test()
         upstream.onError(Throwable())
-        assertSame(timeRef.value, 1)
+        assertSame(timeRef.value, 1L)
         upstream.onError(Throwable())
-        assertSame(timeRef.value, 2)
+        assertSame(timeRef.value, 2L)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/RetryTest.kt
@@ -10,6 +10,7 @@ import com.badoo.reaktive.utils.atomic.AtomicLong
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -87,9 +88,9 @@ class RetryTest : CompletableToCompletableTests by CompletableToCompletableTests
             }
             .test()
         upstream.onError(Throwable())
-        assertSame(timeRef.value, 1L)
+        assertEquals(1, timeRef.value)
         upstream.onError(Throwable())
-        assertSame(timeRef.value, 2L)
+        assertEquals(2, timeRef.value)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/RetryTest.kt
@@ -96,9 +96,9 @@ class RetryTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ retry() }) {
             }
             .test()
         upstream.onError(Throwable())
-        assertSame(timeRef.value, 1)
+        assertSame(timeRef.value, 1L)
         upstream.onError(Throwable())
-        assertSame(timeRef.value, 2)
+        assertSame(timeRef.value, 2L)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/RetryTest.kt
@@ -88,7 +88,7 @@ class RetryTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ retry() }) {
 
     @Test
     fun predicate_receives_valid_counter_WHEN_upstream_produces_error() {
-        val timeRef = AtomicLong(0)
+        val timeRef = AtomicLong()
         upstream
             .retry { time, _ ->
                 timeRef.value = time

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/RetryTest.kt
@@ -11,6 +11,7 @@ import com.badoo.reaktive.utils.atomic.AtomicLong
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -96,9 +97,9 @@ class RetryTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ retry() }) {
             }
             .test()
         upstream.onError(Throwable())
-        assertSame(timeRef.value, 1L)
+        assertEquals(1, timeRef.value)
         upstream.onError(Throwable())
-        assertSame(timeRef.value, 2L)
+        assertEquals(2, timeRef.value)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/RetryTest.kt
@@ -7,7 +7,7 @@ import com.badoo.reaktive.test.maybe.TestMaybe
 import com.badoo.reaktive.test.maybe.assertComplete
 import com.badoo.reaktive.test.maybe.assertSuccess
 import com.badoo.reaktive.test.maybe.test
-import com.badoo.reaktive.utils.atomic.AtomicInt
+import com.badoo.reaktive.utils.atomic.AtomicLong
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import kotlin.test.Ignore
 import kotlin.test.Test
@@ -88,7 +88,7 @@ class RetryTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ retry() }) {
 
     @Test
     fun predicate_receives_valid_counter_WHEN_upstream_produces_error() {
-        val timeRef = AtomicInt()
+        val timeRef = AtomicLong(0)
         upstream
             .retry { time, _ ->
                 timeRef.value = time

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RepeatTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RepeatTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertTrue
 class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImpl({ repeat(times = 0) }) {
 
     @Test
-    fun emits_all_values_of_first_iteration_WHEN_count_is_positive() {
+    fun emits_all_values_of_first_iteration_WHEN_times_is_positive() {
         val upstream = TestObservable<Int?>()
         val observer = upstream.repeat(times = 2).test()
 
@@ -32,7 +32,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     }
 
     @Test
-    fun emits_all_values_of_first_iteration_WHEN_count_is_0() {
+    fun emits_all_values_of_first_iteration_WHEN_times_is_zero() {
         val upstream = TestObservable<Int?>()
         val observer = upstream.repeat(times = 0).test()
 
@@ -42,17 +42,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     }
 
     @Test
-    fun emits_all_values_of_first_iteration_WHEN_count_is_negative() {
-        val upstream = TestObservable<Int?>()
-        val observer = upstream.repeat(times = -1).test()
-
-        upstream.onNext(0, null, 2)
-
-        observer.assertValues(0, null, 2)
-    }
-
-    @Test
-    fun resubscribes_to_upstream_WHEN_upstream_completed_and_count_not_reached() {
+    fun resubscribes_to_upstream_WHEN_upstream_completed_and_times_not_reached() {
         val upstreams = List(2) { TestObservable<Int>() }
         val index = AtomicInt(-1)
 
@@ -69,7 +59,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     }
 
     @Test
-    fun does_not_subscribe_to_upstream_WHEN_upstream_completed_and_count_is_0() {
+    fun does_not_subscribe_to_upstream_WHEN_upstream_completed_and_times_is_0() {
         val upstream = TestObservable<Int?>()
         upstream.repeat(times = 0).test()
 
@@ -80,7 +70,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     }
 
     @Test
-    fun does_not_subscribe_to_upstream_WHEN_upstream_completed_and_count_is_reached() {
+    fun does_not_subscribe_to_upstream_WHEN_upstream_completed_and_times_is_reached() {
         val upstream = TestObservable<Int?>()
         upstream.repeat(times = 1).test()
 
@@ -92,9 +82,9 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     }
 
     @Test
-    fun emits_all_values_of_second_iteration_WHEN_count_is_negative() {
+    fun emits_all_values_of_second_iteration_WHEN_times_is_infinite() {
         val upstream = TestObservable<Int?>()
-        val observer = upstream.repeat(times = -1).test()
+        val observer = upstream.repeat(times = Long.MAX_VALUE).test()
 
         upstream.onNext(0, 1)
         upstream.onComplete()
@@ -105,7 +95,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     }
 
     @Test
-    fun emits_all_values_of_second_iteration_WHEN_count_is_1() {
+    fun emits_all_values_of_second_iteration_WHEN_times_is_1() {
         val upstream = TestObservable<Int?>()
         val observer = upstream.repeat(times = 1).test()
 
@@ -118,7 +108,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     }
 
     @Test
-    fun completes_after_second_iteration_WHEN_count_is_1() {
+    fun completes_after_second_iteration_WHEN_times_is_1() {
         val upstream = TestObservable<Int?>()
         val observer = upstream.repeat(times = 1).test()
 
@@ -131,7 +121,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     }
 
     @Test
-    fun does_not_completes_after_second_iteration_WHEN_count_is_2() {
+    fun does_not_completes_after_second_iteration_WHEN_times_is_2() {
         val upstream = TestObservable<Int?>()
         val observer = upstream.repeat(times = 2).test()
 
@@ -190,7 +180,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     }
 
     @Test
-    fun emits_all_values_repeatedly_for_first_1000_iterations_WHEN_count_is_negative() {
+    fun emits_all_values_repeatedly_for_first_1000_iterations_WHEN_times_is_infinite() {
         val list = SharedList<Int>(3000)
 
         observableUnsafe<Int> { observer ->
@@ -200,7 +190,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
             observer.onNext(2)
             observer.onComplete()
         }
-            .repeat(times = -1)
+            .repeat(times = Long.MAX_VALUE)
             .subscribe(
                 object : SerialDisposable(), ObservableObserver<Int> {
                     override fun onSubscribe(disposable: Disposable) {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RepeatTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RepeatTest.kt
@@ -19,12 +19,12 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImpl({ repeat(count = 0) }) {
+class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImpl({ repeat(times = 0) }) {
 
     @Test
     fun emits_all_values_of_first_iteration_WHEN_count_is_positive() {
         val upstream = TestObservable<Int?>()
-        val observer = upstream.repeat(count = 2).test()
+        val observer = upstream.repeat(times = 2).test()
 
         upstream.onNext(0, null, 2)
 
@@ -34,7 +34,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     @Test
     fun emits_all_values_of_first_iteration_WHEN_count_is_0() {
         val upstream = TestObservable<Int?>()
-        val observer = upstream.repeat(count = 0).test()
+        val observer = upstream.repeat(times = 0).test()
 
         upstream.onNext(0, null, 2)
 
@@ -44,7 +44,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     @Test
     fun emits_all_values_of_first_iteration_WHEN_count_is_negative() {
         val upstream = TestObservable<Int?>()
-        val observer = upstream.repeat(count = -1).test()
+        val observer = upstream.repeat(times = -1).test()
 
         upstream.onNext(0, null, 2)
 
@@ -61,7 +61,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
                 upstreams[index.addAndGet(1)].subscribe(observer)
             }
 
-        upstream.repeat(count = 1).test()
+        upstream.repeat(times = 1).test()
 
         upstreams[0].onComplete()
 
@@ -71,7 +71,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     @Test
     fun does_not_subscribe_to_upstream_WHEN_upstream_completed_and_count_is_0() {
         val upstream = TestObservable<Int?>()
-        upstream.repeat(count = 0).test()
+        upstream.repeat(times = 0).test()
 
         upstream.onNext(0)
         upstream.onComplete()
@@ -82,7 +82,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     @Test
     fun does_not_subscribe_to_upstream_WHEN_upstream_completed_and_count_is_reached() {
         val upstream = TestObservable<Int?>()
-        upstream.repeat(count = 1).test()
+        upstream.repeat(times = 1).test()
 
         upstream.onComplete()
         upstream.onNext(0)
@@ -94,7 +94,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     @Test
     fun emits_all_values_of_second_iteration_WHEN_count_is_negative() {
         val upstream = TestObservable<Int?>()
-        val observer = upstream.repeat(count = -1).test()
+        val observer = upstream.repeat(times = -1).test()
 
         upstream.onNext(0, 1)
         upstream.onComplete()
@@ -107,7 +107,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     @Test
     fun emits_all_values_of_second_iteration_WHEN_count_is_1() {
         val upstream = TestObservable<Int?>()
-        val observer = upstream.repeat(count = 1).test()
+        val observer = upstream.repeat(times = 1).test()
 
         upstream.onNext(0, 1)
         observer.reset()
@@ -120,7 +120,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     @Test
     fun completes_after_second_iteration_WHEN_count_is_1() {
         val upstream = TestObservable<Int?>()
-        val observer = upstream.repeat(count = 1).test()
+        val observer = upstream.repeat(times = 1).test()
 
         upstream.onNext(0)
         upstream.onComplete()
@@ -133,7 +133,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     @Test
     fun does_not_completes_after_second_iteration_WHEN_count_is_2() {
         val upstream = TestObservable<Int?>()
-        val observer = upstream.repeat(count = 2).test()
+        val observer = upstream.repeat(times = 2).test()
 
         upstream.onNext(0)
         upstream.onComplete()
@@ -146,8 +146,8 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     @Test
     fun does_not_resubscribe_to_upstream_recursively() {
         val isFirstIteration = AtomicBoolean(true)
-        val isFirstIterationFinished = AtomicBoolean()
-        val isSecondIterationRecursive = AtomicBoolean()
+        val isFirstIterationFinished = AtomicBoolean(false)
+        val isSecondIterationRecursive = AtomicBoolean(false)
 
         val upstream =
             observableUnsafe<Int> { observer ->
@@ -161,14 +161,14 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
                 }
             }
 
-        upstream.repeat(count = 1).test()
+        upstream.repeat(times = 1).test()
 
         assertFalse(isSecondIterationRecursive.value)
     }
 
     @Test
     fun does_not_resubscribe_to_upstream_WHEN_disposed_and_upstream_completed() {
-        val isResubscribed = AtomicBoolean()
+        val isResubscribed = AtomicBoolean(false)
         val upstreamObserver = AtomicReference<ObservableObserver<Int>?>(null)
 
         val upstream =
@@ -181,7 +181,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
                 }
             }
 
-        val downstreamObserver = upstream.repeat(count = 1).test()
+        val downstreamObserver = upstream.repeat(times = 1).test()
 
         downstreamObserver.dispose()
         upstreamObserver.value!!.onComplete()
@@ -200,7 +200,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
             observer.onNext(2)
             observer.onComplete()
         }
-            .repeat(count = -1)
+            .repeat(times = -1)
             .subscribe(
                 object : SerialDisposable(), ObservableObserver<Int> {
                     override fun onSubscribe(disposable: Disposable) {
@@ -229,7 +229,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     @Test
     fun produces_error_WHEN_second_iteration_produced_error() {
         val upstream = TestObservable<Int>()
-        val observer = upstream.repeat(count = 2).test()
+        val observer = upstream.repeat(times = 2).test()
         val error = Exception()
 
         upstream.onComplete()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RepeatTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RepeatTest.kt
@@ -146,8 +146,8 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
     @Test
     fun does_not_resubscribe_to_upstream_recursively() {
         val isFirstIteration = AtomicBoolean(true)
-        val isFirstIterationFinished = AtomicBoolean(false)
-        val isSecondIterationRecursive = AtomicBoolean(false)
+        val isFirstIterationFinished = AtomicBoolean()
+        val isSecondIterationRecursive = AtomicBoolean()
 
         val upstream =
             observableUnsafe<Int> { observer ->
@@ -168,7 +168,7 @@ class RepeatTest : ObservableToObservableTests by ObservableToObservableTestsImp
 
     @Test
     fun does_not_resubscribe_to_upstream_WHEN_disposed_and_upstream_completed() {
-        val isResubscribed = AtomicBoolean(false)
+        val isResubscribed = AtomicBoolean()
         val upstreamObserver = AtomicReference<ObservableObserver<Int>?>(null)
 
         val upstream =

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RetryTest.kt
@@ -97,9 +97,9 @@ class RetryTest : ObservableToObservableTests by ObservableToObservableTestsImpl
             }
             .test()
         upstream.onError(Throwable())
-        assertSame(timeRef.value, 1)
+        assertSame(timeRef.value, 1L)
         upstream.onError(Throwable())
-        assertSame(timeRef.value, 2)
+        assertSame(timeRef.value, 2L)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RetryTest.kt
@@ -89,7 +89,7 @@ class RetryTest : ObservableToObservableTests by ObservableToObservableTestsImpl
 
     @Test
     fun predicate_receives_valid_counter_WHEN_upstream_produces_error() {
-        val timeRef = AtomicLong(0)
+        val timeRef = AtomicLong()
         upstream
             .retry { time, _ ->
                 timeRef.value = time

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RetryTest.kt
@@ -8,7 +8,7 @@ import com.badoo.reaktive.test.observable.assertComplete
 import com.badoo.reaktive.test.observable.assertValues
 import com.badoo.reaktive.test.observable.onNext
 import com.badoo.reaktive.test.observable.test
-import com.badoo.reaktive.utils.atomic.AtomicInt
+import com.badoo.reaktive.utils.atomic.AtomicLong
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import kotlin.test.Ignore
 import kotlin.test.Test
@@ -89,7 +89,7 @@ class RetryTest : ObservableToObservableTests by ObservableToObservableTestsImpl
 
     @Test
     fun predicate_receives_valid_counter_WHEN_upstream_produces_error() {
-        val timeRef = AtomicInt()
+        val timeRef = AtomicLong(0)
         upstream
             .retry { time, _ ->
                 timeRef.value = time

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RetryTest.kt
@@ -12,6 +12,7 @@ import com.badoo.reaktive.utils.atomic.AtomicLong
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -97,9 +98,9 @@ class RetryTest : ObservableToObservableTests by ObservableToObservableTestsImpl
             }
             .test()
         upstream.onError(Throwable())
-        assertSame(timeRef.value, 1L)
+        assertEquals(1, timeRef.value)
         upstream.onError(Throwable())
-        assertSame(timeRef.value, 2L)
+        assertEquals(2, timeRef.value)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/RetryTest.kt
@@ -87,9 +87,9 @@ class RetryTest : SingleToSingleTests by SingleToSingleTestsImpl({ retry() }) {
             }
             .test()
         upstream.onError(Throwable())
-        assertSame(timeRef.value, 1)
+        assertSame(timeRef.value, 1L)
         upstream.onError(Throwable())
-        assertSame(timeRef.value, 2)
+        assertSame(timeRef.value, 2L)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/RetryTest.kt
@@ -6,7 +6,7 @@ import com.badoo.reaktive.test.base.hasSubscribers
 import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.test.single.assertSuccess
 import com.badoo.reaktive.test.single.test
-import com.badoo.reaktive.utils.atomic.AtomicInt
+import com.badoo.reaktive.utils.atomic.AtomicLong
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import kotlin.test.Ignore
 import kotlin.test.Test
@@ -79,7 +79,7 @@ class RetryTest : SingleToSingleTests by SingleToSingleTestsImpl({ retry() }) {
 
     @Test
     fun predicate_receives_valid_counter_WHEN_upstream_produces_error() {
-        val timeRef = AtomicInt()
+        val timeRef = AtomicLong(0)
         upstream
             .retry { time, _ ->
                 timeRef.value = time

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/RetryTest.kt
@@ -10,6 +10,7 @@ import com.badoo.reaktive.utils.atomic.AtomicLong
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -87,9 +88,9 @@ class RetryTest : SingleToSingleTests by SingleToSingleTestsImpl({ retry() }) {
             }
             .test()
         upstream.onError(Throwable())
-        assertSame(timeRef.value, 1L)
+        assertEquals(1, timeRef.value)
         upstream.onError(Throwable())
-        assertSame(timeRef.value, 2L)
+        assertEquals(2, timeRef.value)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/RetryTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/RetryTest.kt
@@ -79,7 +79,7 @@ class RetryTest : SingleToSingleTests by SingleToSingleTestsImpl({ retry() }) {
 
     @Test
     fun predicate_receives_valid_counter_WHEN_upstream_produces_error() {
-        val timeRef = AtomicLong(0)
+        val timeRef = AtomicLong()
         upstream
             .retry { time, _ ->
                 timeRef.value = time


### PR DESCRIPTION
## Task
Change type and rename parameters for Retry and Repeat #620.

## Changes
* Rename `count` to `times` for `Repeat` and make it Long. Also change default parameter value to `Long.MAX_VALUE`.
* Change type to long for `Retry` (see notes)
* Small changes around tests

## Notes
* Unfortunately if I put default value for retry we have clashing function calls. If my knowledge of Kotlin is correct, then I have to provide some parameter to help compiler to resolve type. This might be inconvenient for the user of the library. However, version with default selector is less performant. We could remove there default parameter value and use the simpler instead.