### PR TITLE
[2.0] Fixed subjects not emitting initial values synchronously on subscription under load

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/LinkedQueue.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/LinkedQueue.kt
@@ -1,0 +1,41 @@
+package com.badoo.reaktive.subject
+
+import com.badoo.reaktive.utils.atomic.AtomicReference
+
+internal class LinkedQueue<T>(
+    private val limit: Int,
+) {
+    private val _head = AtomicReference<MutableNode<T>?>(null)
+    val head: Node<T>? get() = _head.value // Can be read concurrently
+
+    private var tail: MutableNode<T>? = null
+    private var size: Int = 0
+
+    fun addLast(value: T) {
+        val node = MutableNode(value)
+
+        if (size == 0) {
+            _head.value = node
+            tail = node
+            size++
+        } else {
+            requireNotNull(tail).next = node
+            tail = node
+
+            if (size < limit) {
+                size++
+            } else {
+                _head.value = requireNotNull(_head.value).next
+            }
+        }
+    }
+
+    interface Node<out T> {
+        val value: T
+        val next: Node<T>?
+    }
+
+    private class MutableNode<T>(override val value: T) : Node<T> {
+        override var next: MutableNode<T>? = null
+    }
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/LinkedQueueExt.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/LinkedQueueExt.kt
@@ -1,0 +1,12 @@
+package com.badoo.reaktive.subject
+
+internal fun <T> LinkedQueue.Node<T>.forEachAndGetLast(block: (T) -> Unit): LinkedQueue.Node<T> {
+    var node = this
+
+    while (true) {
+        block(node.value)
+        node = node.next ?: break
+    }
+
+    return node
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/behavior/BehaviorSubjectBuilder.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/behavior/BehaviorSubjectBuilder.kt
@@ -1,9 +1,5 @@
 package com.badoo.reaktive.subject.behavior
 
-import com.badoo.reaktive.observable.ObservableObserver
-import com.badoo.reaktive.subject.DefaultSubject
-import com.badoo.reaktive.utils.atomic.AtomicReference
-
 /**
  * Creates a new instance of [BehaviorSubject].
  *
@@ -11,20 +7,4 @@ import com.badoo.reaktive.utils.atomic.AtomicReference
  */
 @Suppress("FunctionName")
 fun <T> BehaviorSubject(initialValue: T): BehaviorSubject<T> =
-    object : DefaultSubject<T>(), BehaviorSubject<T> {
-        @Suppress("ObjectPropertyName")
-        private val _value = AtomicReference(initialValue)
-        override val value: T get() = _value.value
-
-        override fun onAfterSubscribe(observer: ObservableObserver<T>) {
-            super.onAfterSubscribe(observer)
-
-            observer.onNext(value)
-        }
-
-        override fun onBeforeNext(value: T) {
-            super.onBeforeNext(value)
-
-            _value.value = value
-        }
-    }
+    BehaviorSubjectImpl(initialValue)

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/behavior/BehaviorSubjectImpl.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/behavior/BehaviorSubjectImpl.kt
@@ -1,0 +1,35 @@
+package com.badoo.reaktive.subject.behavior
+
+import com.badoo.reaktive.observable.ObservableObserver
+import com.badoo.reaktive.subject.AbstractSubject
+import com.badoo.reaktive.subject.LinkedQueue
+import com.badoo.reaktive.subject.LinkedQueue.Node
+import com.badoo.reaktive.subject.forEachAndGetLast
+import com.badoo.reaktive.subject.isActive
+
+internal class BehaviorSubjectImpl<T>(initialValue: T) : AbstractSubject<T, Node<T>?>(), BehaviorSubject<T> {
+
+    private val buffer = LinkedQueue<T>(limit = 1).apply { addLast(initialValue) }
+    private val node get() = requireNotNull(buffer.head)
+    override val value: T get() = node.value
+
+    override fun subscribe(observer: ObservableObserver<T>) {
+        val disposable = observer.onSubscribe() ?: return
+        val lastNode = node.takeIf { isActive }?.forEachAndGetLast { observer.onNext(it) }
+        onSubscribe(observer, disposable, lastNode)
+    }
+
+    override fun onAfterSubscribe(observer: ObservableObserver<T>, token: Node<T>?) {
+        super.onAfterSubscribe(observer, token)
+
+        token?.next?.forEachAndGetLast {
+            observer.onNext(it)
+        }
+    }
+
+    override fun onBeforeNext(value: T) {
+        super.onBeforeNext(value)
+
+        buffer.addLast(value)
+    }
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/publish/PublishSubjectBuilder.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/publish/PublishSubjectBuilder.kt
@@ -1,11 +1,16 @@
 package com.badoo.reaktive.subject.publish
 
-import com.badoo.reaktive.subject.DefaultSubject
+import com.badoo.reaktive.observable.ObservableObserver
+import com.badoo.reaktive.subject.AbstractSubject
 
 /**
  * Creates a new instance of [PublishSubject].
  */
 @Suppress("FunctionName")
 fun <T> PublishSubject(): PublishSubject<T> =
-    object : DefaultSubject<T>(), PublishSubject<T> {
+    object : AbstractSubject<T, Nothing?>(), PublishSubject<T> {
+        override fun subscribe(observer: ObservableObserver<T>) {
+            val disposable = observer.onSubscribe() ?: return
+            onSubscribe(observer, disposable, null)
+        }
     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/replay/ReplaySubjectBuilder.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/replay/ReplaySubjectBuilder.kt
@@ -1,8 +1,5 @@
 package com.badoo.reaktive.subject.replay
 
-import com.badoo.reaktive.observable.ObservableObserver
-import com.badoo.reaktive.subject.DefaultSubject
-
 /**
  * Creates a new instance of [ReplaySubject].
  *
@@ -13,22 +10,5 @@ import com.badoo.reaktive.subject.DefaultSubject
 fun <T> ReplaySubject(bufferSize: Int = Int.MAX_VALUE): ReplaySubject<T> {
     require(bufferSize > 0) { "Buffer size must be a positive value" }
 
-    return object : DefaultSubject<T>(), ReplaySubject<T> {
-        private val buffer = ArrayDeque<T>()
-
-        override fun onSubscribed(observer: ObservableObserver<T>): Boolean {
-            buffer.forEach(observer::onNext)
-
-            return true
-        }
-
-        override fun onBeforeNext(value: T) {
-            super.onBeforeNext(value)
-
-            if (buffer.size >= bufferSize) {
-                buffer.removeFirst()
-            }
-            buffer.addLast(value)
-        }
-    }
+    return ReplaySubjectImpl(bufferLimit = bufferSize)
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/replay/ReplaySubjectImpl.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/replay/ReplaySubjectImpl.kt
@@ -1,0 +1,34 @@
+package com.badoo.reaktive.subject.replay
+
+import com.badoo.reaktive.observable.ObservableObserver
+import com.badoo.reaktive.subject.AbstractSubject
+import com.badoo.reaktive.subject.LinkedQueue
+import com.badoo.reaktive.subject.LinkedQueue.Node
+import com.badoo.reaktive.subject.forEachAndGetLast
+
+internal class ReplaySubjectImpl<T>(
+    bufferLimit: Int,
+) : AbstractSubject<T, Node<T>?>(), ReplaySubject<T> {
+
+    private val buffer: LinkedQueue<T> = LinkedQueue(limit = bufferLimit)
+
+    override fun subscribe(observer: ObservableObserver<T>) {
+        val disposable = observer.onSubscribe() ?: return
+        val lastNode = buffer.head?.forEachAndGetLast { observer.onNext(it) }
+        onSubscribe(observer, disposable, lastNode)
+    }
+
+    override fun onAfterSubscribe(observer: ObservableObserver<T>, token: Node<T>?) {
+        super.onAfterSubscribe(observer, token)
+
+        token?.next?.forEachAndGetLast {
+            observer.onNext(it)
+        }
+    }
+
+    override fun onBeforeNext(value: T) {
+        super.onBeforeNext(value)
+
+        buffer.addLast(value)
+    }
+}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/unicast/UnicastSubjectImpl.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/subject/unicast/UnicastSubjectImpl.kt
@@ -1,0 +1,60 @@
+package com.badoo.reaktive.subject.unicast
+
+import com.badoo.reaktive.observable.ObservableObserver
+import com.badoo.reaktive.subject.AbstractSubject
+import com.badoo.reaktive.subject.LinkedQueue
+import com.badoo.reaktive.subject.LinkedQueue.Node
+import com.badoo.reaktive.subject.Subject
+import com.badoo.reaktive.subject.forEachAndGetLast
+import com.badoo.reaktive.subject.isActive
+import com.badoo.reaktive.utils.atomic.AtomicReference
+
+internal class UnicastSubjectImpl<T>(
+    bufferLimit: Int,
+    private val onTerminate: () -> Unit,
+) : AbstractSubject<T, Node<T>?>(), UnicastSubject<T> {
+
+    private val buffer = AtomicReference<LinkedQueue<T>?>(LinkedQueue(limit = bufferLimit))
+
+    override fun subscribe(observer: ObservableObserver<T>) {
+        val disposable = observer.onSubscribe() ?: return
+        val buffer = buffer.getAndSet(null)
+
+        if (buffer != null) {
+            val lastNode = buffer.head?.forEachAndGetLast { observer.onNext(it) }
+            onSubscribe(observer, disposable, lastNode)
+        } else {
+            observer.onError(IllegalStateException("Only one single observer allowed for UnicastSubject"))
+        }
+    }
+
+    override fun onAfterSubscribe(observer: ObservableObserver<T>, token: Node<T>?) {
+        super.onAfterSubscribe(observer, token)
+
+        token?.next?.forEachAndGetLast {
+            observer.onNext(it)
+        }
+    }
+
+    override fun onBeforeNext(value: T) {
+        super.onBeforeNext(value)
+
+        buffer.value?.addLast(value)
+    }
+
+    override fun onAfterUnsubscribe(observer: ObservableObserver<T>) {
+        super.onAfterUnsubscribe(observer)
+
+        if (isActive) {
+            status = Subject.Status.Completed
+        }
+    }
+
+    override fun onStatusChanged(status: Subject.Status) {
+        super.onStatusChanged(status)
+
+        if (!isActive) {
+            onTerminate()
+        }
+    }
+}

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/subject/BehaviorSubjectTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/subject/BehaviorSubjectTest.kt
@@ -1,9 +1,11 @@
 package com.badoo.reaktive.subject
 
+import com.badoo.reaktive.observable.subscribe
 import com.badoo.reaktive.subject.behavior.BehaviorSubject
 import com.badoo.reaktive.test.observable.assertValue
 import com.badoo.reaktive.test.observable.test
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 
 class BehaviorSubjectTest : SubjectGenericTests by SubjectGenericTests(BehaviorSubject(0)) {
@@ -46,5 +48,42 @@ class BehaviorSubjectTest : SubjectGenericTests by SubjectGenericTests(BehaviorS
         val value = subject.value
 
         assertEquals(2, value)
+    }
+
+    @Test
+    fun emits_initial_value_synchronously_WHEN_subscribed_recursively() {
+        val subject = BehaviorSubject(0)
+        var emittedValues: List<Int>? = null
+
+        subject.subscribe {
+            if (it == 1) {
+                emittedValues = subject.test().values
+            }
+        }
+
+        subject.onNext(1)
+
+        assertContentEquals(listOf(1), emittedValues)
+    }
+
+    @Test
+    fun emits_all_queued_values_WHEN_subscribed_recursively() {
+        val subject = BehaviorSubject<Int?>(0)
+        var emittedValues: List<Int?>? = null
+
+        var isSubscribedRecursively = false
+        subject.subscribe {
+            if ((it == 1) && !isSubscribedRecursively) {
+                isSubscribedRecursively = true
+                subject.onNext(2)
+                subject.onNext(null)
+                subject.onNext(1)
+                emittedValues = subject.test().values
+            }
+        }
+
+        subject.onNext(1)
+
+        assertContentEquals(listOf(1, 2, null, 1), emittedValues)
     }
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/subject/UnicastSubjectTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/subject/UnicastSubjectTest.kt
@@ -1,13 +1,16 @@
 package com.badoo.reaktive.subject
 
+import com.badoo.reaktive.observable.subscribe
 import com.badoo.reaktive.subject.unicast.UnicastSubject
 import com.badoo.reaktive.test.base.assertError
+import com.badoo.reaktive.test.observable.TestObservableObserver
 import com.badoo.reaktive.test.observable.assertNoValues
 import com.badoo.reaktive.test.observable.assertValues
 import com.badoo.reaktive.test.observable.test
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class UnicastSubjectTest : SubjectGenericTests by SubjectGenericTests(UnicastSubject(), 1) {
 
@@ -44,6 +47,19 @@ class UnicastSubjectTest : SubjectGenericTests by SubjectGenericTests(UnicastSub
         val observer = subject.test()
 
         observer.assertError { it is IllegalStateException }
+    }
+
+    @Test
+    fun produces_IllegalStateException_WHEN_second_subscriber_recursively() {
+        var observer: TestObservableObserver<*>? = null
+
+        subject.subscribe {
+            observer = subject.test()
+        }
+
+        subject.onNext(0)
+
+        assertNotNull(observer).assertError { it is IllegalStateException }
     }
 
     @Test


### PR DESCRIPTION
The idea is to use a singly-linked queue. On each subscription, acquire the current head and emit the item (or all items till the end, depending on the type of the subject). Then pass the last emitted item via serializer and emit any new items when processed.

Observers must not miss any new items that are sent to the subject cuncurrently after initial items are emitted (synchronously on subscription). E.g. if `BehaviorSubject` holds item A, and a new observer receives that item synchronously on subscription, and new items B, C and D are sent to the subject concurrently, then that observer must receive B, C and D eventually.

Fixes #727