### PR TITLE
[2.0] Fix sample operator emits same values and does not emit nulls

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Sample.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Sample.kt
@@ -5,6 +5,7 @@ import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
 import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.getAndUpdate
 
 /**
  * Returns an [Observable] that emits the most recently emitted element (if any)
@@ -27,10 +28,9 @@ fun <T> Observable<T>.sample(windowMillis: Long, scheduler: Scheduler): Observab
                     disposables += disposable
 
                     executor.submitRepeating(startDelayMillis = windowMillis, periodMillis = windowMillis) {
-                        lastValue
-                            .value
-                            ?.value
-                            ?.also(emitter::onNext)
+                        lastValue.getAndUpdate { null }?.also {
+                            emitter.onNext(it.value)
+                        }
                     }
                 }
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SampleTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SampleTest.kt
@@ -33,12 +33,12 @@ class SampleTest :
 
         upstream.onNext(4)
         timer.advanceBy(100L)
-        upstream.onNext(null)
-        timer.advanceBy(100L)
         upstream.onNext(5)
         timer.advanceBy(100L)
+        upstream.onNext(null)
+        timer.advanceBy(100L)
 
-        observer.assertValues(1, 3, 5)
+        observer.assertValues(1, 3, null)
     }
 
     @Test
@@ -60,6 +60,19 @@ class SampleTest :
         upstream.onNext(0)
         upstream.onComplete()
         scheduler.timer.advanceBy(1000L)
+
+        observer.assertNoValues()
+    }
+
+    @Test
+    fun does_not_emit_same_value_WHEN_timeout_reached_second_time() {
+        val scheduler = TestScheduler()
+        val observer = upstream.sample(windowMillis = 100L, scheduler = scheduler).test()
+        upstream.onNext(0)
+        scheduler.timer.advanceBy(100L)
+        observer.reset()
+
+        scheduler.timer.advanceBy(100L)
 
         observer.assertNoValues()
     }


### PR DESCRIPTION
Discovered and fixed two bugs in `Observable#sample`:

- Emits the last value again and again on every period hit.
- Does not emit `null` values.

See the related [RxJava doc](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#sample-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).