### PR TITLE
[2.0] Specified jvmTarget for all projects

### DIFF
--- a/benchmarks/jmh/build.gradle
+++ b/benchmarks/jmh/build.gradle
@@ -10,6 +10,10 @@ dependencies {
     implementation libs.kotlinx.coroutines.core
 }
 
+kotlin {
+    jvmToolchain(11)
+}
+
 jmh {
     benchmarkMode = ['avgt']
     timeUnit = 'ms'

--- a/includedBuild/gradleConfiguration/src/main/kotlin/com/badoo/reaktive/configuration/MppConfigurationPlugin.kt
+++ b/includedBuild/gradleConfiguration/src/main/kotlin/com/badoo/reaktive/configuration/MppConfigurationPlugin.kt
@@ -7,6 +7,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.invoke
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 class MppConfigurationPlugin : Plugin<Project> {
@@ -153,6 +154,11 @@ class MppConfigurationPlugin : Plugin<Project> {
         project.kotlin {
             jvm {
                 disableIfUndefined(Target.JVM)
+                compilations.getByName("main").apply {
+                    compilerOptions.configure {
+                        jvmTarget.set(JvmTarget.JVM_1_8)
+                    }
+                }
             }
             sourceSets {
                 maybeCreate("jvmMain").dependencies { implementation(project.getLibrary("kotlin-stdlib")) }

--- a/rxjava2-interop/build.gradle
+++ b/rxjava2-interop/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'publish-configuration'
@@ -6,6 +8,12 @@ plugins {
 
 group = reaktive_group_id
 version = reaktive_version
+
+compileKotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_1_8
+    }
+}
 
 publishing {
     publications {

--- a/rxjava3-interop/build.gradle
+++ b/rxjava3-interop/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'publish-configuration'
@@ -6,6 +8,12 @@ plugins {
 
 group = reaktive_group_id
 version = reaktive_version
+
+compileKotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_1_8
+    }
+}
 
 publishing {
     publications {


### PR DESCRIPTION
Also specified `jvmToolchain` for benchmarks, it seems to produce more stable results across different build environments.