### PR TITLE
Added BehaviorObservableWrapper

### DIFF
--- a/docs/SwiftInterop.md
+++ b/docs/SwiftInterop.md
@@ -9,25 +9,18 @@ The following Gradle configuration can be used as a reference.
 
 ```Kotlin
 kotlin {
-    ios {
-        binaries {
-            framework {
-                // Some setup code here
+    targets
+        .filterIsInstance<KotlinNativeTarget>()
+        .filter { it.konanTarget.family == Family.IOS }
+        .forEach { target ->
+            target.binaries {
+                framework {
+                    // Some setup code here
 
-                when (val target = this.compilation.target.name) {
-                    "iosX64" -> {
-                        export("com.badoo.reaktive:reaktive-iossim:<version>")
-                    }
-
-                    "iosArm64" -> {
-                        export("com.badoo.reaktive:reaktive-iosarm64:<version>")
-                    }
-
-                    else -> error("Unsupported target: $target")
+                    export("com.badoo.reaktive:reaktive:<version>")
                 }
             }
         }
-    }
 
     sourceSets {
         named("commonMain") {
@@ -48,6 +41,7 @@ Reaktive provides wrapper classes.
 You can wrap Reaktive sources using corresponding `wrap()` extension functions:
 
 - `Observable<T>.wrap(): ObservableWrapper<T>`
+- `BehaviorObservable<T>.wrap(): BehaviorObservableWrapper<T>` - can be also used for exposing `BehaviorSubject` 
 - `Single<T>.wrap(): SingleWrapper<T>`
 - `Maybe<T>.wrap(): MaybeWrapper<T>`
 - `Completable.wrap(): CompletableWrapper`
@@ -64,6 +58,13 @@ class SharedDataSource {
             .subscribeOn(ioScheduler)
             .observeOn(mainScheduler)
             .wrap()
+}
+```
+
+```kotlin
+class SharedViewModel {
+    private val _state = BehaviorSubject(State())
+    val state: BehaviorObservableWrapper<State> = _state.wrap()
 }
 ```
 

--- a/reaktive/api/android/reaktive.api
+++ b/reaktive/api/android/reaktive.api
@@ -588,6 +588,15 @@ public final class com/badoo/reaktive/observable/AutoConnectKt {
 	public static synthetic fun autoConnect$default (Lcom/badoo/reaktive/observable/ConnectableObservable;IILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
+public class com/badoo/reaktive/observable/BehaviorObservableWrapper : com/badoo/reaktive/observable/ObservableWrapper, com/badoo/reaktive/subject/behavior/BehaviorObservable {
+	public fun <init> (Lcom/badoo/reaktive/subject/behavior/BehaviorObservable;)V
+	public fun getValue ()Ljava/lang/Object;
+}
+
+public final class com/badoo/reaktive/observable/BehaviorObservableWrapperKt {
+	public static final fun wrap (Lcom/badoo/reaktive/subject/behavior/BehaviorObservable;)Lcom/badoo/reaktive/observable/BehaviorObservableWrapper;
+}
+
 public final class com/badoo/reaktive/observable/BufferCountSkipKt {
 	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;II)Lcom/badoo/reaktive/observable/Observable;
 	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;IIILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;

--- a/reaktive/api/jvm/reaktive.api
+++ b/reaktive/api/jvm/reaktive.api
@@ -581,6 +581,15 @@ public final class com/badoo/reaktive/observable/AutoConnectKt {
 	public static synthetic fun autoConnect$default (Lcom/badoo/reaktive/observable/ConnectableObservable;IILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
+public class com/badoo/reaktive/observable/BehaviorObservableWrapper : com/badoo/reaktive/observable/ObservableWrapper, com/badoo/reaktive/subject/behavior/BehaviorObservable {
+	public fun <init> (Lcom/badoo/reaktive/subject/behavior/BehaviorObservable;)V
+	public fun getValue ()Ljava/lang/Object;
+}
+
+public final class com/badoo/reaktive/observable/BehaviorObservableWrapperKt {
+	public static final fun wrap (Lcom/badoo/reaktive/subject/behavior/BehaviorObservable;)Lcom/badoo/reaktive/observable/BehaviorObservableWrapper;
+}
+
 public final class com/badoo/reaktive/observable/BufferCountSkipKt {
 	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;II)Lcom/badoo/reaktive/observable/Observable;
 	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;IIILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/BehaviorObservableWrapper.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/BehaviorObservableWrapper.kt
@@ -1,0 +1,16 @@
+package com.badoo.reaktive.observable
+
+import com.badoo.reaktive.subject.behavior.BehaviorObservable
+
+/**
+ * Same as [ObservableWrapper] but wraps and implements [BehaviorObservable] and exposes the current value.
+ */
+open class BehaviorObservableWrapper<out T : Any>(
+    private val inner: BehaviorObservable<T>,
+) : ObservableWrapper<T>(inner), BehaviorObservable<T> {
+
+    override val value: T get() = inner.value
+}
+
+fun <T : Any> BehaviorObservable<T>.wrap(): BehaviorObservableWrapper<T> =
+    BehaviorObservableWrapper(this)


### PR DESCRIPTION
This is useful for exposing stateful observables to Swift (e.g. `BahaviorSubject` or `BehaviorObservable`), so reading the current state is also possible.

Also fixes #695.