### PR TITLE
Fixed AtomicReference primitive updates stuck on native

### DIFF
--- a/utils-internal/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicReferenceExt.kt
+++ b/utils-internal/src/commonMain/kotlin/com/badoo/reaktive/utils/atomic/AtomicReferenceExt.kt
@@ -2,25 +2,30 @@ package com.badoo.reaktive.utils.atomic
 
 import com.badoo.reaktive.utils.InternalReaktiveApi
 
+@Suppress("UNCHECKED_CAST") // https://youtrack.jetbrains.com/issue/KT-57412
 @InternalReaktiveApi
 inline fun <T> AtomicReference<T>.getAndChange(update: (T) -> T): T {
-    var prev: T
-    do {
-        prev = value
-    } while (!compareAndSet(prev, update(prev)))
+    while (true) {
+        val prev: Any? = value
+        val next: Any? = update(prev as T)
 
-    return prev
+        if (compareAndSet(prev, next as T)) {
+            return prev
+        }
+    }
 }
 
+@Suppress("UNCHECKED_CAST") // https://youtrack.jetbrains.com/issue/KT-57412
 @InternalReaktiveApi
 inline fun <T, R : T> AtomicReference<T>.changeAndGet(update: (T) -> R): R {
-    var next: R
-    do {
-        val prev = value
-        next = update(prev)
-    } while (!compareAndSet(prev, next))
+    while (true) {
+        val prev: Any? = value
+        val next: Any? = update(prev as T)
 
-    return next
+        if (compareAndSet(prev, next as R)) {
+            return next
+        }
+    }
 }
 
 @InternalReaktiveApi

--- a/utils-internal/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicReferenceTest.kt
+++ b/utils-internal/src/commonTest/kotlin/com/badoo/reaktive/utils/atomic/AtomicReferenceTest.kt
@@ -49,11 +49,27 @@ class AtomicReferenceTest {
     }
 
     @Test
+    fun getAndUpdate_with_large_primitives() {
+        val ref = AtomicReference(1000)
+        val result = ref.getAndChange { it + 1 }
+        assertEquals(1000, result)
+        assertEquals(1001, ref.value)
+    }
+
+    @Test
     fun updateAndGet() {
         val ref = AtomicReference(VALUE_1)
         val result = ref.changeAndGet { VALUE_2 }
         assertSame(VALUE_2, result)
         assertSame(VALUE_2, ref.value)
+    }
+
+    @Test
+    fun updateAndGet_with_large_primitives() {
+        val ref = AtomicReference(1000)
+        val result = ref.changeAndGet { it + 1 }
+        assertEquals(1001, result)
+        assertEquals(1001, ref.value)
     }
 
     @Test
@@ -65,10 +81,17 @@ class AtomicReferenceTest {
     }
 
     @Test
-    fun update() {
+    fun change() {
         val ref = AtomicReference(VALUE_1)
         ref.change { VALUE_2 }
         assertSame(VALUE_2, ref.value)
+    }
+
+    @Test
+    fun change_with_large_primitives() {
+        val ref = AtomicReference(1000)
+        ref.change { it + 1 }
+        assertEquals(1001, ref.value)
     }
 
     private companion object {


### PR DESCRIPTION
There is a [bug](https://youtrack.jetbrains.com/issue/KT-57412) in Kotlin/Native that leads to unnecessary unboxing-boxing of large primitives with inline functions. As a result, `getAndChange`, `changeAndGet` and `change` function may stuck. This happens because `AtomicReference` compares by reference, and the references are different. The workaround is to specify variable types as `Any?` and use unsafe cast which prevents unboxing-boxing.