### PR TITLE
Update documentation for reaktive-iosarm64 rename

### DIFF
--- a/docs/SwiftInterop.md
+++ b/docs/SwiftInterop.md
@@ -20,7 +20,7 @@ kotlin {
                     }
 
                     "iosArm64" -> {
-                        export("com.badoo.reaktive:reaktive-ios64:<version>")
+                        export("com.badoo.reaktive:reaktive-iosarm64:<version>")
                     }
 
                     else -> error("Unsupported target: $target")


### PR DESCRIPTION
The maven artifact `reaktive-ios64` appears to have been renamed to `reaktive-iosarm64` starting at version 1.2.1