### PR TITLE
[2.0] Use Duration in DelayQueue, ExpirationPool and LooperThread (2 of 4)

### DIFF
--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/looperthread/CachedLooperThreadStrategy.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/looperthread/CachedLooperThreadStrategy.kt
@@ -1,15 +1,16 @@
 package com.badoo.reaktive.looperthread
 
 import com.badoo.reaktive.utils.ExpirationPool
+import kotlin.time.Duration
 
 internal class CachedLooperThreadStrategy(
-    private val keepAliveTimeoutMillis: Long
+    private val keepAliveTimeout: Duration
 ) : LooperThreadStrategy {
 
     override fun get(): LooperThread = pool.acquire() ?: LooperThread()
 
     override fun recycle(looperThread: LooperThread) {
-        pool.release(looperThread, keepAliveTimeoutMillis)
+        pool.release(looperThread, keepAliveTimeout)
     }
 
     override fun destroy() {

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/looperthread/LooperThread.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/looperthread/LooperThread.kt
@@ -3,6 +3,7 @@ package com.badoo.reaktive.looperthread
 import com.badoo.reaktive.utils.DelayQueue
 import kotlin.native.concurrent.TransferMode
 import kotlin.native.concurrent.Worker
+import kotlin.time.Duration
 
 internal class LooperThread {
 
@@ -13,8 +14,8 @@ internal class LooperThread {
         worker.execute(TransferMode.SAFE, { this }) { it.loop() }
     }
 
-    fun schedule(token: Any, startTimeMillis: Long, task: () -> Unit) {
-        queue.offerAt(Message(token, task), startTimeMillis)
+    fun schedule(token: Any, startTime: Duration, task: () -> Unit) {
+        queue.offerAt(Message(token, task), startTime)
     }
 
     fun cancel(token: Any) {

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/scheduler/CreateIoScheduler.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/scheduler/CreateIoScheduler.kt
@@ -1,5 +1,7 @@
 package com.badoo.reaktive.scheduler
 
 import com.badoo.reaktive.looperthread.CachedLooperThreadStrategy
+import kotlin.time.Duration.Companion.seconds
 
-actual fun createIoScheduler(): Scheduler = SchedulerImpl(CachedLooperThreadStrategy(keepAliveTimeoutMillis = 60000L))
+actual fun createIoScheduler(): Scheduler =
+    SchedulerImpl(CachedLooperThreadStrategy(keepAliveTimeout = 60.seconds))

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/scheduler/SchedulerImpl.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/scheduler/SchedulerImpl.kt
@@ -6,6 +6,7 @@ import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.looperthread.LooperThreadStrategy
 import kotlin.native.concurrent.AtomicInt
 import kotlin.system.getTimeMillis
+import kotlin.time.Duration.Companion.milliseconds
 
 internal class SchedulerImpl(
     private val looperThreadStrategy: LooperThreadStrategy
@@ -42,7 +43,7 @@ internal class SchedulerImpl(
 
         override fun submit(delayMillis: Long, task: () -> Unit) {
             if (!isDisposed) {
-                looperThread.schedule(this, getStartTimeMillis(delayMillis), task)
+                looperThread.schedule(this, getStartTimeMillis(delayMillis).milliseconds, task)
             }
         }
 
@@ -53,12 +54,12 @@ internal class SchedulerImpl(
                     val nextStartTimeMillis = getStartTimeMillis(periodMillis)
                     task()
                     if (!isDisposed) {
-                        looperThread.schedule(this, nextStartTimeMillis, t)
+                        looperThread.schedule(this, nextStartTimeMillis.milliseconds, t)
                     }
                 }
             }
             if (!isDisposed) {
-                looperThread.schedule(this, getStartTimeMillis(startDelayMillis), t)
+                looperThread.schedule(this, getStartTimeMillis(startDelayMillis).milliseconds, t)
             }
         }
 

--- a/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/ExpirationPool.kt
+++ b/reaktive/src/nativeCommonMain/kotlin/com/badoo/reaktive/utils/ExpirationPool.kt
@@ -2,6 +2,7 @@ package com.badoo.reaktive.utils
 
 import kotlin.native.concurrent.TransferMode
 import kotlin.native.concurrent.Worker
+import kotlin.time.Duration
 
 /*
  * Not cancellable nor destroyable, implement when needed. Currently used only as singleton.
@@ -20,8 +21,8 @@ internal class ExpirationPool<T : Any>(
 
     fun acquire(): T? = queue.removeFirst()
 
-    fun release(item: T, timeoutMillis: Long) {
-        queue.offer(item, timeoutMillis)
+    fun release(item: T, timeout: Duration) {
+        queue.offer(item, timeout)
     }
 
     private fun drainQueue() {

--- a/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/looperthread/LooperThreadTest.kt
+++ b/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/looperthread/LooperThreadTest.kt
@@ -6,10 +6,10 @@ import com.badoo.reaktive.utils.lock.synchronized
 import com.badoo.reaktive.utils.lock.waitForOrFail
 import platform.posix.usleep
 import kotlin.system.getTimeMillis
-import kotlin.system.getTimeNanos
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 
 class LooperThreadTest {
 
@@ -20,7 +20,7 @@ class LooperThreadTest {
         val thread = LooperThread()
         val startTime = getTimeMillis() + 200L
 
-        thread.schedule(Unit, startTime) {
+        thread.schedule(Unit, startTime.milliseconds) {
             lock.synchronized {
                 isExecuted.value = true
                 lock.signal()
@@ -31,7 +31,7 @@ class LooperThreadTest {
             lock.waitForOrFail(predicate = isExecuted::value)
         }
 
-        assertTrue(getTimeNanos() >= startTime)
+        assertTrue(getTimeMillis() >= startTime)
     }
 
     @Test
@@ -40,7 +40,7 @@ class LooperThreadTest {
         val lock = ConditionLock()
         val thread = LooperThread()
 
-        thread.schedule(Unit, getTimeMillis()) {
+        thread.schedule(Unit, getTimeMillis().milliseconds) {
             lock.synchronized {
                 isExecuted.value = true
                 lock.signal()
@@ -54,7 +54,7 @@ class LooperThreadTest {
         thread.destroy()
 
         isExecuted.value = false
-        thread.schedule(Unit, getTimeMillis()) {
+        thread.schedule(Unit, getTimeMillis().milliseconds) {
             isExecuted.value = true
         }
 

--- a/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/utils/DelayQueueTest.kt
+++ b/reaktive/src/nativeCommonTest/kotlin/com/badoo/reaktive/utils/DelayQueueTest.kt
@@ -7,6 +7,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 class DelayQueueTest {
 
@@ -16,7 +18,7 @@ class DelayQueueTest {
     fun provides_item_with_delay() {
         val startMillis = getTimeMillis()
 
-        queue.offer(0, 200L)
+        queue.offer(0, 200.milliseconds)
         val value = queue.take()
 
         assertTrue(getTimeMillis() - startMillis >= 200L)
@@ -27,9 +29,9 @@ class DelayQueueTest {
     fun provides_items_in_correct_order_and_with_correct_delays() {
         val startMillis = getTimeMillis()
 
-        queue.offer(2, 300L)
-        queue.offer(3, 500L)
-        queue.offer(1, 200L)
+        queue.offer(2, 300.milliseconds)
+        queue.offer(3, 500.milliseconds)
+        queue.offer(1, 200.milliseconds)
         val v1 = queue.take()
         val t1 = getTimeMillis() - startMillis
         val v2 = queue.take()
@@ -49,8 +51,8 @@ class DelayQueueTest {
     fun removes_first_item() {
         val startMillis = getTimeMillis()
 
-        queue.offer(0, 200L)
-        queue.offer(1, 100L)
+        queue.offer(0, 200.milliseconds)
+        queue.offer(1, 100.milliseconds)
         queue.removeFirst()
         val value = queue.take()
 
@@ -62,7 +64,7 @@ class DelayQueueTest {
     fun able_to_offer_and_take_from_different_threads() {
         Worker
             .start(true)
-            .execute(TransferMode.SAFE, { queue }) { it.offer(0, 0) }
+            .execute(TransferMode.SAFE, { queue }) { it.offer(0, Duration.ZERO) }
 
         val value = queue.take()
 
@@ -71,9 +73,9 @@ class DelayQueueTest {
 
     @Test
     fun provide_items_with_same_delay_in_the_same_order() {
-        queue.offer(0, 0L)
-        queue.offer(1, 0L)
-        queue.offer(2, 0L)
+        queue.offer(0, Duration.ZERO)
+        queue.offer(1, Duration.ZERO)
+        queue.offer(2, Duration.ZERO)
         val values = listOf(queue.take(), queue.take(), queue.take())
 
         assertEquals(listOf(0, 1, 2), values)
@@ -81,7 +83,7 @@ class DelayQueueTest {
 
     @Test
     fun take_returns_null_when_terminated() {
-        queue.offer(0, 0L)
+        queue.offer(0, Duration.ZERO)
         queue.terminate()
         val value = queue.take()
 
@@ -90,10 +92,10 @@ class DelayQueueTest {
 
     @Test
     fun removeIf_removes_items() {
-        queue.offer(value = 0, timeoutMillis = 0L)
-        queue.offer(value = 1, timeoutMillis = 0L)
-        queue.offer(value = 2, timeoutMillis = 0L)
-        queue.offer(value = 3, timeoutMillis = 0L)
+        queue.offer(value = 0, timeout = Duration.ZERO)
+        queue.offer(value = 1, timeout = Duration.ZERO)
+        queue.offer(value = 2, timeout = Duration.ZERO)
+        queue.offer(value = 3, timeout = Duration.ZERO)
 
         queue.removeIf { (it == 1) || (it == 3) }
 


### PR DESCRIPTION
Last preparatory PR before migrating schedulers.