### PR TITLE
[2.0.0] Renamed Observable#scan `accumulate` argument to `accumulator`

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Scan.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Scan.kt
@@ -6,13 +6,13 @@ import com.badoo.reaktive.utils.ObjectReference
 import com.badoo.reaktive.utils.Uninitialized
 
 /**
- * Returns an [Observable] that subscribes to the source [Observable] and calls the [accumulate] function
- * with a result of a previous [accumulate] invocation and a current element.
- * The returned [Observable] emits every value returned by the [accumulate] function.
+ * Returns an [Observable] that subscribes to the source [Observable] and calls the [accumulator] function
+ * with a result of a previous [accumulator] invocation and a current element.
+ * The returned [Observable] emits every value returned by the [accumulator] function.
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#scan-io.reactivex.functions.BiFunction-).
  */
-fun <T> Observable<T>.scan(accumulate: (acc: T, value: T) -> T): Observable<T> =
+fun <T> Observable<T>.scan(accumulator: (acc: T, value: T) -> T): Observable<T> =
     observable { emitter ->
         subscribe(
             object : ObservableObserver<T>, CompletableCallbacks by emitter {
@@ -27,7 +27,7 @@ fun <T> Observable<T>.scan(accumulate: (acc: T, value: T) -> T): Observable<T> =
                         } else {
                             try {
                                 @Suppress("UNCHECKED_CAST")
-                                accumulate(previous as T, value)
+                                accumulator(previous as T, value)
                             } catch (e: Throwable) {
                                 emitter.onError(e)
                                 return
@@ -58,15 +58,15 @@ fun <T, R> Observable<T>.scan(seed: R, accumulator: (acc: R, value: T) -> R): Ob
     scan<T, R>({ seed }, accumulator)
 
 /**
- * Returns an [Observable] that subscribes to the source [Observable] and calls the [accumulate] function
+ * Returns an [Observable] that subscribes to the source [Observable] and calls the [accumulator] function
  * first with a value returned by [getSeed] function and a first element emitted by the source [Observable].
- * Then for every subsequent element emitted by the source [Observable], calls [accumulate] with
+ * Then for every subsequent element emitted by the source [Observable], calls [accumulator] with
  * its previous result the emitted element. The returned [Observable] emits every value returned by
- * the [accumulate] function.
+ * the [accumulator] function.
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#scanWith-java.util.concurrent.Callable-io.reactivex.functions.BiFunction-).
  */
-fun <T, R> Observable<T>.scan(getSeed: () -> R, accumulate: (acc: R, value: T) -> R): Observable<R> =
+fun <T, R> Observable<T>.scan(getSeed: () -> R, accumulator: (acc: R, value: T) -> R): Observable<R> =
     observable { emitter ->
         val cache: ObjectReference<R> =
             getSeed()
@@ -81,7 +81,7 @@ fun <T, R> Observable<T>.scan(getSeed: () -> R, accumulate: (acc: R, value: T) -
 
                     val next =
                         try {
-                            accumulate(previous, value)
+                            accumulator(previous, value)
                         } catch (e: Throwable) {
                             emitter.onError(e)
                             return


### PR DESCRIPTION
For consistency with RxJava.

As part of #620.