### PR TITLE
[2.0] Replaced atomics with simple variables

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/operator/Retry.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/base/operator/Retry.kt
@@ -3,18 +3,17 @@ package com.badoo.reaktive.base.operator
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.exceptions.CompositeException
 import com.badoo.reaktive.base.tryCatch
-import com.badoo.reaktive.utils.atomic.AtomicLong
 
 internal class Retry(
     private val emitter: ErrorCallback,
     private val predicate: (attempt: Long, Throwable) -> Boolean
 ) {
-    private val attempt = AtomicLong(0)
+    private var attempt = 0L
 
     fun onError(error: Throwable, resubscribe: () -> Unit) {
         emitter.tryCatch(
-            { predicate(attempt.addAndGet(1), error) },
-            { CompositeException(error, it) }
+            block = { predicate(++attempt, error) },
+            errorTransformer = { CompositeException(error, it) }
         ) { shouldRetry ->
             if (shouldRetry) {
                 resubscribe()

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/CombineLatest.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/CombineLatest.kt
@@ -6,7 +6,6 @@ import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.utils.Uninitialized
-import com.badoo.reaktive.utils.atomic.AtomicInt
 import com.badoo.reaktive.utils.serializer.serializer
 
 /**
@@ -27,7 +26,7 @@ fun <T, R> Iterable<Observable<T>>.combineLatest(mapper: (List<T>) -> R): Observ
         val disposables = CompositeDisposable()
         emitter.setDisposable(disposables)
         val values = MutableList<Any?>(sources.size) { Uninitialized }
-        val activeSourceCount = AtomicInt(sources.size)
+        var activeSourceCount = sources.size
 
         val serializer =
             serializer<CombineLatestEvent<T>> { event ->
@@ -52,10 +51,10 @@ fun <T, R> Iterable<Observable<T>>.combineLatest(mapper: (List<T>) -> R): Observ
                     }
 
                     is CombineLatestEvent.OnComplete -> {
-                        val remainingActiveSources = activeSourceCount.addAndGet(-1)
+                        activeSourceCount--
 
                         // Complete if all sources are completed or a source is completed without a value
-                        val allCompleted = (remainingActiveSources == 0) || (values[event.index] === Uninitialized)
+                        val allCompleted = (activeSourceCount == 0) || (values[event.index] === Uninitialized)
                         if (allCompleted) {
                             emitter.onComplete()
                         }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ConcatMap.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ConcatMap.kt
@@ -7,7 +7,6 @@ import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.SerialDisposable
 import com.badoo.reaktive.disposable.addTo
-import com.badoo.reaktive.utils.atomic.AtomicReference
 import com.badoo.reaktive.utils.serializer.Serializer
 import com.badoo.reaktive.utils.serializer.serializer
 
@@ -32,7 +31,7 @@ private class ConcatMapObserver<in T, in R>(
     private val actor = serializer(::processEvent)
     private val innerObserver = InnerObserver(callbacks, actor).addTo(this)
     private val queue = ArrayDeque<T>()
-    private val state = AtomicReference(State.IDLE)
+    private var state = State.IDLE
 
     override fun onSubscribe(disposable: Disposable) {
         add(disposable)
@@ -55,8 +54,8 @@ private class ConcatMapObserver<in T, in R>(
         }
 
     private fun onUpstreamCompleted(): Boolean {
-        val oldState = state.value
-        state.value = State.UPSTREAM_COMPLETED
+        val oldState = state
+        state = State.UPSTREAM_COMPLETED
 
         if (oldState == State.IDLE) {
             callbacks.onComplete()
@@ -68,12 +67,12 @@ private class ConcatMapObserver<in T, in R>(
 
     private fun onInnerCompleted(): Boolean {
         if (queue.isEmpty()) {
-            if (state.value == State.UPSTREAM_COMPLETED) {
+            if (state == State.UPSTREAM_COMPLETED) {
                 callbacks.onComplete()
                 return false
             }
 
-            state.value = State.IDLE
+            state = State.IDLE
         } else {
             @Suppress("UNCHECKED_CAST")
             subscribe(queue.removeFirst())
@@ -83,10 +82,10 @@ private class ConcatMapObserver<in T, in R>(
     }
 
     private fun onUpstreamValue(value: T): Boolean {
-        if (state.value == State.INNER_ACTIVE) {
+        if (state == State.INNER_ACTIVE) {
             queue.addLast(value)
         } else {
-            state.value = State.INNER_ACTIVE
+            state = State.INNER_ACTIVE
             subscribe(value)
         }
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Interval.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Interval.kt
@@ -1,7 +1,6 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.scheduler.Scheduler
-import com.badoo.reaktive.utils.atomic.AtomicLong
 
 /**
  * Returns an [Observable] that emits `0L` after [startDelayMillis] and
@@ -16,8 +15,8 @@ fun observableInterval(periodMillis: Long, startDelayMillis: Long = periodMillis
         val executor = scheduler.newExecutor()
         emitter.setDisposable(executor)
 
-        val count = AtomicLong(-1L)
+        var count = 0L
         executor.submitRepeating(startDelayMillis, periodMillis) {
-            emitter.onNext(count.addAndGet(1L))
+            emitter.onNext(count++)
         }
     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Repeat.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Repeat.kt
@@ -3,7 +3,6 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.ValueCallback
 import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.utils.atomic.AtomicLong
 import com.badoo.reaktive.utils.serializer.serializer
 
 /**
@@ -21,7 +20,7 @@ fun <T> Observable<T>.repeat(times: Long = Long.MAX_VALUE): Observable<T> {
     return observable { emitter ->
         val observer =
             object : ObservableObserver<T>, ValueCallback<T> by emitter, ErrorCallback by emitter {
-                private val counter: AtomicLong? = if (times < Long.MAX_VALUE) AtomicLong(times) else null
+                private var counter = times
 
                 // Prevents recursive subscriptions
                 private val serializer =
@@ -35,7 +34,7 @@ fun <T> Observable<T>.repeat(times: Long = Long.MAX_VALUE): Observable<T> {
                 }
 
                 override fun onComplete() {
-                    if ((counter == null) || (counter.addAndGet(-1) > 0)) {
+                    if ((counter == Long.MAX_VALUE) || (--counter > 0)) {
                         if (!emitter.isDisposed) {
                             subscribeToUpstream()
                         }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/RepeatUntil.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/RepeatUntil.kt
@@ -4,7 +4,6 @@ import com.badoo.reaktive.base.ErrorCallback
 import com.badoo.reaktive.base.ValueCallback
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.utils.atomic.AtomicInt
 
 /**
  * Returns an [Observable] that calls the [predicate] when this [Observable] completes
@@ -16,7 +15,7 @@ fun <T> Observable<T>.repeatUntil(predicate: () -> Boolean): Observable<T> =
     observable { emitter ->
         val observer =
             object : ObservableObserver<T>, ValueCallback<T> by emitter, ErrorCallback by emitter {
-                private val recursiveGuard = AtomicInt()
+                private var recursiveGuard = 0
 
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)
@@ -39,10 +38,10 @@ fun <T> Observable<T>.repeatUntil(predicate: () -> Boolean): Observable<T> =
 
                 fun subscribeToUpstream() {
                     // Prevents recursive subscriptions
-                    if (recursiveGuard.addAndGet(1) == 1) {
+                    if (++recursiveGuard == 1) {
                         do {
                             subscribe(this)
-                        } while (recursiveGuard.addAndGet(-1) > 0)
+                        } while (--recursiveGuard > 0)
                     }
                 }
             }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Skip.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Skip.kt
@@ -1,7 +1,6 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.disposable.Disposable
-import com.badoo.reaktive.utils.atomic.AtomicLong
 
 /**
  * Returns an [Observable] that skips the first [count] elements emitted by the source [Observable] and emits the remainder.
@@ -12,15 +11,15 @@ fun <T> Observable<T>.skip(count: Long): Observable<T> =
     observable { emitter ->
         subscribe(
             object : ObservableObserver<T>, ObservableCallbacks<T> by emitter {
-                private var remaining = AtomicLong(count)
+                private var remaining = count
 
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)
                 }
 
                 override fun onNext(value: T) {
-                    if (remaining.value != 0L) {
-                        remaining.addAndGet(-1)
+                    if (remaining != 0L) {
+                        remaining--
                     } else {
                         emitter.onNext(value)
                     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SwitchIfEmpty.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/SwitchIfEmpty.kt
@@ -5,7 +5,6 @@ import com.badoo.reaktive.base.subscribeSafe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.SerialDisposable
-import com.badoo.reaktive.utils.atomic.AtomicBoolean
 
 /**
  * Returns an [Observable] that emits the elements emitted by the source [Observable],
@@ -29,19 +28,19 @@ fun <T> Observable<T>.switchIfEmpty(otherObservable: () -> Observable<T>): Obser
 
         subscribe(
             object : ObservableObserver<T>, ErrorCallback by emitter {
-                private val isEmpty = AtomicBoolean(true)
+                private var isEmpty = true
 
                 override fun onSubscribe(disposable: Disposable) {
                     serialDisposable.set(disposable)
                 }
 
                 override fun onNext(value: T) {
-                    isEmpty.value = false
+                    isEmpty = false
                     emitter.onNext(value)
                 }
 
                 override fun onComplete() {
-                    if (isEmpty.value) {
+                    if (isEmpty) {
                         emitter.tryCatch(otherObservable) {
                             it.subscribeSafe(
                                 object : ObservableObserver<T>, ObservableCallbacks<T> by emitter {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/TakeObservable.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/TakeObservable.kt
@@ -3,7 +3,6 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.SerialDisposable
-import com.badoo.reaktive.utils.atomic.AtomicInt
 
 /**
  * Emit only the first [limit] elements emitted by source [Observable].
@@ -17,26 +16,29 @@ fun <T> Observable<T>.take(limit: Int): Observable<T> {
         val serialDisposable = SerialDisposable()
         emitter.setDisposable(serialDisposable)
 
-        val remaining = AtomicInt(limit)
+        subscribe(
+            object : ObservableObserver<T>, CompletableCallbacks by emitter {
+                private var remaining = limit
 
-        subscribe(object : ObservableObserver<T>, CompletableCallbacks by emitter {
-            override fun onSubscribe(disposable: Disposable) {
-                serialDisposable.set(disposable)
+                override fun onSubscribe(disposable: Disposable) {
+                    serialDisposable.set(disposable)
 
-                if (remaining.value == 0) {
-                    onComplete()
-                }
-            }
-
-            override fun onNext(value: T) {
-                if (remaining.value > 0) {
-                    val stop = remaining.addAndGet(-1) == 0
-                    emitter.onNext(value)
-                    if (stop) {
+                    if (remaining == 0) {
                         onComplete()
                     }
                 }
+
+                override fun onNext(value: T) {
+                    if (remaining > 0) {
+                        remaining--
+                        val stop = remaining == 0
+                        emitter.onNext(value)
+                        if (stop) {
+                            onComplete()
+                        }
+                    }
+                }
             }
-        })
+        )
     }
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/RepeatUntil.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/RepeatUntil.kt
@@ -5,7 +5,6 @@ import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.observable.observable
-import com.badoo.reaktive.utils.atomic.AtomicInt
 
 /**
  * When the [Single] signals `onSuccess`, re-subscribes to the [Single] if the [predicate] function returns `false`.
@@ -16,7 +15,7 @@ fun <T> Single<T>.repeatUntil(predicate: (T) -> Boolean): Observable<T> =
     observable { emitter ->
         val observer =
             object : SingleObserver<T>, ErrorCallback by emitter {
-                private val recursiveGuard = AtomicInt()
+                private var recursiveGuard = 0
 
                 override fun onSubscribe(disposable: Disposable) {
                     emitter.setDisposable(disposable)
@@ -39,10 +38,10 @@ fun <T> Single<T>.repeatUntil(predicate: (T) -> Boolean): Observable<T> =
 
                 fun subscribeToUpstream() {
                     // Prevents recursive subscriptions
-                    if (recursiveGuard.addAndGet(1) == 1) {
+                    if (++recursiveGuard == 1) {
                         do {
                             subscribe(this)
-                        } while (recursiveGuard.addAndGet(-1) > 0)
+                        } while (--recursiveGuard > 0)
                     }
                 }
             }


### PR DESCRIPTION
There are cases where atomics are used only due to legacy freezings, the access is already synchronized anyway. Now we can use normal variables there. The access is already synchronized by either `serializer`, or the upstream calling the observer synchronously.