### PR TITLE
Hardcode Xcode version because Kotlin expects particular emulators

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Install dependencies
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libgtk-3-dev nodejs chromium-browser
+      - name: Select Xcode version
+        uses: maxim-lobanov/setup-xcode@9a697e2b393340c3cacd97468baa318e4c883d98
+        with:
+          xcode-version: '13.4.1'
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Build Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libgtk-3-dev nodejs chromium-browser
       - name: Select Xcode version
+        if: matrix.os == 'macOS-latest'
         uses: maxim-lobanov/setup-xcode@9a697e2b393340c3cacd97468baa318e4c883d98
         with:
           xcode-version: '13.4.1'

--- a/.github/workflows/release-nmtc.yml
+++ b/.github/workflows/release-nmtc.yml
@@ -72,6 +72,10 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '11'
+      - name: Select Xcode version
+        uses: maxim-lobanov/setup-xcode@9a697e2b393340c3cacd97468baa318e4c883d98
+        with:
+          xcode-version: '13.4.1'
       - name: Release iOS, MacOS
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,10 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '11'
+      - name: Select Xcode version
+        uses: maxim-lobanov/setup-xcode@9a697e2b393340c3cacd97468baa318e4c883d98
+        with:
+          xcode-version: '13.4.1'
       - name: Release iOS, MacOS
         uses: gradle/gradle-build-action@v2
         with:
@@ -124,6 +128,10 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '11'
+      - name: Select Xcode version
+        uses: maxim-lobanov/setup-xcode@9a697e2b393340c3cacd97468baa318e4c883d98
+        with:
+          xcode-version: '13.4.1'
       - name: Check iOS
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
Looks like it is better to match Xcode version with particular Kotlin version.

```
java.lang.IllegalStateException: command '/usr/bin/xcrun' exited with errors (exit code: 148)
Invalid device: Apple Watch Series 5 - 44mm
```

Issue: https://youtrack.jetbrains.com/issue/KT-54814