### PR TITLE
Added counter tests for repeatWhen

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/RepeatWhen.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/RepeatWhen.kt
@@ -9,7 +9,7 @@ import com.badoo.reaktive.observable.repeatWhen
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Completable.html#repeatWhen-io.reactivex.functions.Function-).
  */
-fun Completable.repeatWhen(handler: (repeatNumber: Int) -> Maybe<*>): Completable =
+fun Completable.repeatWhen(handler: (attempt: Int) -> Maybe<*>): Completable =
     asObservable<Nothing>()
         .repeatWhen(handler)
         .asCompletable()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/RepeatWhen.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/RepeatWhen.kt
@@ -9,5 +9,5 @@ import com.badoo.reaktive.observable.repeatWhen
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Maybe.html#repeatWhen-io.reactivex.functions.Function-).
  */
-fun <T> Maybe<T>.repeatWhen(handler: (repeatNumber: Int) -> Maybe<*>): Observable<T> =
+fun <T> Maybe<T>.repeatWhen(handler: (attempt: Int) -> Maybe<*>): Observable<T> =
     asObservable().repeatWhen(handler)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/RepeatWhen.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/RepeatWhen.kt
@@ -18,7 +18,7 @@ import com.badoo.reaktive.utils.atomic.AtomicInt
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#repeatWhen-io.reactivex.functions.Function-).
  */
-fun <T> Observable<T>.repeatWhen(handler: (repeatNumber: Int) -> Maybe<*>): Observable<T> =
+fun <T> Observable<T>.repeatWhen(handler: (attempt: Int) -> Maybe<*>): Observable<T> =
     observable { emitter ->
         val observer =
             object : ObservableObserver<T>, ValueCallback<T> by emitter, ErrorCallback by emitter {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/RepeatWhen.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/RepeatWhen.kt
@@ -17,7 +17,7 @@ import com.badoo.reaktive.utils.atomic.AtomicInt
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Single.html#repeatWhen-io.reactivex.functions.Function-).
  */
-fun <T> Single<T>.repeatWhen(handler: (repeatNumber: Int, value: T) -> Maybe<*>): Observable<T> =
+fun <T> Single<T>.repeatWhen(handler: (attempt: Int, value: T) -> Maybe<*>): Observable<T> =
     observable { emitter ->
         val observer =
             object : SingleObserver<T>, ErrorCallback by emitter {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RepeatWhenTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RepeatWhenTest.kt
@@ -15,6 +15,7 @@ import com.badoo.reaktive.utils.atomic.AtomicInt
 import kotlin.math.max
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertSame
 
 class RepeatWhenTest : ObservableToObservableTests by ObservableToObservableTestsImpl({ repeatWhen { maybeOfEmpty<Unit>() } }) {
 
@@ -156,5 +157,22 @@ class RepeatWhenTest : ObservableToObservableTests by ObservableToObservableTest
         upstream.onError(error)
 
         observer.assertError(error)
+    }
+
+    @Test
+    fun predicate_receives_valid_attempt_WHEN_upstream_completes() {
+        val upstream = TestObservable<Int?>()
+        val timeRef = AtomicInt()
+        upstream
+            .repeatWhen { attempt ->
+                timeRef.value = attempt
+                maybeOf(Unit)
+            }
+            .test()
+
+        upstream.onComplete()
+        assertSame(timeRef.value, 1)
+        upstream.onComplete()
+        assertSame(timeRef.value, 2)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/RepeatWhenTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/RepeatWhenTest.kt
@@ -4,18 +4,23 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.maybe.maybeOf
 import com.badoo.reaktive.maybe.maybeOfEmpty
 import com.badoo.reaktive.maybe.maybeUnsafe
+import com.badoo.reaktive.observable.repeatWhen
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.maybe.TestMaybe
+import com.badoo.reaktive.test.observable.TestObservable
 import com.badoo.reaktive.test.observable.assertComplete
 import com.badoo.reaktive.test.observable.assertValues
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.single.TestSingle
 import com.badoo.reaktive.utils.atomic.AtomicInt
 import com.badoo.reaktive.utils.atomic.atomicList
+import com.badoo.reaktive.utils.atomic.getValue
 import com.badoo.reaktive.utils.atomic.plusAssign
+import com.badoo.reaktive.utils.atomic.setValue
 import kotlin.math.max
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertSame
 
 class RepeatWhenTest : SingleToObservableTests by SingleToObservableTestsImpl({ repeatWhen { _, _ -> maybeOfEmpty<Unit>() } }) {
 
@@ -175,5 +180,23 @@ class RepeatWhenTest : SingleToObservableTests by SingleToObservableTestsImpl({ 
         upstream.onError(error)
 
         observer.assertError(error)
+    }
+
+    @Test
+    fun predicate_receives_valid_attempt_WHEN_upstream_completes() {
+        val upstream = TestObservable<Int?>()
+        var attemptVar by AtomicInt()
+
+        upstream
+            .repeatWhen { attempt ->
+                attemptVar = attempt
+                maybeOf(Unit)
+            }
+            .test()
+
+        upstream.onComplete()
+        assertSame(attemptVar, 1)
+        upstream.onComplete()
+        assertSame(attemptVar, 2)
     }
 }


### PR DESCRIPTION
Also renamed the handler's argument from `repeatNumber` to `attempt`, for consistency with the `retry` operator. Should be fine because it's not part of the API and basically just a hint.