### PR TITLE
Undesirable disconnect fix with replay, refCount, and firstOrError

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/RefCount.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/RefCount.kt
@@ -32,7 +32,7 @@ fun <T> ConnectableObservable<T>.refCount(subscriberCount: Int = 1): Observable<
                 }
             }
 
-        val shouldSubscribe = subscribeCount.addAndGet(1) == subscriberCount
+        val shouldConnect = subscribeCount.addAndGet(1) == subscriberCount
 
         this@refCount.subscribe(
             object : ObservableObserver<T>, ObservableCallbacks<T> by emitter {
@@ -42,7 +42,7 @@ fun <T> ConnectableObservable<T>.refCount(subscriberCount: Int = 1): Observable<
             }
         )
 
-        if (shouldSubscribe) {
+        if (shouldConnect) {
             this@refCount.connect {
                 disposable.value = it
             }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/RefCount.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/RefCount.kt
@@ -32,6 +32,8 @@ fun <T> ConnectableObservable<T>.refCount(subscriberCount: Int = 1): Observable<
                 }
             }
 
+        val shouldSubscribe = subscribeCount.addAndGet(1) == subscriberCount
+
         this@refCount.subscribe(
             object : ObservableObserver<T>, ObservableCallbacks<T> by emitter {
                 override fun onSubscribe(disposable: Disposable) {
@@ -40,7 +42,7 @@ fun <T> ConnectableObservable<T>.refCount(subscriberCount: Int = 1): Observable<
             }
         )
 
-        if (subscribeCount.addAndGet(1) == subscriberCount) {
+        if (shouldSubscribe) {
             this@refCount.connect {
                 disposable.value = it
             }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RefCountTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RefCountTest.kt
@@ -1,11 +1,13 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.subject.publish.PublishSubject
 import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.observable.TestObservableObserver
 import com.badoo.reaktive.test.observable.assertComplete
 import com.badoo.reaktive.test.observable.assertValues
 import com.badoo.reaktive.test.observable.test
+import com.badoo.reaktive.test.single.test
 import com.badoo.reaktive.utils.SharedList
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import com.badoo.reaktive.utils.atomic.AtomicInt
@@ -111,6 +113,18 @@ class RefCountTest {
         assertFalse(disposable.isDisposed)
     }
 
+    // @Test
+    // fun does_not_disconnect_from_upstream_WHEN_subscriberCount_is_1_and_first_or_error_with_replay() {
+    //     val disposable = Disposable()
+    //     val upstream = PublishSubject<Int>()
+    //     val refCount = upstream.replay(1).refCount(subscriberCount = 1)
+    //     refCount.test()
+    //     upstream.onNext(1)
+    //     refCount.firstOrError().test()
+    //
+    //     assertFalse(disposable.isDisposed)
+    // }
+
     @Test
     fun subscription_to_upstream_happens_before_connection_to_upstream() {
         val events = SharedList<String>()
@@ -214,4 +228,5 @@ class RefCountTest {
                 subscribe.invoke(observer)
             }
         }
+
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RefCountTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RefCountTest.kt
@@ -245,5 +245,4 @@ class RefCountTest {
                 subscribe.invoke(observer)
             }
         }
-
 }


### PR DESCRIPTION
Modified the refCount function to account for the subscribeCount before the actual subscribe. This resolved an issue when you are using both replay, and firstOrError.

I have attempted to create a Unit test to replicate the issue but I was unsuccessful, I am not familiar enough with the testing environment to recreate it in Unit Tests. I  have left the test in comments however.

To replicate the issue: 
 - create an observable
 - apply replay(1).refcount() and store separately
 - subscribe once to the second observable which causes a connection
 - send a value through the upstream
 - THEN subscribe again to the second observable using firstOrError()

This results in the connectable being disconnected. The reason being is with replay and a value stored in the buffer, the single subscribes, receives the onNext and immediately completes before the refCounts subscribeCount increase. So when the single completes and disposes, the subscribeCount is decremented to 0 and it disposes the connectable even though there is still a subscriber active.