### PR TITLE
[2.0.0] Removed deprecated throttle operator without Scheduler argument

### DIFF
--- a/reaktive/api/android/reaktive.api
+++ b/reaktive/api/android/reaktive.api
@@ -949,7 +949,6 @@ public final class com/badoo/reaktive/observable/ThreadLocalKt {
 }
 
 public final class com/badoo/reaktive/observable/ThrottleKt {
-	public static final synthetic fun throttle (Lcom/badoo/reaktive/observable/Observable;J)Lcom/badoo/reaktive/observable/Observable;
 	public static final fun throttle (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
 	public static synthetic fun throttle$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;ILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }

--- a/reaktive/api/jvm/reaktive.api
+++ b/reaktive/api/jvm/reaktive.api
@@ -942,7 +942,6 @@ public final class com/badoo/reaktive/observable/ThreadLocalKt {
 }
 
 public final class com/badoo/reaktive/observable/ThrottleKt {
-	public static final synthetic fun throttle (Lcom/badoo/reaktive/observable/Observable;J)Lcom/badoo/reaktive/observable/Observable;
 	public static final fun throttle (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
 	public static synthetic fun throttle$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;ILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Throttle.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Throttle.kt
@@ -6,10 +6,6 @@ import com.badoo.reaktive.scheduler.Scheduler
 import com.badoo.reaktive.scheduler.computationScheduler
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
 
-@Deprecated(level = DeprecationLevel.HIDDEN, message = "Hidden for binary compatibility until v2.0.0")
-fun <T> Observable<T>.throttle(windowMillis: Long): Observable<T> =
-    throttle(windowMillis = windowMillis, scheduler = computationScheduler)
-
 /**
  * Returns an [Observable] that emits only the first element emitted by the source [Observable] during a time window
  * defined by [windowMillis], which begins with the emitted element.


### PR DESCRIPTION
As part of #620