### PR TITLE
Removed deprecated iosArm32 and linuxArm32Hfp targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,18 +38,7 @@ jobs:
         with:
           arguments: |
             build
-            linkDebugTestLinuxArm32Hfp
             -Ptarget=all_linux_hosted
-      - name: Test linuxArm32Hfp
-        if: matrix.os == 'ubuntu-latest'
-        uses: uraimo/run-on-arch-action@v2
-        with:
-          arch: armv7
-          distro: ubuntu20.04
-          run: |
-            ./utils/build/bin/linuxArm32Hfp/debugTest/test.kexe
-            ./reaktive/build/bin/linuxArm32Hfp/debugTest/test.kexe
-            ./reaktive-testing/build/bin/linuxArm32Hfp/debugTest/test.kexe
       - name: Build macOS
         if: matrix.os == 'macOS-latest'
         uses: gradle/gradle-build-action@v2

--- a/includedBuild/gradleConfiguration/src/main/kotlin/com/badoo/reaktive/configuration/DarwinPlugin.kt
+++ b/includedBuild/gradleConfiguration/src/main/kotlin/com/badoo/reaktive/configuration/DarwinPlugin.kt
@@ -13,7 +13,6 @@ class DarwinPlugin : Plugin<Project> {
 
     private fun configureDarwinCompilation(target: Project) {
         target.extensions.configure(KotlinMultiplatformExtension::class.java) {
-            iosArm32().disableIfUndefined(Target.IOS)
             iosArm64().disableIfUndefined(Target.IOS)
             iosX64().disableIfUndefined(Target.IOS)
             iosSimulatorArm64().disableIfUndefined(Target.IOS)

--- a/includedBuild/gradleConfiguration/src/main/kotlin/com/badoo/reaktive/configuration/MppConfigurationExtension.kt
+++ b/includedBuild/gradleConfiguration/src/main/kotlin/com/badoo/reaktive/configuration/MppConfigurationExtension.kt
@@ -5,13 +5,4 @@ import javax.inject.Inject
 
 open class MppConfigurationExtension @Inject constructor(
     private val project: Project
-) {
-    var isLinuxArm32HfpEnabled: Boolean = false
-        private set
-
-    fun enableLinuxArm32Hfp() {
-        if (isLinuxArm32HfpEnabled) return
-        project.plugins.findPlugin(MppConfigurationPlugin::class.java)?.setupLinuxArm32HfpTarget(project)
-        isLinuxArm32HfpEnabled = true
-    }
-}
+)

--- a/includedBuild/gradleConfiguration/src/main/kotlin/com/badoo/reaktive/configuration/MppConfigurationPlugin.kt
+++ b/includedBuild/gradleConfiguration/src/main/kotlin/com/badoo/reaktive/configuration/MppConfigurationPlugin.kt
@@ -110,9 +110,6 @@ class MppConfigurationPlugin : Plugin<Project> {
                 maybeCreate("macosArm64Main").dependsOn(getByName("darwinCommonMain"))
                 maybeCreate("macosArm64Test").dependsOn(getByName("darwinCommonTest"))
 
-                maybeCreate("iosArm32Main").dependsOn(getByName("darwinCommonMain"))
-                maybeCreate("iosArm32Test").dependsOn(getByName("darwinCommonTest"))
-
                 maybeCreate("iosArm64Main").dependsOn(getByName("darwinCommonMain"))
                 maybeCreate("iosArm64Test").dependsOn(getByName("darwinCommonTest"))
 
@@ -166,18 +163,6 @@ class MppConfigurationPlugin : Plugin<Project> {
         project.kotlin {
             linuxX64 {
                 disableIfUndefined(Target.LINUX)
-            }
-        }
-    }
-
-    fun setupLinuxArm32HfpTarget(project: Project) {
-        project.kotlin {
-            linuxArm32Hfp {
-                disableIfUndefined(Target.LINUX)
-            }
-            sourceSets {
-                maybeCreate("linuxArm32HfpMain").dependsOn(getByName("linuxCommonMain"))
-                maybeCreate("linuxArm32HfpTest").dependsOn(getByName("linuxCommonTest"))
             }
         }
     }

--- a/includedBuild/gradleConfiguration/src/main/kotlin/com/badoo/reaktive/publish/PublishConfigurationPlugin.kt
+++ b/includedBuild/gradleConfiguration/src/main/kotlin/com/badoo/reaktive/publish/PublishConfigurationPlugin.kt
@@ -133,8 +133,6 @@ class PublishConfigurationPlugin : Plugin<Project> {
             "androidDebug" to Target.shouldPublishTarget(project, Target.JVM),
             "androidRelease" to Target.shouldPublishTarget(project, Target.JVM),
             "linuxX64" to Target.shouldPublishTarget(project, Target.LINUX),
-            "linuxArm32Hfp" to Target.shouldPublishTarget(project, Target.LINUX),
-            "iosArm32" to Target.shouldPublishTarget(project, Target.IOS),
             "iosArm64" to Target.shouldPublishTarget(project, Target.IOS),
             "iosX64" to Target.shouldPublishTarget(project, Target.IOS),
             "iosSimulatorArm64" to Target.shouldPublishTarget(project, Target.IOS),

--- a/reaktive-annotations/build.gradle
+++ b/reaktive-annotations/build.gradle
@@ -3,7 +3,3 @@ plugins {
     id 'publish-configuration'
     id 'detekt-configuration'
 }
-
-configuration {
-    enableLinuxArm32Hfp()
-}

--- a/reaktive-testing/build.gradle
+++ b/reaktive-testing/build.gradle
@@ -6,10 +6,6 @@ plugins {
     id 'detekt-configuration'
 }
 
-configuration {
-    enableLinuxArm32Hfp()
-}
-
 kotlin {
     sourceSets {
         commonMain {

--- a/reaktive/build.gradle
+++ b/reaktive/build.gradle
@@ -4,10 +4,6 @@ plugins {
     id 'detekt-configuration'
 }
 
-configuration {
-    enableLinuxArm32Hfp()
-}
-
 kotlin {
     sourceSets {
         commonMain {

--- a/sample-mpp-module/build.gradle
+++ b/sample-mpp-module/build.gradle
@@ -13,7 +13,6 @@ kotlin {
         }
     }
 
-    configureFrameworks(iosArm32())
     configureFrameworks(iosArm64())
     configureFrameworks(iosX64())
     configureFrameworks(iosSimulatorArm64())

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -4,10 +4,6 @@ plugins {
     id 'detekt-configuration'
 }
 
-configuration {
-    enableLinuxArm32Hfp()
-}
-
 kotlin {
     sourceSets {
         commonTest {


### PR DESCRIPTION
Those targets are deprecated since Kotlin 1.8.20 and will be removed in Kotlin 1.9.20 (see the [blog post](https://blog.jetbrains.com/kotlin/2023/02/update-regarding-kotlin-native-targets/)).

As part of #620 