### PR TITLE
[2.0] Optimized DelayQueue

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/queue/PriorityQueue.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/utils/queue/PriorityQueue.kt
@@ -4,11 +4,14 @@ package com.badoo.reaktive.utils.queue
 
 internal class PriorityQueue<T>(
     private val comparator: Comparator<in T>
-) {
+) : Iterable<T> {
 
     private var array: Array<T?>? = null
     private var _size: Int = 0
     val isEmpty: Boolean get() = _size == 0
+
+    fun peek(): T? =
+        array?.takeUnless { isEmpty }?.get(0)
 
     fun offer(item: T) {
         var arr: Array<T?>? = array
@@ -45,6 +48,28 @@ internal class PriorityQueue<T>(
         array = null
         _size = 0
     }
+
+    /**
+     * The doc is derived from Java PriorityQueue.
+     *
+     * Returns an iterator over the elements in this queue. The
+     * iterator does not return the elements in any particular order.
+     *
+     * @return an iterator over the elements in this queue
+     */
+    override fun iterator(): Iterator<T> =
+        object : Iterator<T> {
+            private var index = 0
+
+            override fun hasNext(): Boolean = index < _size
+
+            @Suppress("UNCHECKED_CAST")
+            override fun next(): T {
+                val arr = array?.takeIf { index < _size } ?: throw NoSuchElementException()
+
+                return arr[index++] as T
+            }
+        }
 
     private companion object {
         private const val INITIAL_CAPACITY = 8

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/queue/PriorityQueueTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/utils/queue/PriorityQueueTest.kt
@@ -23,6 +23,13 @@ class PriorityQueueTest {
     }
 
     @Test
+    fun peek_returns_null_WHEN_new_instance() {
+        val item = queue.peek()
+
+        assertNull(item)
+    }
+
+    @Test
     fun not_empty_WHEN_offer_1_non_null_item() {
         queue.offer(1)
 
@@ -41,6 +48,15 @@ class PriorityQueueTest {
         queue.offer(1)
 
         val item = queue.poll()
+
+        assertEquals(1, item)
+    }
+
+    @Test
+    fun peek_returns_same_item_WHEN_offer_1_item() {
+        queue.offer(1)
+
+        val item = queue.peek()
 
         assertEquals(1, item)
     }
@@ -95,6 +111,21 @@ class PriorityQueueTest {
     }
 
     @Test
+    fun peek_returns_prioritized_items() {
+        val items = getItemsForTest()
+
+        items.forEach(queue::offer)
+
+        val resultItems =
+            List(items.size) {
+                queue.peek()
+                queue.poll()
+            }
+
+        assertEquals(items.sorted(), resultItems)
+    }
+
+    @Test
     fun poll_returns_prioritized_items_WHEN_offer_items_and_poll_half_of_the_items_and_offer_items() {
         val fullItems = getItemsForTest()
         val fullSize = fullItems.size
@@ -133,6 +164,36 @@ class PriorityQueueTest {
         queue.clear()
 
         assertTrue(queue.isEmpty)
+    }
+
+    @Test
+    fun new_instance_has_empty_iterator() {
+        val iterator = queue.iterator()
+
+        assertFalse(iterator.hasNext())
+    }
+
+    @Test
+    fun iterator_returns_items_in_any_order() {
+        val items = getItemsForTest()
+        items.forEach(queue::offer)
+
+        val resultItems = queue.iterator().asSequence().toSet()
+
+        assertEquals(items.toSet(), resultItems)
+    }
+
+    @Test
+    fun iterator_is_empty_WHEN_offer_100_items_and_poll_100_items() {
+        offer100Items()
+
+        repeat(100) {
+            queue.poll()
+        }
+
+        val iterator = queue.iterator()
+
+        assertFalse(iterator.hasNext())
     }
 
     private fun getItemsForTest(): List<Int> = listOf(5, 10, 3, 6, 4, 3, 6, 10, 2, 3, 1, 5, 50, 0)

--- a/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/utils/DelayQueueTest.kt
+++ b/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/utils/DelayQueueTest.kt
@@ -87,4 +87,18 @@ class DelayQueueTest {
 
         assertNull(value)
     }
+
+    @Test
+    fun removeIf_removes_items() {
+        queue.offer(value = 0, timeoutMillis = 0L)
+        queue.offer(value = 1, timeoutMillis = 0L)
+        queue.offer(value = 2, timeoutMillis = 0L)
+        queue.offer(value = 3, timeoutMillis = 0L)
+
+        queue.removeIf { (it == 1) || (it == 3) }
+
+        val values = listOf(queue.take(), queue.take())
+
+        assertEquals(listOf(0, 2), values)
+    }
 }


### PR DESCRIPTION
Now we can replace the atomic-based queue with `PriorityQueue` in native `DelayQueue`. Also added `peek` and `iterator` back to `PriorityQueue`, they were removed in #718.