### PR TITLE
[2.0] Use Duration in Clock (1 of 3)

### DIFF
--- a/coroutines-interop/src/jvmCommonTest/kotlin/com/badoo/reaktive/coroutinesinterop/CoroutineContextSchedulerJvmTest.kt
+++ b/coroutines-interop/src/jvmCommonTest/kotlin/com/badoo/reaktive/coroutinesinterop/CoroutineContextSchedulerJvmTest.kt
@@ -1,12 +1,12 @@
 package com.badoo.reaktive.coroutinesinterop
 
-import com.badoo.reaktive.utils.NANOS_IN_MILLI
-import com.badoo.reaktive.utils.atomic.AtomicLong
 import com.badoo.reaktive.utils.clock.Clock
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CoroutineContextSchedulerJvmTest {
@@ -229,17 +229,15 @@ class CoroutineContextSchedulerJvmTest {
     }
 
     private fun advanceTimeBy(millis: Long) {
-        clock.advanceBy(millis)
+        clock.advanceBy(millis.milliseconds)
         dispatcher.advanceTimeBy(millis)
     }
 
     private class TestClock : Clock {
-        private val _uptimeMillis = AtomicLong()
-        override val uptimeMillis: Long get() = _uptimeMillis.value
-        override val uptimeNanos: Long get() = uptimeMillis * NANOS_IN_MILLI
+        override var uptime: Duration = Duration.ZERO
 
-        fun advanceBy(millis: Long) {
-            _uptimeMillis.addAndGet(millis)
+        fun advanceBy(duration: Duration) {
+            uptime += duration
         }
     }
 

--- a/coroutines-interop/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/coroutinesinterop/CoroutineContextScheduler.kt
+++ b/coroutines-interop/src/jvmJsCommonMain/kotlin/com/badoo/reaktive/coroutinesinterop/CoroutineContextScheduler.kt
@@ -86,7 +86,7 @@ internal class CoroutineContextScheduler(
             channelRef.value?.channel?.apply {
                 trySend(
                     Task(
-                        startAtMillis = clock.uptimeMillis + startDelayMillis,
+                        startAtMillis = clock.uptime.inWholeMilliseconds + startDelayMillis,
                         periodMillis = periodMillis,
                         task = task
                     )
@@ -95,7 +95,7 @@ internal class CoroutineContextScheduler(
         }
 
         private suspend fun execute(scope: CoroutineScope, task: Task) {
-            if (clock.uptimeMillis < task.startAtMillis) {
+            if (clock.uptime.inWholeMilliseconds < task.startAtMillis) {
                 scope.launch {
                     delayUntilStart(task.startAtMillis)
                     repeatTask(task.periodMillis, task.task)
@@ -107,7 +107,7 @@ internal class CoroutineContextScheduler(
 
         private suspend fun repeatTask(periodMillis: Long, task: () -> Unit) {
             while (true) {
-                val nextStartAtMillis = clock.uptimeMillis + periodMillis
+                val nextStartAtMillis = clock.uptime.inWholeMilliseconds + periodMillis
 
                 mutex.lock()
                 try {
@@ -125,7 +125,7 @@ internal class CoroutineContextScheduler(
         }
 
         private suspend fun delayUntilStart(startAtMillis: Long) {
-            val uptimeMillis = clock.uptimeMillis
+            val uptimeMillis = clock.uptime.inWholeMilliseconds
             if (uptimeMillis < startAtMillis) {
                 delay(startAtMillis - uptimeMillis)
             }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/scheduler/TrampolineScheduler.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/scheduler/TrampolineScheduler.kt
@@ -56,7 +56,7 @@ internal class TrampolineScheduler(
         }
 
         private fun submit(startDelayMillis: Long, periodMillis: Long, task: () -> Unit) {
-            submit(Task(clock.uptimeMillis + startDelayMillis, periodMillis, task))
+            submit(Task(clock.uptime.inWholeMilliseconds + startDelayMillis, periodMillis, task))
         }
 
         private fun submit(task: Task) {
@@ -70,7 +70,7 @@ internal class TrampolineScheduler(
                 return false
             }
 
-            val delay = task.startTime - clock.uptimeMillis
+            val delay = task.startTime - clock.uptime.inWholeMilliseconds
             if ((delay > 0) && !sleep(delay)) {
                 return false
             }
@@ -79,7 +79,7 @@ internal class TrampolineScheduler(
                 return false
             }
 
-            val nextStartMillis = if (task.periodMillis >= 0L) clock.uptimeMillis + task.periodMillis else -1L
+            val nextStartMillis = if (task.periodMillis >= 0L) clock.uptime.inWholeMilliseconds + task.periodMillis else -1L
 
             task.task()
 

--- a/reaktive/src/jsMain/kotlin/com/badoo/reaktive/scheduler/CreateTrampolineScheduler.kt
+++ b/reaktive/src/jsMain/kotlin/com/badoo/reaktive/scheduler/CreateTrampolineScheduler.kt
@@ -1,18 +1,20 @@
 package com.badoo.reaktive.scheduler
 
 import com.badoo.reaktive.utils.clock.DefaultClock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 actual fun createTrampolineScheduler(): Scheduler =
     TrampolineScheduler(
         sleep = {
-            busySleep(it)
+            busySleep(it.milliseconds)
             true
         }
     )
 
-@Suppress("EmptyWhileBlock")
-private fun busySleep(millis: Long) {
-    val end = DefaultClock.uptimeMillis + millis
-    while (DefaultClock.uptimeMillis < end) {
+private fun busySleep(duration: Duration) {
+    val end = DefaultClock.uptime + duration
+    while (DefaultClock.uptime < end) {
+        // no-op
     }
 }

--- a/utils-internal/src/commonMain/kotlin/com/badoo/reaktive/utils/Constants.kt
+++ b/utils-internal/src/commonMain/kotlin/com/badoo/reaktive/utils/Constants.kt
@@ -4,10 +4,4 @@ package com.badoo.reaktive.utils
 const val NANOS_IN_MILLI = 1_000_000L
 
 @InternalReaktiveApi
-const val NANOS_IN_SECOND = 1_000_000_000L
-
-@InternalReaktiveApi
 const val MICROS_IN_MILLI = 1_000L
-
-@InternalReaktiveApi
-const val MILLIS_IN_SECOND = 1_000L

--- a/utils-internal/src/commonMain/kotlin/com/badoo/reaktive/utils/clock/Clock.kt
+++ b/utils-internal/src/commonMain/kotlin/com/badoo/reaktive/utils/clock/Clock.kt
@@ -1,11 +1,10 @@
 package com.badoo.reaktive.utils.clock
 
 import com.badoo.reaktive.utils.InternalReaktiveApi
+import kotlin.time.Duration
 
 @InternalReaktiveApi
 interface Clock {
 
-    val uptimeMillis: Long
-
-    val uptimeNanos: Long
+    val uptime: Duration
 }

--- a/utils-internal/src/commonTest/kotlin/com/badoo/reaktive/utils/clock/DefaultClockTest.kt
+++ b/utils-internal/src/commonTest/kotlin/com/badoo/reaktive/utils/clock/DefaultClockTest.kt
@@ -1,0 +1,29 @@
+package com.badoo.reaktive.utils.clock
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.TimeSource
+
+class DefaultClockTest {
+
+    @Test
+    fun uptime_increases() {
+        val time1 = DefaultClock.uptime
+        busySleep(1.milliseconds)
+        val time2 = DefaultClock.uptime
+
+        assertTrue(time1.isPositive())
+        assertTrue(time2 - time1 >= 1.milliseconds)
+    }
+
+    @OptIn(ExperimentalTime::class)
+    private fun busySleep(duration: Duration) {
+        val end = TimeSource.Monotonic.markNow()
+        while (end.elapsedNow() < duration) {
+            // no-op
+        }
+    }
+}

--- a/utils-internal/src/jsMain/kotlin/com/badoo/reaktive/utils/clock/DefaultClock.kt
+++ b/utils-internal/src/jsMain/kotlin/com/badoo/reaktive/utils/clock/DefaultClock.kt
@@ -1,34 +1,25 @@
 package com.badoo.reaktive.utils.clock
 
 import com.badoo.reaktive.utils.InternalReaktiveApi
-import com.badoo.reaktive.utils.MILLIS_IN_SECOND
-import com.badoo.reaktive.utils.NANOS_IN_MILLI
-import com.badoo.reaktive.utils.NANOS_IN_SECOND
 import kotlinx.browser.window
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
 
 private external val process: dynamic
 
 @InternalReaktiveApi
 actual object DefaultClock : Clock {
 
-    override val uptimeMillis: Long
-        get() = if (isWindowDefined) window.performance.now().toLong() else hrTimeMillis
+    private val isWindowDefined = jsTypeOf(window) != "undefined"
 
-    override val uptimeNanos: Long
-        get() = if (isWindowDefined) window.performance.now().toLong() * NANOS_IN_MILLI else hrTimeNanos
-
-    private val isWindowDefined: Boolean = jsTypeOf(window) != "undefined"
-
-    private val hrTimeMillis: Long
-        get() {
-            val t = process.hrtime()
-
-            return ((t[0] as Int) * MILLIS_IN_SECOND + (t[1] as Int) / NANOS_IN_MILLI)
-        }
-    private val hrTimeNanos: Long
-        get() {
-            val t = process.hrtime()
-
-            return (t[0] as Int) * NANOS_IN_SECOND + t[1] as Int
-        }
+    override val uptime: Duration
+        get() =
+            if (isWindowDefined) {
+                window.performance.now().milliseconds
+            } else {
+                val t = process.hrtime().unsafeCast<IntArray>()
+                t[0].seconds + t[1].nanoseconds
+            }
 }

--- a/utils-internal/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/clock/DefaultClock.kt
+++ b/utils-internal/src/jvmCommonMain/kotlin/com/badoo/reaktive/utils/clock/DefaultClock.kt
@@ -1,12 +1,12 @@
 package com.badoo.reaktive.utils.clock
 
 import com.badoo.reaktive.utils.InternalReaktiveApi
-import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.nanoseconds
 
 @InternalReaktiveApi
 actual object DefaultClock : Clock {
 
-    override val uptimeMillis: Long get() = TimeUnit.NANOSECONDS.toMillis(System.nanoTime())
-
-    override val uptimeNanos: Long get() = System.nanoTime()
+    override val uptime: Duration
+        get() = System.nanoTime().nanoseconds
 }

--- a/utils-internal/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/clock/DefaultClock.kt
+++ b/utils-internal/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/clock/DefaultClock.kt
@@ -1,13 +1,13 @@
 package com.badoo.reaktive.utils.clock
 
 import com.badoo.reaktive.utils.InternalReaktiveApi
-import kotlin.system.getTimeMillis
 import kotlin.system.getTimeNanos
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.nanoseconds
 
 @InternalReaktiveApi
 actual object DefaultClock : Clock {
 
-    override val uptimeMillis: Long get() = getTimeMillis()
-
-    override val uptimeNanos: Long get() = getTimeNanos()
+    override val uptime: Duration
+        get() = getTimeNanos().nanoseconds
 }


### PR DESCRIPTION
Started migrating APIs from millis to `kotlin.time.Duration`. This is the 1st PR out of 3.

Converted `Clock` and all its usages. The next PR will address `Scheduler` and all its implementations.

As part of #620.