### PR TITLE
[2.0] Use Duration in operators (4 of 4)

### DIFF
--- a/reaktive/api/android/reaktive.api
+++ b/reaktive/api/android/reaktive.api
@@ -145,12 +145,12 @@ public final class com/badoo/reaktive/completable/DeferKt {
 }
 
 public final class com/badoo/reaktive/completable/DelayKt {
-	public static final fun delay (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/completable/Completable;
-	public static synthetic fun delay$default (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/completable/Completable;
+	public static final fun delay-dWUq8MI (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/completable/Completable;
+	public static synthetic fun delay-dWUq8MI$default (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/completable/Completable;
 }
 
 public final class com/badoo/reaktive/completable/DelaySubscriptionKt {
-	public static final fun delaySubscription (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/completable/Completable;
+	public static final fun delaySubscription-8Mi8wO0 (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/completable/Completable;
 }
 
 public final class com/badoo/reaktive/completable/DoOnAfterKt {
@@ -218,12 +218,12 @@ public final class com/badoo/reaktive/completable/SubscribeOnKt {
 }
 
 public final class com/badoo/reaktive/completable/TimeoutKt {
-	public static final fun timeout (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/completable/Completable;)Lcom/badoo/reaktive/completable/Completable;
-	public static synthetic fun timeout$default (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/completable/Completable;ILjava/lang/Object;)Lcom/badoo/reaktive/completable/Completable;
+	public static final fun timeout-dWUq8MI (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/completable/Completable;)Lcom/badoo/reaktive/completable/Completable;
+	public static synthetic fun timeout-dWUq8MI$default (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/completable/Completable;ILjava/lang/Object;)Lcom/badoo/reaktive/completable/Completable;
 }
 
 public final class com/badoo/reaktive/completable/TimerKt {
-	public static final fun completableTimer (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/completable/Completable;
+	public static final fun completableTimer-VtjQ1oo (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/completable/Completable;
 }
 
 public final class com/badoo/reaktive/completable/UsingKt {
@@ -347,12 +347,12 @@ public final class com/badoo/reaktive/maybe/DeferKt {
 }
 
 public final class com/badoo/reaktive/maybe/DelayKt {
-	public static final fun delay (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/maybe/Maybe;
-	public static synthetic fun delay$default (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/maybe/Maybe;
+	public static final fun delay-dWUq8MI (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/maybe/Maybe;
+	public static synthetic fun delay-dWUq8MI$default (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/maybe/Maybe;
 }
 
 public final class com/badoo/reaktive/maybe/DelaySubscriptionKt {
-	public static final fun delaySubscription (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/maybe/Maybe;
+	public static final fun delaySubscription-8Mi8wO0 (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/maybe/Maybe;
 }
 
 public final class com/badoo/reaktive/maybe/DoOnAfterKt {
@@ -514,12 +514,12 @@ public final class com/badoo/reaktive/maybe/SwitchIfEmptyKt {
 }
 
 public final class com/badoo/reaktive/maybe/TimeoutKt {
-	public static final fun timeout (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/maybe/Maybe;)Lcom/badoo/reaktive/maybe/Maybe;
-	public static synthetic fun timeout$default (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/maybe/Maybe;ILjava/lang/Object;)Lcom/badoo/reaktive/maybe/Maybe;
+	public static final fun timeout-dWUq8MI (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/maybe/Maybe;)Lcom/badoo/reaktive/maybe/Maybe;
+	public static synthetic fun timeout-dWUq8MI$default (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/maybe/Maybe;ILjava/lang/Object;)Lcom/badoo/reaktive/maybe/Maybe;
 }
 
 public final class com/badoo/reaktive/maybe/TimerKt {
-	public static final fun maybeTimer (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/maybe/Maybe;
+	public static final fun maybeTimer-VtjQ1oo (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/maybe/Maybe;
 }
 
 public final class com/badoo/reaktive/maybe/UsingKt {
@@ -587,14 +587,14 @@ public final class com/badoo/reaktive/observable/BufferCountSkipKt {
 }
 
 public final class com/badoo/reaktive/observable/BufferKt {
-	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZ)Lcom/badoo/reaktive/observable/Observable;
-	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;IZ)Lcom/badoo/reaktive/observable/Observable;
 	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;JZ)Lcom/badoo/reaktive/observable/Observable;
 	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;JZ)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;IZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun buffer-FbhrOv8 (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZ)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun buffer-FbhrOv8$default (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun buffer-WPwdCS8 (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;IZ)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun buffer-WPwdCS8$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;IZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/CollectKt {
@@ -641,7 +641,7 @@ public abstract interface class com/badoo/reaktive/observable/ConnectableObserva
 }
 
 public final class com/badoo/reaktive/observable/DebounceKt {
-	public static final fun debounce (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun debounce-8Mi8wO0 (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/DebounceWithSelectorKt {
@@ -657,12 +657,12 @@ public final class com/badoo/reaktive/observable/DeferKt {
 }
 
 public final class com/badoo/reaktive/observable/DelayKt {
-	public static final fun delay (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun delay$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun delay-dWUq8MI (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun delay-dWUq8MI$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/DelaySubscriptionKt {
-	public static final fun delaySubscription (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun delaySubscription-8Mi8wO0 (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/DistinctUntilChangedKt {
@@ -749,8 +749,8 @@ public final class com/badoo/reaktive/observable/FlattenKt {
 }
 
 public final class com/badoo/reaktive/observable/IntervalKt {
-	public static final fun observableInterval (JJLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun observableInterval$default (JJLcom/badoo/reaktive/scheduler/Scheduler;ILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun observableInterval-NqJ4yvY (JJLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun observableInterval-NqJ4yvY$default (JJLcom/badoo/reaktive/scheduler/Scheduler;ILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/MapIterableKt {
@@ -869,7 +869,7 @@ public final class com/badoo/reaktive/observable/RetryKt {
 }
 
 public final class com/badoo/reaktive/observable/SampleKt {
-	public static final fun sample (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun sample-8Mi8wO0 (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/ScanKt {
@@ -941,24 +941,24 @@ public final class com/badoo/reaktive/observable/TakeWhilePredicateKt {
 }
 
 public final class com/badoo/reaktive/observable/ThrottleKt {
-	public static final fun throttle (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun throttle$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;ILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun throttle-8Mi8wO0 (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun throttle-8Mi8wO0$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;ILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/ThrottleLatestKt {
-	public static final fun throttleLatest (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/observable/Observable;
 	public static final fun throttleLatest (Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;Z)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun throttleLatest$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 	public static synthetic fun throttleLatest$default (Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun throttleLatest-dWUq8MI (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun throttleLatest-dWUq8MI$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/TimeoutKt {
-	public static final fun timeout (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/observable/Observable;)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun timeout$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/observable/Observable;ILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun timeout-dWUq8MI (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/observable/Observable;)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun timeout-dWUq8MI$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/observable/Observable;ILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/TimerKt {
-	public static final fun observableTimer (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun observableTimer-VtjQ1oo (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/ToListKt {
@@ -989,17 +989,17 @@ public final class com/badoo/reaktive/observable/VariousKt {
 }
 
 public final class com/badoo/reaktive/observable/WindowByBoundaryKt {
-	public static final fun window (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;JZ)Lcom/badoo/reaktive/observable/Observable;
 	public static final fun window (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;JZ)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun window$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 	public static synthetic fun window$default (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun window-WPwdCS8 (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;JZ)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun window-WPwdCS8$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/WindowBySignalKt {
-	public static final fun window (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZ)Lcom/badoo/reaktive/observable/Observable;
 	public static final fun window (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;JZ)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun window$default (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 	public static synthetic fun window$default (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun window-FbhrOv8 (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZ)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun window-FbhrOv8$default (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/WindowSizedKt {
@@ -1086,17 +1086,11 @@ public abstract interface class com/badoo/reaktive/scheduler/Scheduler {
 
 public abstract interface class com/badoo/reaktive/scheduler/Scheduler$Executor : com/badoo/reaktive/disposable/Disposable {
 	public abstract fun cancel ()V
-	public abstract fun submit (JLkotlin/jvm/functions/Function0;)V
 	public abstract fun submit-NqJ4yvY (JJLkotlin/jvm/functions/Function0;)V
-	public abstract fun submitRepeating (JJLkotlin/jvm/functions/Function0;)V
 }
 
 public final class com/badoo/reaktive/scheduler/Scheduler$Executor$DefaultImpls {
-	public static fun submit (Lcom/badoo/reaktive/scheduler/Scheduler$Executor;JLkotlin/jvm/functions/Function0;)V
-	public static synthetic fun submit$default (Lcom/badoo/reaktive/scheduler/Scheduler$Executor;JLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static synthetic fun submit-NqJ4yvY$default (Lcom/badoo/reaktive/scheduler/Scheduler$Executor;JJLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public static fun submitRepeating (Lcom/badoo/reaktive/scheduler/Scheduler$Executor;JJLkotlin/jvm/functions/Function0;)V
-	public static synthetic fun submitRepeating$default (Lcom/badoo/reaktive/scheduler/Scheduler$Executor;JJLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 }
 
 public final class com/badoo/reaktive/scheduler/SchedulerExtKt {
@@ -1146,12 +1140,12 @@ public final class com/badoo/reaktive/single/DeferKt {
 }
 
 public final class com/badoo/reaktive/single/DelayKt {
-	public static final fun delay (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/single/Single;
-	public static synthetic fun delay$default (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/single/Single;
+	public static final fun delay-dWUq8MI (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/single/Single;
+	public static synthetic fun delay-dWUq8MI$default (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/single/Single;
 }
 
 public final class com/badoo/reaktive/single/DelaySubscriptionKt {
-	public static final fun delaySubscription (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/single/Single;
+	public static final fun delaySubscription-8Mi8wO0 (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/single/Single;
 }
 
 public final class com/badoo/reaktive/single/DoOnAfterKt {
@@ -1301,12 +1295,12 @@ public final class com/badoo/reaktive/single/SubscribeOnKt {
 }
 
 public final class com/badoo/reaktive/single/TimeoutKt {
-	public static final fun timeout (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/single/Single;)Lcom/badoo/reaktive/single/Single;
-	public static synthetic fun timeout$default (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/single/Single;ILjava/lang/Object;)Lcom/badoo/reaktive/single/Single;
+	public static final fun timeout-dWUq8MI (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/single/Single;)Lcom/badoo/reaktive/single/Single;
+	public static synthetic fun timeout-dWUq8MI$default (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/single/Single;ILjava/lang/Object;)Lcom/badoo/reaktive/single/Single;
 }
 
 public final class com/badoo/reaktive/single/TimerKt {
-	public static final fun singleTimer (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/single/Single;
+	public static final fun singleTimer-VtjQ1oo (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/single/Single;
 }
 
 public final class com/badoo/reaktive/single/UsingKt {

--- a/reaktive/api/jvm/reaktive.api
+++ b/reaktive/api/jvm/reaktive.api
@@ -138,12 +138,12 @@ public final class com/badoo/reaktive/completable/DeferKt {
 }
 
 public final class com/badoo/reaktive/completable/DelayKt {
-	public static final fun delay (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/completable/Completable;
-	public static synthetic fun delay$default (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/completable/Completable;
+	public static final fun delay-dWUq8MI (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/completable/Completable;
+	public static synthetic fun delay-dWUq8MI$default (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/completable/Completable;
 }
 
 public final class com/badoo/reaktive/completable/DelaySubscriptionKt {
-	public static final fun delaySubscription (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/completable/Completable;
+	public static final fun delaySubscription-8Mi8wO0 (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/completable/Completable;
 }
 
 public final class com/badoo/reaktive/completable/DoOnAfterKt {
@@ -211,12 +211,12 @@ public final class com/badoo/reaktive/completable/SubscribeOnKt {
 }
 
 public final class com/badoo/reaktive/completable/TimeoutKt {
-	public static final fun timeout (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/completable/Completable;)Lcom/badoo/reaktive/completable/Completable;
-	public static synthetic fun timeout$default (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/completable/Completable;ILjava/lang/Object;)Lcom/badoo/reaktive/completable/Completable;
+	public static final fun timeout-dWUq8MI (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/completable/Completable;)Lcom/badoo/reaktive/completable/Completable;
+	public static synthetic fun timeout-dWUq8MI$default (Lcom/badoo/reaktive/completable/Completable;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/completable/Completable;ILjava/lang/Object;)Lcom/badoo/reaktive/completable/Completable;
 }
 
 public final class com/badoo/reaktive/completable/TimerKt {
-	public static final fun completableTimer (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/completable/Completable;
+	public static final fun completableTimer-VtjQ1oo (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/completable/Completable;
 }
 
 public final class com/badoo/reaktive/completable/UsingKt {
@@ -340,12 +340,12 @@ public final class com/badoo/reaktive/maybe/DeferKt {
 }
 
 public final class com/badoo/reaktive/maybe/DelayKt {
-	public static final fun delay (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/maybe/Maybe;
-	public static synthetic fun delay$default (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/maybe/Maybe;
+	public static final fun delay-dWUq8MI (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/maybe/Maybe;
+	public static synthetic fun delay-dWUq8MI$default (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/maybe/Maybe;
 }
 
 public final class com/badoo/reaktive/maybe/DelaySubscriptionKt {
-	public static final fun delaySubscription (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/maybe/Maybe;
+	public static final fun delaySubscription-8Mi8wO0 (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/maybe/Maybe;
 }
 
 public final class com/badoo/reaktive/maybe/DoOnAfterKt {
@@ -507,12 +507,12 @@ public final class com/badoo/reaktive/maybe/SwitchIfEmptyKt {
 }
 
 public final class com/badoo/reaktive/maybe/TimeoutKt {
-	public static final fun timeout (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/maybe/Maybe;)Lcom/badoo/reaktive/maybe/Maybe;
-	public static synthetic fun timeout$default (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/maybe/Maybe;ILjava/lang/Object;)Lcom/badoo/reaktive/maybe/Maybe;
+	public static final fun timeout-dWUq8MI (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/maybe/Maybe;)Lcom/badoo/reaktive/maybe/Maybe;
+	public static synthetic fun timeout-dWUq8MI$default (Lcom/badoo/reaktive/maybe/Maybe;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/maybe/Maybe;ILjava/lang/Object;)Lcom/badoo/reaktive/maybe/Maybe;
 }
 
 public final class com/badoo/reaktive/maybe/TimerKt {
-	public static final fun maybeTimer (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/maybe/Maybe;
+	public static final fun maybeTimer-VtjQ1oo (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/maybe/Maybe;
 }
 
 public final class com/badoo/reaktive/maybe/UsingKt {
@@ -580,14 +580,14 @@ public final class com/badoo/reaktive/observable/BufferCountSkipKt {
 }
 
 public final class com/badoo/reaktive/observable/BufferKt {
-	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZ)Lcom/badoo/reaktive/observable/Observable;
-	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;IZ)Lcom/badoo/reaktive/observable/Observable;
 	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;JZ)Lcom/badoo/reaktive/observable/Observable;
 	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;JZ)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;IZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun buffer-FbhrOv8 (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZ)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun buffer-FbhrOv8$default (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun buffer-WPwdCS8 (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;IZ)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun buffer-WPwdCS8$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;IZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/CollectKt {
@@ -634,7 +634,7 @@ public abstract interface class com/badoo/reaktive/observable/ConnectableObserva
 }
 
 public final class com/badoo/reaktive/observable/DebounceKt {
-	public static final fun debounce (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun debounce-8Mi8wO0 (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/DebounceWithSelectorKt {
@@ -650,12 +650,12 @@ public final class com/badoo/reaktive/observable/DeferKt {
 }
 
 public final class com/badoo/reaktive/observable/DelayKt {
-	public static final fun delay (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun delay$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun delay-dWUq8MI (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun delay-dWUq8MI$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/DelaySubscriptionKt {
-	public static final fun delaySubscription (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun delaySubscription-8Mi8wO0 (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/DistinctUntilChangedKt {
@@ -742,8 +742,8 @@ public final class com/badoo/reaktive/observable/FlattenKt {
 }
 
 public final class com/badoo/reaktive/observable/IntervalKt {
-	public static final fun observableInterval (JJLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun observableInterval$default (JJLcom/badoo/reaktive/scheduler/Scheduler;ILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun observableInterval-NqJ4yvY (JJLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun observableInterval-NqJ4yvY$default (JJLcom/badoo/reaktive/scheduler/Scheduler;ILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/MapIterableKt {
@@ -862,7 +862,7 @@ public final class com/badoo/reaktive/observable/RetryKt {
 }
 
 public final class com/badoo/reaktive/observable/SampleKt {
-	public static final fun sample (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun sample-8Mi8wO0 (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/ScanKt {
@@ -934,24 +934,24 @@ public final class com/badoo/reaktive/observable/TakeWhilePredicateKt {
 }
 
 public final class com/badoo/reaktive/observable/ThrottleKt {
-	public static final fun throttle (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun throttle$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;ILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun throttle-8Mi8wO0 (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun throttle-8Mi8wO0$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;ILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/ThrottleLatestKt {
-	public static final fun throttleLatest (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/observable/Observable;
 	public static final fun throttleLatest (Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;Z)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun throttleLatest$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 	public static synthetic fun throttleLatest$default (Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun throttleLatest-dWUq8MI (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun throttleLatest-dWUq8MI$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/TimeoutKt {
-	public static final fun timeout (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/observable/Observable;)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun timeout$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/observable/Observable;ILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun timeout-dWUq8MI (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/observable/Observable;)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun timeout-dWUq8MI$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/observable/Observable;ILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/TimerKt {
-	public static final fun observableTimer (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun observableTimer-VtjQ1oo (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/ToListKt {
@@ -982,17 +982,17 @@ public final class com/badoo/reaktive/observable/VariousKt {
 }
 
 public final class com/badoo/reaktive/observable/WindowByBoundaryKt {
-	public static final fun window (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;JZ)Lcom/badoo/reaktive/observable/Observable;
 	public static final fun window (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;JZ)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun window$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 	public static synthetic fun window$default (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun window-WPwdCS8 (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;JZ)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun window-WPwdCS8$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/WindowBySignalKt {
-	public static final fun window (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZ)Lcom/badoo/reaktive/observable/Observable;
 	public static final fun window (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;JZ)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun window$default (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 	public static synthetic fun window$default (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun window-FbhrOv8 (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZ)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun window-FbhrOv8$default (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }
 
 public final class com/badoo/reaktive/observable/WindowSizedKt {
@@ -1079,17 +1079,11 @@ public abstract interface class com/badoo/reaktive/scheduler/Scheduler {
 
 public abstract interface class com/badoo/reaktive/scheduler/Scheduler$Executor : com/badoo/reaktive/disposable/Disposable {
 	public abstract fun cancel ()V
-	public abstract fun submit (JLkotlin/jvm/functions/Function0;)V
 	public abstract fun submit-NqJ4yvY (JJLkotlin/jvm/functions/Function0;)V
-	public abstract fun submitRepeating (JJLkotlin/jvm/functions/Function0;)V
 }
 
 public final class com/badoo/reaktive/scheduler/Scheduler$Executor$DefaultImpls {
-	public static fun submit (Lcom/badoo/reaktive/scheduler/Scheduler$Executor;JLkotlin/jvm/functions/Function0;)V
-	public static synthetic fun submit$default (Lcom/badoo/reaktive/scheduler/Scheduler$Executor;JLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static synthetic fun submit-NqJ4yvY$default (Lcom/badoo/reaktive/scheduler/Scheduler$Executor;JJLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public static fun submitRepeating (Lcom/badoo/reaktive/scheduler/Scheduler$Executor;JJLkotlin/jvm/functions/Function0;)V
-	public static synthetic fun submitRepeating$default (Lcom/badoo/reaktive/scheduler/Scheduler$Executor;JJLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 }
 
 public final class com/badoo/reaktive/scheduler/SchedulerExtKt {
@@ -1139,12 +1133,12 @@ public final class com/badoo/reaktive/single/DeferKt {
 }
 
 public final class com/badoo/reaktive/single/DelayKt {
-	public static final fun delay (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/single/Single;
-	public static synthetic fun delay$default (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/single/Single;
+	public static final fun delay-dWUq8MI (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;Z)Lcom/badoo/reaktive/single/Single;
+	public static synthetic fun delay-dWUq8MI$default (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;ZILjava/lang/Object;)Lcom/badoo/reaktive/single/Single;
 }
 
 public final class com/badoo/reaktive/single/DelaySubscriptionKt {
-	public static final fun delaySubscription (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/single/Single;
+	public static final fun delaySubscription-8Mi8wO0 (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/single/Single;
 }
 
 public final class com/badoo/reaktive/single/DoOnAfterKt {
@@ -1294,12 +1288,12 @@ public final class com/badoo/reaktive/single/SubscribeOnKt {
 }
 
 public final class com/badoo/reaktive/single/TimeoutKt {
-	public static final fun timeout (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/single/Single;)Lcom/badoo/reaktive/single/Single;
-	public static synthetic fun timeout$default (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/single/Single;ILjava/lang/Object;)Lcom/badoo/reaktive/single/Single;
+	public static final fun timeout-dWUq8MI (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/single/Single;)Lcom/badoo/reaktive/single/Single;
+	public static synthetic fun timeout-dWUq8MI$default (Lcom/badoo/reaktive/single/Single;JLcom/badoo/reaktive/scheduler/Scheduler;Lcom/badoo/reaktive/single/Single;ILjava/lang/Object;)Lcom/badoo/reaktive/single/Single;
 }
 
 public final class com/badoo/reaktive/single/TimerKt {
-	public static final fun singleTimer (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/single/Single;
+	public static final fun singleTimer-VtjQ1oo (JLcom/badoo/reaktive/scheduler/Scheduler;)Lcom/badoo/reaktive/single/Single;
 }
 
 public final class com/badoo/reaktive/single/UsingKt {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Delay.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Delay.kt
@@ -4,6 +4,7 @@ import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
  * Delays `onComplete` signal from the current [Completable] for the specified time.
@@ -11,7 +12,7 @@ import com.badoo.reaktive.scheduler.Scheduler
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Completable.html#delay-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-boolean-).
  */
-fun Completable.delay(delayMillis: Long, scheduler: Scheduler, delayError: Boolean = false): Completable =
+fun Completable.delay(delay: Duration, scheduler: Scheduler, delayError: Boolean = false): Completable =
     completable { emitter ->
         val disposables = CompositeDisposable()
         emitter.setDisposable(disposables)
@@ -25,12 +26,12 @@ fun Completable.delay(delayMillis: Long, scheduler: Scheduler, delayError: Boole
                 }
 
                 override fun onComplete() {
-                    executor.submit(delayMillis, emitter::onComplete)
+                    executor.submit(delay = delay, task = emitter::onComplete)
                 }
 
                 override fun onError(error: Throwable) {
                     if (delayError) {
-                        executor.submit(delayMillis) {
+                        executor.submit(delay = delay) {
                             emitter.onError(error)
                         }
                     } else {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/DelaySubscription.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/DelaySubscription.kt
@@ -3,20 +3,19 @@ package com.badoo.reaktive.completable
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
  * Delays the actual subscription to the [Completable] for the specified time.
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Completable.html#delaySubscription-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).
  */
-fun Completable.delaySubscription(delayMillis: Long, scheduler: Scheduler): Completable {
-    require(delayMillis >= 0L) { "delayMillis must not be negative" }
-
-    return completable { emitter ->
+fun Completable.delaySubscription(delay: Duration, scheduler: Scheduler): Completable =
+    completable { emitter ->
         val executor = scheduler.newExecutor()
         emitter.setDisposable(executor)
 
-        executor.submit(delayMillis) {
+        executor.submit(delay = delay) {
             emitter.tryCatch {
                 subscribe(
                     object : CompletableObserver, CompletableCallbacks by emitter {
@@ -28,4 +27,3 @@ fun Completable.delaySubscription(delayMillis: Long, scheduler: Scheduler): Comp
             }
         }
     }
-}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Timeout.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Timeout.kt
@@ -5,13 +5,14 @@ import com.badoo.reaktive.base.exceptions.TimeoutException
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.addTo
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
- * Disposes the current [Completable] if it does not signal within the [timeoutMillis] timeout, and subscribes to [other] [Completable] if provided.
+ * Disposes the current [Completable] if it does not signal within the [timeout], and subscribes to [other] [Completable] if provided.
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Completable.html#timeout-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-io.reactivex.CompletableSource-).
  */
-fun Completable.timeout(timeoutMillis: Long, scheduler: Scheduler, other: Completable? = null): Completable =
+fun Completable.timeout(timeout: Duration, scheduler: Scheduler, other: Completable? = null): Completable =
     completable { emitter ->
         val onTimeout: () -> Unit =
             {
@@ -38,7 +39,7 @@ fun Completable.timeout(timeoutMillis: Long, scheduler: Scheduler, other: Comple
         scheduler
             .newExecutor()
             .addTo(upstreamObserver)
-            .submit(timeoutMillis, onTimeout)
+            .submit(delay = timeout, task = onTimeout)
 
         subscribe(upstreamObserver)
     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Timer.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Timer.kt
@@ -1,15 +1,16 @@
 package com.badoo.reaktive.completable
 
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
- * Signals `onComplete` after the given [delayMillis] delay.
+ * Signals `onComplete` after the given [delay].
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Completable.html#timer-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).
  */
-fun completableTimer(delayMillis: Long, scheduler: Scheduler): Completable =
+fun completableTimer(delay: Duration, scheduler: Scheduler): Completable =
     completable { emitter ->
         val executor = scheduler.newExecutor()
         emitter.setDisposable(executor)
-        executor.submit(delayMillis, emitter::onComplete)
+        executor.submit(delay = delay, task = emitter::onComplete)
     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Delay.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Delay.kt
@@ -4,6 +4,7 @@ import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
  * Delays `onSuccess` and `onComplete` signals from the current [Maybe] for the specified time.
@@ -11,7 +12,7 @@ import com.badoo.reaktive.scheduler.Scheduler
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Maybe.html#delay-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).
  */
-fun <T> Maybe<T>.delay(delayMillis: Long, scheduler: Scheduler, delayError: Boolean = false): Maybe<T> =
+fun <T> Maybe<T>.delay(delay: Duration, scheduler: Scheduler, delayError: Boolean = false): Maybe<T> =
     maybe { emitter ->
         val disposables = CompositeDisposable()
         emitter.setDisposable(disposables)
@@ -25,18 +26,18 @@ fun <T> Maybe<T>.delay(delayMillis: Long, scheduler: Scheduler, delayError: Bool
                 }
 
                 override fun onSuccess(value: T) {
-                    executor.submit(delayMillis) {
+                    executor.submit(delay = delay) {
                         emitter.onSuccess(value)
                     }
                 }
 
                 override fun onComplete() {
-                    executor.submit(delayMillis, emitter::onComplete)
+                    executor.submit(delay = delay, task = emitter::onComplete)
                 }
 
                 override fun onError(error: Throwable) {
                     if (delayError) {
-                        executor.submit(delayMillis) {
+                        executor.submit(delay = delay) {
                             emitter.onError(error)
                         }
                     } else {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DelaySubscription.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/DelaySubscription.kt
@@ -3,20 +3,19 @@ package com.badoo.reaktive.maybe
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
  * Delays the actual subscription to the [Maybe] for the specified time.
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Maybe.html#delaySubscription-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).
  */
-fun <T> Maybe<T>.delaySubscription(delayMillis: Long, scheduler: Scheduler): Maybe<T> {
-    require(delayMillis >= 0L) { "delayMillis must not be negative" }
-
-    return maybe { emitter ->
+fun <T> Maybe<T>.delaySubscription(delay: Duration, scheduler: Scheduler): Maybe<T> =
+    maybe { emitter ->
         val executor = scheduler.newExecutor()
         emitter.setDisposable(executor)
 
-        executor.submit(delayMillis) {
+        executor.submit(delay = delay) {
             emitter.tryCatch {
                 subscribe(
                     object : MaybeObserver<T>, MaybeCallbacks<T> by emitter {
@@ -28,4 +27,3 @@ fun <T> Maybe<T>.delaySubscription(delayMillis: Long, scheduler: Scheduler): May
             }
         }
     }
-}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Timeout.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Timeout.kt
@@ -5,14 +5,15 @@ import com.badoo.reaktive.base.exceptions.TimeoutException
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.addTo
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
- * Disposes the current [Maybe] if it does not signal within the [timeoutMillis] timeout,
+ * Disposes the current [Maybe] if it does not signal within the [timeout],
  * and subscribes to [other] [Maybe] if provided.
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Maybe.html#timeout-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-io.reactivex.MaybeSource-).
  */
-fun <T> Maybe<T>.timeout(timeoutMillis: Long, scheduler: Scheduler, other: Maybe<T>? = null): Maybe<T> =
+fun <T> Maybe<T>.timeout(timeout: Duration, scheduler: Scheduler, other: Maybe<T>? = null): Maybe<T> =
     maybe { emitter ->
         val onTimeout: () -> Unit =
             {
@@ -40,7 +41,7 @@ fun <T> Maybe<T>.timeout(timeoutMillis: Long, scheduler: Scheduler, other: Maybe
                 }
 
                 fun startTimeout() {
-                    executor.submit(timeoutMillis, onTimeout)
+                    executor.submit(delay = timeout, task = onTimeout)
                 }
             }
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Timer.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Timer.kt
@@ -1,15 +1,16 @@
 package com.badoo.reaktive.maybe
 
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
- * Signals `onSuccess` with [delayMillis] value after the given [delayMillis] delay.
+ * Signals `onSuccess` with [delay] value after the given [delay].
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Maybe.html#timer-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).
  */
-fun maybeTimer(delayMillis: Long, scheduler: Scheduler): Maybe<Long> =
+fun maybeTimer(delay: Duration, scheduler: Scheduler): Maybe<Duration> =
     maybe { emitter ->
         val executor = scheduler.newExecutor()
         emitter.setDisposable(executor)
-        executor.submit(delayMillis) { emitter.onSuccess(delayMillis) }
+        executor.submit(delay = delay) { emitter.onSuccess(delay) }
     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Buffer.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Buffer.kt
@@ -2,6 +2,7 @@ package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
  * Returns an [Observable] that emits non-overlapping windows of elements it collects from the source [Observable].
@@ -9,12 +10,12 @@ import com.badoo.reaktive.scheduler.Scheduler
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/3.x/javadoc/io/reactivex/rxjava3/core/Observable.html#buffer-long-java.util.concurrent.TimeUnit-io.reactivex.rxjava3.core.Scheduler-int-io.reactivex.rxjava3.functions.Supplier-boolean-).
  */
 fun <T> Observable<T>.buffer(
-    spanMillis: Long,
+    span: Duration,
     scheduler: Scheduler,
     limit: Int = Int.MAX_VALUE,
     restartOnLimit: Boolean = false
 ): Observable<List<T>> =
-    window(spanMillis = spanMillis, scheduler = scheduler, limit = limit.toLong(), restartOnLimit = restartOnLimit)
+    window(span = span, scheduler = scheduler, limit = limit.toLong(), restartOnLimit = restartOnLimit)
         .flatMapSingle { it.toList() }
 
 /**
@@ -37,13 +38,13 @@ fun <T> Observable<T>.buffer(
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/3.x/javadoc/io/reactivex/rxjava3/core/Observable.html#buffer-long-long-java.util.concurrent.TimeUnit-io.reactivex.rxjava3.core.Scheduler-).
  */
 fun <T> Observable<T>.buffer(
-    spanMillis: Long,
-    skipMillis: Long,
+    span: Duration,
+    skip: Duration,
     scheduler: Scheduler,
     limit: Long = Long.MAX_VALUE,
     restartOnLimit: Boolean = false
 ): Observable<List<T>> =
-    window(spanMillis = spanMillis, skipMillis = skipMillis, scheduler = scheduler, limit = limit, restartOnLimit = restartOnLimit)
+    window(span = span, skip = skip, scheduler = scheduler, limit = limit, restartOnLimit = restartOnLimit)
         .flatMapSingle { it.toList() }
 
 /**

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Debounce.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Debounce.kt
@@ -9,14 +9,15 @@ import com.badoo.reaktive.scheduler.Scheduler
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import com.badoo.reaktive.utils.atomic.change
 import com.badoo.reaktive.utils.atomic.getAndChange
+import kotlin.time.Duration
 
 /**
  * Returns an [Observable] that mirrors the source [Observable], but drops elements
- * that are followed by newer ones before the [timeoutMillis] timeout expires on a specified [Scheduler].
+ * that are followed by newer ones before the [timeout] expires on a specified [Scheduler].
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#debounce-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).
  */
-fun <T> Observable<T>.debounce(timeoutMillis: Long, scheduler: Scheduler): Observable<T> =
+fun <T> Observable<T>.debounce(timeout: Duration, scheduler: Scheduler): Observable<T> =
     observable { emitter ->
         val disposables = CompositeDisposable()
         emitter.setDisposable(disposables)
@@ -37,7 +38,7 @@ fun <T> Observable<T>.debounce(timeoutMillis: Long, scheduler: Scheduler): Obser
 
                     executor.cancel()
 
-                    executor.submit(timeoutMillis) {
+                    executor.submit(delay = timeout) {
                         pendingValue.change {
                             if (it === newPendingValue) null else it
                         }
@@ -66,6 +67,6 @@ fun <T> Observable<T>.debounce(timeoutMillis: Long, scheduler: Scheduler): Obser
         )
     }
 
-internal class DebouncePendingValue<T>(
+internal class DebouncePendingValue<out T>(
     val value: T
 )

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Delay.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Delay.kt
@@ -4,6 +4,7 @@ import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
  * Delays `onNext` and `onComplete` signals from the current [Observable] for the specified time.
@@ -11,7 +12,7 @@ import com.badoo.reaktive.scheduler.Scheduler
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#delay-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-boolean-).
  */
-fun <T> Observable<T>.delay(delayMillis: Long, scheduler: Scheduler, delayError: Boolean = false): Observable<T> =
+fun <T> Observable<T>.delay(delay: Duration, scheduler: Scheduler, delayError: Boolean = false): Observable<T> =
     observable { emitter ->
         val disposables = CompositeDisposable()
         emitter.setDisposable(disposables)
@@ -25,18 +26,18 @@ fun <T> Observable<T>.delay(delayMillis: Long, scheduler: Scheduler, delayError:
                 }
 
                 override fun onNext(value: T) {
-                    executor.submit(delayMillis) {
+                    executor.submit(delay = delay) {
                         emitter.onNext(value)
                     }
                 }
 
                 override fun onComplete() {
-                    executor.submit(delayMillis, emitter::onComplete)
+                    executor.submit(delay = delay, task = emitter::onComplete)
                 }
 
                 override fun onError(error: Throwable) {
                     if (delayError) {
-                        executor.submit(delayMillis) {
+                        executor.submit(delay = delay) {
                             emitter.onError(error)
                         }
                     } else {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DelaySubscription.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/DelaySubscription.kt
@@ -3,20 +3,19 @@ package com.badoo.reaktive.observable
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
  * Delays the actual subscription to the [Observable] for the specified time.
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#delaySubscription-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).
  */
-fun <T> Observable<T>.delaySubscription(delayMillis: Long, scheduler: Scheduler): Observable<T> {
-    require(delayMillis >= 0L) { "delayMillis must not be negative" }
-
-    return observable { emitter ->
+fun <T> Observable<T>.delaySubscription(delay: Duration, scheduler: Scheduler): Observable<T> =
+    observable { emitter ->
         val executor = scheduler.newExecutor()
         emitter.setDisposable(executor)
 
-        executor.submit(delayMillis) {
+        executor.submit(delay = delay) {
             emitter.tryCatch {
                 subscribe(
                     object : ObservableObserver<T>, ObservableCallbacks<T> by emitter {
@@ -28,4 +27,3 @@ fun <T> Observable<T>.delaySubscription(delayMillis: Long, scheduler: Scheduler)
             }
         }
     }
-}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Interval.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Interval.kt
@@ -1,22 +1,23 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
- * Returns an [Observable] that emits `0L` after [startDelayMillis] and
- * ever increasing numbers after each period of time specified by [periodMillis], on a specified [Scheduler].
+ * Returns an [Observable] that emits `0L` after [startDelay] and
+ * ever increasing numbers after each period of time specified by [period], on a specified [Scheduler].
  *
  * Default start delay is equal to the specified period
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#interval-long-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).
  */
-fun observableInterval(periodMillis: Long, startDelayMillis: Long = periodMillis, scheduler: Scheduler): Observable<Long> =
+fun observableInterval(period: Duration, startDelay: Duration = period, scheduler: Scheduler): Observable<Long> =
     observable { emitter ->
         val executor = scheduler.newExecutor()
         emitter.setDisposable(executor)
 
         var count = 0L
-        executor.submitRepeating(startDelayMillis, periodMillis) {
+        executor.submit(delay = startDelay, period = period) {
             emitter.onNext(count++)
         }
     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Sample.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Sample.kt
@@ -6,6 +6,7 @@ import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
 import com.badoo.reaktive.utils.atomic.AtomicReference
 import com.badoo.reaktive.utils.atomic.getAndChange
+import kotlin.time.Duration
 
 /**
  * Returns an [Observable] that emits the most recently emitted element (if any)
@@ -13,7 +14,7 @@ import com.badoo.reaktive.utils.atomic.getAndChange
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#sample-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).
  */
-fun <T> Observable<T>.sample(windowMillis: Long, scheduler: Scheduler): Observable<T> =
+fun <T> Observable<T>.sample(window: Duration, scheduler: Scheduler): Observable<T> =
     observable { emitter ->
         val disposables = CompositeDisposable()
         emitter.setDisposable(disposables)
@@ -27,7 +28,7 @@ fun <T> Observable<T>.sample(windowMillis: Long, scheduler: Scheduler): Observab
                 override fun onSubscribe(disposable: Disposable) {
                     disposables += disposable
 
-                    executor.submitRepeating(startDelayMillis = windowMillis, periodMillis = windowMillis) {
+                    executor.submit(delay = window, period = window) {
                         lastValue.getAndChange { null }?.also {
                             emitter.onNext(it.value)
                         }
@@ -51,6 +52,6 @@ fun <T> Observable<T>.sample(windowMillis: Long, scheduler: Scheduler): Observab
         )
     }
 
-private class SampleLastValue<T>(
+private class SampleLastValue<out T>(
     val value: T
 )

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Throttle.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Throttle.kt
@@ -5,17 +5,18 @@ import com.badoo.reaktive.disposable.addTo
 import com.badoo.reaktive.scheduler.Scheduler
 import com.badoo.reaktive.scheduler.computationScheduler
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
+import kotlin.time.Duration
 
 /**
  * Returns an [Observable] that emits only the first element emitted by the source [Observable] during a time window
- * defined by [windowMillis], which begins with the emitted element.
+ * defined by [window], which begins with the emitted element.
  *
  * Values are emitted on the upstream thread, the [scheduler] is used only for timings.
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#throttleFirst-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).
  */
-fun <T> Observable<T>.throttle(windowMillis: Long, scheduler: Scheduler = computationScheduler): Observable<T> {
-    if (windowMillis <= 0) {
+fun <T> Observable<T>.throttle(window: Duration, scheduler: Scheduler = computationScheduler): Observable<T> {
+    if (!window.isPositive()) {
         return this
     }
 
@@ -32,7 +33,7 @@ fun <T> Observable<T>.throttle(windowMillis: Long, scheduler: Scheduler = comput
                 override fun onNext(value: T) {
                     if (gate.compareAndSet(false, true)) {
                         emitter.onNext(value)
-                        executor.submit(delayMillis = windowMillis) { gate.value = false }
+                        executor.submit(delay = window) { gate.value = false }
                     }
                 }
             }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ThrottleLatest.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/ThrottleLatest.kt
@@ -13,20 +13,19 @@ import com.badoo.reaktive.scheduler.Scheduler
 import com.badoo.reaktive.utils.Uninitialized
 import com.badoo.reaktive.utils.serializer.Serializer
 import com.badoo.reaktive.utils.serializer.serializer
+import kotlin.time.Duration
 
 /**
- * Emits a first element from the source [Observable] and opens a time window specified by [timeoutMillis].
+ * Emits a first element from the source [Observable] and opens a time window specified by [timeout].
  * Then does not emit any elements from the source [Observable] while the time window is open, and only emits a
  * most recent element when the time window closes.
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#throttleLatest-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-boolean-)
  */
-fun <T> Observable<T>.throttleLatest(timeoutMillis: Long, scheduler: Scheduler, emitLast: Boolean = false): Observable<T> {
-    require(timeoutMillis >= 0L) { "Timeout must not be negative" }
+fun <T> Observable<T>.throttleLatest(timeout: Duration, scheduler: Scheduler, emitLast: Boolean = false): Observable<T> {
+    val timeoutTimer = completableTimer(timeout, scheduler)
 
-    val timeout = completableTimer(timeoutMillis, scheduler)
-
-    return throttleLatest(timeout = { timeout }, emitLast = emitLast)
+    return throttleLatest(timeout = { timeoutTimer }, emitLast = emitLast)
 }
 
 /**

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Timeout.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Timeout.kt
@@ -6,15 +6,16 @@ import com.badoo.reaktive.completable.CompletableCallbacks
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.addTo
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
  * Returns an [Observable] that emits elements from the source [Observable] and counts a timeout specified by
- * [timeoutMillis]. If the timeout ever hits, disposes the source [Observable] and subscribes to the
+ * [timeout]. If the timeout ever hits, disposes the source [Observable] and subscribes to the
  * [other][other] [Observable], if any.
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#timeout-io.reactivex.functions.Function-io.reactivex.ObservableSource-).
  */
-fun <T> Observable<T>.timeout(timeoutMillis: Long, scheduler: Scheduler, other: Observable<T>? = null): Observable<T> =
+fun <T> Observable<T>.timeout(timeout: Duration, scheduler: Scheduler, other: Observable<T>? = null): Observable<T> =
     observable { emitter ->
         val onTimeout: () -> Unit =
             {
@@ -43,7 +44,7 @@ fun <T> Observable<T>.timeout(timeoutMillis: Long, scheduler: Scheduler, other: 
                 }
 
                 fun startTimeout() {
-                    executor.submit(timeoutMillis, onTimeout)
+                    executor.submit(delay = timeout, task = onTimeout)
                 }
             }
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Timer.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Timer.kt
@@ -1,18 +1,19 @@
 package com.badoo.reaktive.observable
 
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
- * Signals `onNext` with [delayMillis] value after the given [delayMillis] delay, and then completes.
+ * Signals `onNext` with [delay] value after the given [delay] delay, and then completes.
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#timer-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).
  */
-fun observableTimer(delayMillis: Long, scheduler: Scheduler): Observable<Long> =
+fun observableTimer(delay: Duration, scheduler: Scheduler): Observable<Duration> =
     observable { emitter ->
         val executor = scheduler.newExecutor()
         emitter.setDisposable(executor)
-        executor.submit(delayMillis) {
-            emitter.onNext(delayMillis)
+        executor.submit(delay = delay) {
+            emitter.onNext(delay)
             emitter.onComplete()
         }
     }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/WindowByBoundary.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/WindowByBoundary.kt
@@ -11,6 +11,7 @@ import com.badoo.reaktive.subject.unicast.UnicastSubject
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import com.badoo.reaktive.utils.serializer.Serializer
 import com.badoo.reaktive.utils.serializer.serializer
+import kotlin.time.Duration
 
 /**
  * Returns an [Observable] that emits non-overlapping windows of elements it collects from the source [Observable].
@@ -18,15 +19,15 @@ import com.badoo.reaktive.utils.serializer.serializer
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#window-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-long-boolean-).
  */
 fun <T> Observable<T>.window(
-    spanMillis: Long,
+    span: Duration,
     scheduler: Scheduler,
     limit: Long = Long.MAX_VALUE,
     restartOnLimit: Boolean = false
 ): Observable<Observable<T>> {
-    require(spanMillis > 0) { "spanMillis must by positive" }
+    require(span.isPositive()) { "Span duration must by positive" }
 
     return window(
-        boundaries = singleOf(Unit).delay(spanMillis, scheduler).repeat(),
+        boundaries = singleOf(Unit).delay(span, scheduler).repeat(),
         limit = limit,
         restartOnLimit = restartOnLimit
     )

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/WindowBySignal.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/WindowBySignal.kt
@@ -16,6 +16,7 @@ import com.badoo.reaktive.subject.unicast.UnicastSubject
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
 import com.badoo.reaktive.utils.serializer.Serializer
 import com.badoo.reaktive.utils.serializer.serializer
+import kotlin.time.Duration
 
 /**
  * Returns an [Observable] that emits possibly overlapping windows of elements it collects from the source [Observable].
@@ -24,18 +25,18 @@ import com.badoo.reaktive.utils.serializer.serializer
  * [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#window-long-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).
  */
 fun <T> Observable<T>.window(
-    spanMillis: Long,
-    skipMillis: Long,
+    span: Duration,
+    skip: Duration,
     scheduler: Scheduler,
     limit: Long = Long.MAX_VALUE,
     restartOnLimit: Boolean = false
 ): Observable<Observable<T>> {
-    require(spanMillis > 0) { "spanMillis must by positive" }
-    require(skipMillis > 0) { "skipMillis must by positive" }
+    require(span.isPositive()) { "Span duration must by positive" }
+    require(skip.isPositive()) { "Skip duration must by positive" }
 
     return window(
-        opening = singleOf(Unit).repeatWhen { _, _ -> maybeTimer(skipMillis, scheduler) },
-        closing = { completableTimer(spanMillis, scheduler) },
+        opening = singleOf(Unit).repeatWhen { _, _ -> maybeTimer(skip, scheduler) },
+        closing = { completableTimer(span, scheduler) },
         limit = limit,
         restartOnLimit = restartOnLimit
     )

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/scheduler/Scheduler.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/scheduler/Scheduler.kt
@@ -2,7 +2,6 @@ package com.badoo.reaktive.scheduler
 
 import com.badoo.reaktive.disposable.Disposable
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Base interface for schedulers.
@@ -45,22 +44,6 @@ interface Scheduler {
             period: Duration = Duration.INFINITE,
             task: () -> Unit,
         )
-
-        /**
-         * Submits a new tasks for execution
-         *
-         * @param delayMillis a delayMillis in milliseconds before execution
-         * @param task the task to be executed
-         */
-        @Deprecated("Remove in the next PR")
-        fun submit(delayMillis: Long = 0L, task: () -> Unit) {
-            submit(delay = delayMillis.milliseconds, task = task)
-        }
-
-        @Deprecated("Remove in the next PR")
-        fun submitRepeating(startDelayMillis: Long = 0L, periodMillis: Long, task: () -> Unit) {
-            submit(delay = startDelayMillis.milliseconds, period = periodMillis.milliseconds, task = task)
-        }
 
         /**
          * Cancels all tasks. All running tasks will be interrupted, all pending tasks will not be executed.

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Delay.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Delay.kt
@@ -4,6 +4,7 @@ import com.badoo.reaktive.disposable.CompositeDisposable
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.plusAssign
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
  * Delays `onSuccess` signal from the current [Single] for the specified time.
@@ -11,7 +12,7 @@ import com.badoo.reaktive.scheduler.Scheduler
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Single.html#delay-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-boolean-).
  */
-fun <T> Single<T>.delay(delayMillis: Long, scheduler: Scheduler, delayError: Boolean = false): Single<T> =
+fun <T> Single<T>.delay(delay: Duration, scheduler: Scheduler, delayError: Boolean = false): Single<T> =
     single { emitter ->
         val disposables = CompositeDisposable()
         emitter.setDisposable(disposables)
@@ -25,14 +26,14 @@ fun <T> Single<T>.delay(delayMillis: Long, scheduler: Scheduler, delayError: Boo
                 }
 
                 override fun onSuccess(value: T) {
-                    executor.submit(delayMillis) {
+                    executor.submit(delay = delay) {
                         emitter.onSuccess(value)
                     }
                 }
 
                 override fun onError(error: Throwable) {
                     if (delayError) {
-                        executor.submit(delayMillis) {
+                        executor.submit(delay = delay) {
                             emitter.onError(error)
                         }
                     } else {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/DelaySubscription.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/DelaySubscription.kt
@@ -3,20 +3,19 @@ package com.badoo.reaktive.single
 import com.badoo.reaktive.base.tryCatch
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
  * Delays the actual subscription to the [Single] for the specified time.
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Single.html#delaySubscription-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).
  */
-fun <T> Single<T>.delaySubscription(delayMillis: Long, scheduler: Scheduler): Single<T> {
-    require(delayMillis >= 0L) { "delayMillis must not be negative" }
-
-    return single { emitter ->
+fun <T> Single<T>.delaySubscription(delay: Duration, scheduler: Scheduler): Single<T> =
+    single { emitter ->
         val executor = scheduler.newExecutor()
         emitter.setDisposable(executor)
 
-        executor.submit(delayMillis) {
+        executor.submit(delay = delay) {
             emitter.tryCatch {
                 subscribe(
                     object : SingleObserver<T>, SingleCallbacks<T> by emitter {
@@ -28,4 +27,3 @@ fun <T> Single<T>.delaySubscription(delayMillis: Long, scheduler: Scheduler): Si
             }
         }
     }
-}

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Timeout.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Timeout.kt
@@ -5,14 +5,15 @@ import com.badoo.reaktive.base.exceptions.TimeoutException
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.disposable.addTo
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
- * Disposes the current [Single] if it does not signal within the [timeoutMillis] timeout,
+ * Disposes the current [Single] if it does not signal within the [timeout],
  * and subscribes to [other] [Single] if provided.
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Single.html#timeout-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-io.reactivex.SingleSource-).
  */
-fun <T> Single<T>.timeout(timeoutMillis: Long, scheduler: Scheduler, other: Single<T>? = null): Single<T> =
+fun <T> Single<T>.timeout(timeout: Duration, scheduler: Scheduler, other: Single<T>? = null): Single<T> =
     single { emitter ->
         val onTimeout: () -> Unit =
             {
@@ -40,7 +41,7 @@ fun <T> Single<T>.timeout(timeoutMillis: Long, scheduler: Scheduler, other: Sing
                 }
 
                 fun startTimeout() {
-                    executor.submit(timeoutMillis, onTimeout)
+                    executor.submit(delay = timeout, task = onTimeout)
                 }
             }
 

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Timer.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Timer.kt
@@ -1,15 +1,16 @@
 package com.badoo.reaktive.single
 
 import com.badoo.reaktive.scheduler.Scheduler
+import kotlin.time.Duration
 
 /**
- * Signals `onSuccess` with [delayMillis] value after the given [delayMillis] delay.
+ * Signals `onSuccess` with [delay] value after the given [delay].
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Single.html#timer-long-java.util.concurrent.TimeUnit-io.reactivex.Scheduler-).
  */
-fun singleTimer(delayMillis: Long, scheduler: Scheduler): Single<Long> =
+fun singleTimer(delay: Duration, scheduler: Scheduler): Single<Duration> =
     single { emitter ->
         val executor = scheduler.newExecutor()
         emitter.setDisposable(executor)
-        executor.submit(delayMillis) { emitter.onSuccess(delayMillis) }
+        executor.submit(delay = delay) { emitter.onSuccess(delay) }
     }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DelaySubscriptionTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DelaySubscriptionTest.kt
@@ -8,16 +8,17 @@ import com.badoo.reaktive.test.scheduler.assertAllExecutorsDisposed
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.time.Duration.Companion.milliseconds
 
 class DelaySubscriptionTest :
-    CompletableToCompletableTests by CompletableToCompletableTestsImpl({ delaySubscription(0L, TestScheduler()) }) {
+    CompletableToCompletableTests by CompletableToCompletableTestsImpl({ delaySubscription(0.milliseconds, TestScheduler()) }) {
 
     private val upstream = TestCompletable()
     private val scheduler = TestScheduler()
 
     @Test
     fun does_not_subscribe_to_upstream_WHEN_timeout_not_reached() {
-        upstream.delaySubscription(delayMillis = 10L, scheduler = scheduler).test()
+        upstream.delaySubscription(delay = 10.milliseconds, scheduler = scheduler).test()
 
         scheduler.timer.advanceBy(9L)
 
@@ -26,7 +27,7 @@ class DelaySubscriptionTest :
 
     @Test
     fun subscribes_to_upstream_only_once_WHEN_timeout_reached() {
-        upstream.delaySubscription(delayMillis = 10L, scheduler = scheduler).test()
+        upstream.delaySubscription(delay = 10.milliseconds, scheduler = scheduler).test()
 
         scheduler.timer.advanceBy(10L)
 
@@ -35,7 +36,7 @@ class DelaySubscriptionTest :
 
     @Test
     fun disposes_executor_WHEN_timeout_reached() {
-        upstream.delaySubscription(delayMillis = 10L, scheduler = scheduler).test()
+        upstream.delaySubscription(delay = 10.milliseconds, scheduler = scheduler).test()
 
         scheduler.timer.advanceBy(10L)
 
@@ -44,7 +45,7 @@ class DelaySubscriptionTest :
 
     @Test
     fun disposes_executor_WHEN_disposed() {
-        val observer = upstream.delaySubscription(delayMillis = 10L, scheduler = scheduler).test()
+        val observer = upstream.delaySubscription(delay = 10.milliseconds, scheduler = scheduler).test()
 
         observer.dispose()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DelayTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/DelayTest.kt
@@ -8,18 +8,20 @@ import com.badoo.reaktive.test.completable.assertNotComplete
 import com.badoo.reaktive.test.completable.test
 import com.badoo.reaktive.test.scheduler.TestScheduler
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class DelayTest :
-    CompletableToCompletableTests by CompletableToCompletableTestsImpl({ delay(0L, TestScheduler()) }),
+    CompletableToCompletableTests by CompletableToCompletableTestsImpl({ delay(0.milliseconds, TestScheduler()) }),
     DelayErrorTests by DelayErrorTests(
         TestCompletable(),
-        { delayMillis, scheduler, delayError -> delay(delayMillis, scheduler, delayError).test() }
+        { delay, scheduler, delayError -> delay(delay, scheduler, delayError).test() }
     ) {
 
     private val upstream = TestCompletable()
     private val scheduler = TestScheduler()
     private val timer = scheduler.timer
-    private val observer = upstream.delay(1000L, scheduler).test()
+    private val observer = upstream.delay(1.seconds, scheduler).test()
 
     @Test
     fun does_not_complete_synchronously() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/TimeoutTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/TimeoutTest.kt
@@ -11,8 +11,9 @@ import com.badoo.reaktive.test.scheduler.TestScheduler
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
-class TimeoutTest : CompletableToCompletableTests by CompletableToCompletableTestsImpl({ timeout(1000L, TestScheduler()) }) {
+class TimeoutTest : CompletableToCompletableTests by CompletableToCompletableTestsImpl({ timeout(1.seconds, TestScheduler()) }) {
 
     private val upstream = TestCompletable()
     private val other = TestCompletable()
@@ -20,7 +21,7 @@ class TimeoutTest : CompletableToCompletableTests by CompletableToCompletableTes
 
     @Test
     fun completes_WHEN_other_completed() {
-        val observer = upstream.timeout(1000L, scheduler, other).test()
+        val observer = upstream.timeout(1.seconds, scheduler, other).test()
 
         scheduler.timer.advanceBy(1000L)
         other.onComplete()
@@ -30,7 +31,7 @@ class TimeoutTest : CompletableToCompletableTests by CompletableToCompletableTes
 
     @Test
     fun produces_error_WHEN_other_produced_error() {
-        val observer = upstream.timeout(1000L, scheduler, other).test()
+        val observer = upstream.timeout(1.seconds, scheduler, other).test()
         val error = Exception()
 
         scheduler.timer.advanceBy(1000L)
@@ -41,7 +42,7 @@ class TimeoutTest : CompletableToCompletableTests by CompletableToCompletableTes
 
     @Test
     fun does_not_produce_error_WHEN_timeout_not_reached_after_subscribe() {
-        val observer = upstream.timeout(1000L, scheduler).test()
+        val observer = upstream.timeout(1.seconds, scheduler).test()
 
         scheduler.timer.advanceBy(999L)
 
@@ -50,7 +51,7 @@ class TimeoutTest : CompletableToCompletableTests by CompletableToCompletableTes
 
     @Test
     fun produces_error_WHEN_timeout_reached_after_subscribe() {
-        val observer = upstream.timeout(1000L, scheduler).test()
+        val observer = upstream.timeout(1.seconds, scheduler).test()
 
         scheduler.timer.advanceBy(1000L)
 
@@ -59,7 +60,7 @@ class TimeoutTest : CompletableToCompletableTests by CompletableToCompletableTes
 
     @Test
     fun does_not_subscribe_to_other_WHEN_timeout_not_reached_after_subscribe() {
-        upstream.timeout(1000L, scheduler, other).test()
+        upstream.timeout(1.seconds, scheduler, other).test()
 
         scheduler.timer.advanceBy(999L)
 
@@ -68,7 +69,7 @@ class TimeoutTest : CompletableToCompletableTests by CompletableToCompletableTes
 
     @Test
     fun subscribes_to_other_WHEN_timeout_reached_after_subscribe() {
-        upstream.timeout(1000L, scheduler, other).test()
+        upstream.timeout(1.seconds, scheduler, other).test()
 
         scheduler.timer.advanceBy(1000L)
 
@@ -77,7 +78,7 @@ class TimeoutTest : CompletableToCompletableTests by CompletableToCompletableTes
 
     @Test
     fun does_not_produce_error_WHEN_timeout_reached_after_subscribe_and_has_other() {
-        val observer = upstream.timeout(1000L, scheduler, other).test()
+        val observer = upstream.timeout(1.seconds, scheduler, other).test()
 
         scheduler.timer.advanceBy(1000L)
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/TimerTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/completable/TimerTest.kt
@@ -11,12 +11,13 @@ import com.badoo.reaktive.test.scheduler.TestScheduler
 import com.badoo.reaktive.test.scheduler.assertAllExecutorsDisposed
 import kotlin.test.Test
 import kotlin.test.assertFalse
+import kotlin.time.Duration.Companion.seconds
 
 class TimerTest {
 
     private val scheduler = TestScheduler()
     private val timer = scheduler.timer
-    private val upstream = completableTimer(1000L, scheduler)
+    private val upstream = completableTimer(1.seconds, scheduler)
     private val observer = upstream.test()
 
     @Test
@@ -94,5 +95,4 @@ class TimerTest {
         observer.dispose()
         observer.assertNotError()
     }
-
 }

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DelaySubscriptionTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DelaySubscriptionTest.kt
@@ -9,16 +9,17 @@ import com.badoo.reaktive.test.scheduler.assertAllExecutorsDisposed
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.time.Duration.Companion.milliseconds
 
 class DelaySubscriptionTest :
-    MaybeToMaybeTests by MaybeToMaybeTestsImpl({ delaySubscription(0L, TestScheduler()) }) {
+    MaybeToMaybeTests by MaybeToMaybeTestsImpl({ delaySubscription(0.milliseconds, TestScheduler()) }) {
 
     private val upstream = TestMaybe<Int?>()
     private val scheduler = TestScheduler()
 
     @Test
     fun does_not_subscribe_to_upstream_WHEN_timeout_not_reached() {
-        upstream.delaySubscription(delayMillis = 10L, scheduler = scheduler).test()
+        upstream.delaySubscription(delay = 10.milliseconds, scheduler = scheduler).test()
 
         scheduler.timer.advanceBy(9L)
 
@@ -27,7 +28,7 @@ class DelaySubscriptionTest :
 
     @Test
     fun subscribes_to_upstream_only_once_WHEN_timeout_reached() {
-        upstream.delaySubscription(delayMillis = 10L, scheduler = scheduler).test()
+        upstream.delaySubscription(delay = 10.milliseconds, scheduler = scheduler).test()
 
         scheduler.timer.advanceBy(10L)
 
@@ -36,7 +37,7 @@ class DelaySubscriptionTest :
 
     @Test
     fun succeeds_WHEN_upstream_succeeded() {
-        val observer = upstream.delaySubscription(delayMillis = 0L, scheduler = scheduler).test()
+        val observer = upstream.delaySubscription(delay = 0.milliseconds, scheduler = scheduler).test()
 
         upstream.onSuccess(null)
 
@@ -45,7 +46,7 @@ class DelaySubscriptionTest :
 
     @Test
     fun disposes_executor_WHEN_timeout_reached() {
-        upstream.delaySubscription(delayMillis = 10L, scheduler = scheduler).test()
+        upstream.delaySubscription(delay = 10.milliseconds, scheduler = scheduler).test()
 
         scheduler.timer.advanceBy(10L)
 
@@ -54,7 +55,7 @@ class DelaySubscriptionTest :
 
     @Test
     fun disposes_executor_WHEN_disposed() {
-        val observer = upstream.delaySubscription(delayMillis = 10L, scheduler = scheduler).test()
+        val observer = upstream.delaySubscription(delay = 10.milliseconds, scheduler = scheduler).test()
 
         observer.dispose()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DelayTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/DelayTest.kt
@@ -10,9 +10,11 @@ import com.badoo.reaktive.test.maybe.assertSuccess
 import com.badoo.reaktive.test.maybe.test
 import com.badoo.reaktive.test.scheduler.TestScheduler
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class DelayTest :
-    MaybeToMaybeTests by MaybeToMaybeTestsImpl({ delay(0L, TestScheduler()) }),
+    MaybeToMaybeTests by MaybeToMaybeTestsImpl({ delay(0.milliseconds, TestScheduler()) }),
     DelayErrorTests by DelayErrorTests<TestMaybe<Int>>(
         TestMaybe(),
         { delayMillis, scheduler, delayError -> delay(delayMillis, scheduler, delayError).test() }
@@ -21,7 +23,7 @@ class DelayTest :
     private val upstream = TestMaybe<Int?>()
     private val scheduler = TestScheduler()
     private val timer = scheduler.timer
-    private val observer = upstream.delay(1000L, scheduler).test()
+    private val observer = upstream.delay(1.seconds, scheduler).test()
 
     @Test
     fun does_not_succeed_IF_timeout_not_reached() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/TimeoutTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/TimeoutTest.kt
@@ -14,8 +14,9 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
-class TimeoutTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ timeout(1000L, TestScheduler()) }) {
+class TimeoutTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ timeout(1.seconds, TestScheduler()) }) {
 
     private val upstream = TestMaybe<Int?>()
     private val other = TestMaybe<Int?>()
@@ -26,7 +27,7 @@ class TimeoutTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ timeout(1000L, 
         var errorRef: Throwable? = null
 
         upstream
-            .timeout(1000L, scheduler)
+            .timeout(1.seconds, scheduler)
             .subscribe(
                 object : MaybeObserver<Int?> {
                     override fun onSubscribe(disposable: Disposable) {
@@ -52,7 +53,7 @@ class TimeoutTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ timeout(1000L, 
 
     @Test
     fun succeeds_WHEN_other_succeeds() {
-        val observer = upstream.timeout(1000L, scheduler, other).test()
+        val observer = upstream.timeout(1.seconds, scheduler, other).test()
 
         scheduler.timer.advanceBy(1000L)
         observer.reset()
@@ -63,7 +64,7 @@ class TimeoutTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ timeout(1000L, 
 
     @Test
     fun completes_WHEN_other_completed() {
-        val observer = upstream.timeout(1000L, scheduler, other).test()
+        val observer = upstream.timeout(1.seconds, scheduler, other).test()
 
         scheduler.timer.advanceBy(1000L)
         other.onComplete()
@@ -73,7 +74,7 @@ class TimeoutTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ timeout(1000L, 
 
     @Test
     fun produces_error_WHEN_other_produced_error() {
-        val observer = upstream.timeout(1000L, scheduler, other).test()
+        val observer = upstream.timeout(1.seconds, scheduler, other).test()
         val error = Exception()
 
         scheduler.timer.advanceBy(1000L)
@@ -84,7 +85,7 @@ class TimeoutTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ timeout(1000L, 
 
     @Test
     fun does_not_produce_error_WHEN_timeout_not_reached_after_subscribe() {
-        val observer = upstream.timeout(1000L, scheduler).test()
+        val observer = upstream.timeout(1.seconds, scheduler).test()
 
         scheduler.timer.advanceBy(999L)
 
@@ -93,7 +94,7 @@ class TimeoutTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ timeout(1000L, 
 
     @Test
     fun produces_error_WHEN_timeout_reached_after_subscribe() {
-        val observer = upstream.timeout(1000L, scheduler).test()
+        val observer = upstream.timeout(1.seconds, scheduler).test()
 
         scheduler.timer.advanceBy(1000L)
 
@@ -102,7 +103,7 @@ class TimeoutTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ timeout(1000L, 
 
     @Test
     fun does_not_subscribe_to_other_WHEN_timeout_not_reached_after_subscribe() {
-        upstream.timeout(1000L, scheduler, other).test()
+        upstream.timeout(1.seconds, scheduler, other).test()
 
         scheduler.timer.advanceBy(999L)
 
@@ -111,7 +112,7 @@ class TimeoutTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ timeout(1000L, 
 
     @Test
     fun subscribes_to_other_WHEN_timeout_reached_after_subscribe() {
-        upstream.timeout(1000L, scheduler, other).test()
+        upstream.timeout(1.seconds, scheduler, other).test()
 
         scheduler.timer.advanceBy(1000L)
 
@@ -120,7 +121,7 @@ class TimeoutTest : MaybeToMaybeTests by MaybeToMaybeTestsImpl({ timeout(1000L, 
 
     @Test
     fun does_not_produce_error_WHEN_timeout_reached_after_subscribe_and_has_other() {
-        val observer = upstream.timeout(1000L, scheduler, other).test()
+        val observer = upstream.timeout(1.seconds, scheduler, other).test()
 
         scheduler.timer.advanceBy(1000L)
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/TimerTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/maybe/TimerTest.kt
@@ -12,13 +12,13 @@ import com.badoo.reaktive.test.scheduler.TestScheduler
 import com.badoo.reaktive.test.scheduler.assertAllExecutorsDisposed
 import kotlin.test.Test
 import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 class TimerTest {
 
     private val scheduler = TestScheduler()
     private val timer = scheduler.timer
-    private val upstream = maybeTimer(1000L, scheduler)
+    private val upstream = maybeTimer(1.seconds, scheduler)
     private val observer = upstream.test()
 
     @Test
@@ -57,7 +57,7 @@ class TimerTest {
     @Test
     fun succeed_WHEN_timeout_reached() {
         timer.advanceBy(1000L)
-        observer.assertSuccess(1000L)
+        observer.assertSuccess(1.seconds)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/BufferSimpleTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/BufferSimpleTests.kt
@@ -7,6 +7,8 @@ import com.badoo.reaktive.test.observable.onNext
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.scheduler.TestScheduler
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class BufferSimpleTests {
 
@@ -16,7 +18,7 @@ class BufferSimpleTests {
     fun buffer_spanMillis_emits_correct_values() {
         val scheduler = TestScheduler()
         val timer = scheduler.timer
-        val observer = upstream.buffer(spanMillis = 1000L, scheduler = scheduler, limit = 3).test()
+        val observer = upstream.buffer(span = 1.seconds, scheduler = scheduler, limit = 3).test()
 
         upstream.onNext(1, 2)
         timer.advanceBy(999L)
@@ -75,7 +77,7 @@ class BufferSimpleTests {
     fun buffer_spanMillis_skipMillis_emits_correct_values() {
         val scheduler = TestScheduler()
         val timer = scheduler.timer
-        val observer = upstream.buffer(spanMillis = 1000L, skipMillis = 600L, scheduler = scheduler, limit = 13).test()
+        val observer = upstream.buffer(span = 1.seconds, skip = 600.milliseconds, scheduler = scheduler, limit = 13).test()
 
         upstream.onNext(1, 2)
         timer.advanceBy(599L)

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DebounceTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DebounceTest.kt
@@ -8,13 +8,15 @@ import com.badoo.reaktive.test.observable.assertValues
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.scheduler.TestScheduler
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class DebounceTest
-    : ObservableToObservableTests by ObservableToObservableTestsImpl({ debounce(0L, TestScheduler()) }) {
+    : ObservableToObservableTests by ObservableToObservableTestsImpl({ debounce(0.seconds, TestScheduler()) }) {
 
     private val upstream = TestObservable<Int?>()
     private val scheduler = TestScheduler()
-    private val observer = upstream.debounce(100L, scheduler).test()
+    private val observer = upstream.debounce(100.milliseconds, scheduler).test()
 
     @Test
     fun does_not_emit_WHEN_timeout_not_reached() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DebounceWithSelectorTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DebounceWithSelectorTest.kt
@@ -18,9 +18,11 @@ import com.badoo.reaktive.test.scheduler.TestScheduler
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class DebounceWithSelectorTest :
-    ObservableToObservableTests by ObservableToObservableTestsImpl({ debounce { completableTimer(0L, TestScheduler()) } }) {
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ debounce { completableTimer(0.seconds, TestScheduler()) } }) {
 
     private val upstream = TestObservable<String?>()
     private val scheduler = TestScheduler()
@@ -311,7 +313,7 @@ class DebounceWithSelectorTest :
     }
 
     private fun createDefaultObserver(): TestObservableObserver<String?> = upstream.debounce { value ->
-        if (value.isNullOrEmpty()) completableOfEmpty() else completableTimer(100L, scheduler)
+        if (value.isNullOrEmpty()) completableOfEmpty() else completableTimer(100.milliseconds, scheduler)
     }.test()
 
     private fun createInnerSources(count: Int): List<TestCompletable> =

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DelayErrorTests.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DelayErrorTests.kt
@@ -7,6 +7,8 @@ import com.badoo.reaktive.test.base.assertError
 import com.badoo.reaktive.test.base.assertNotError
 import com.badoo.reaktive.test.scheduler.TestScheduler
 import kotlin.test.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 interface DelayErrorTests {
 
@@ -28,12 +30,12 @@ interface DelayErrorTests {
     companion object {
         operator fun <S : ErrorCallback> invoke(
             upstream: S,
-            delay: S.(delayMillis: Long, scheduler: Scheduler, delayError: Boolean) -> TestObserver
+            delay: S.(delay: Duration, scheduler: Scheduler, delayError: Boolean) -> TestObserver
         ): DelayErrorTests =
             object : DelayErrorTests {
                 override fun does_not_produce_error_synchronously_with_delayError_false_WHEN_upstream_produced_error() {
                     val scheduler = TestScheduler(isManualProcessing = true)
-                    val observer = upstream.delay(1000L, scheduler, false)
+                    val observer = upstream.delay(1.seconds, scheduler, false)
 
                     upstream.onError(Exception())
 
@@ -42,7 +44,7 @@ interface DelayErrorTests {
 
                 override fun produces_error_without_delay_with_delayError_false_WHEN_upstream_produced_error() {
                     val scheduler = TestScheduler()
-                    val observer = upstream.delay(1000L, scheduler, false)
+                    val observer = upstream.delay(1.seconds, scheduler, false)
                     val error = Exception()
 
                     upstream.onError(error)
@@ -52,7 +54,7 @@ interface DelayErrorTests {
 
                 override fun does_not_produce_error_synchronously_with_delayError_true_WHEN_upstream_produced_error() {
                     val scheduler = TestScheduler(isManualProcessing = true)
-                    val observer = upstream.delay(1000L, scheduler, true)
+                    val observer = upstream.delay(1.seconds, scheduler, true)
 
                     upstream.onError(Exception())
 
@@ -61,7 +63,7 @@ interface DelayErrorTests {
 
                 override fun does_not_produce_error_with_delayError_true_WHEN_upstream_produced_error_and_timeout_not_reached() {
                     val scheduler = TestScheduler()
-                    val observer = upstream.delay(1000L, scheduler, true)
+                    val observer = upstream.delay(1.seconds, scheduler, true)
 
                     upstream.onError(Exception())
                     scheduler.timer.advanceBy(999L)
@@ -71,7 +73,7 @@ interface DelayErrorTests {
 
                 override fun produces_error_with_delayError_is_true_WHEN_upstream_produced_error_and_timeout_reached() {
                     val scheduler = TestScheduler()
-                    val observer = upstream.delay(1000L, scheduler, true)
+                    val observer = upstream.delay(1.seconds, scheduler, true)
                     val error = Exception()
 
                     upstream.onError(error)

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DelaySubscriptionTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DelaySubscriptionTest.kt
@@ -10,17 +10,18 @@ import com.badoo.reaktive.test.scheduler.assertAllExecutorsDisposed
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.time.Duration.Companion.milliseconds
 
 class DelaySubscriptionTest :
-    ObservableToObservableTests by ObservableToObservableTestsImpl({ delaySubscription(0L, TestScheduler()) }),
-    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ delaySubscription(0L, TestScheduler()) }) {
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ delaySubscription(0.milliseconds, TestScheduler()) }),
+    ObservableToObservableForwardTests by ObservableToObservableForwardTestsImpl({ delaySubscription(0.milliseconds, TestScheduler()) }) {
 
     private val upstream = TestObservable<Int?>()
     private val scheduler = TestScheduler()
 
     @Test
     fun does_not_subscribe_to_upstream_WHEN_timeout_not_reached() {
-        upstream.delaySubscription(delayMillis = 10L, scheduler = scheduler).test()
+        upstream.delaySubscription(delay = 10.milliseconds, scheduler = scheduler).test()
 
         scheduler.timer.advanceBy(9L)
 
@@ -29,7 +30,7 @@ class DelaySubscriptionTest :
 
     @Test
     fun subscribes_to_upstream_only_once_WHEN_timeout_reached() {
-        upstream.delaySubscription(delayMillis = 10L, scheduler = scheduler).test()
+        upstream.delaySubscription(delay = 10.milliseconds, scheduler = scheduler).test()
 
         scheduler.timer.advanceBy(10L)
 
@@ -38,7 +39,7 @@ class DelaySubscriptionTest :
 
     @Test
     fun emits_all_values_in_the_same_order() {
-        val observer = upstream.delaySubscription(delayMillis = 0L, scheduler = scheduler).test()
+        val observer = upstream.delaySubscription(delay = 0.milliseconds, scheduler = scheduler).test()
 
         upstream.onNext(0, null, 1)
 
@@ -47,7 +48,7 @@ class DelaySubscriptionTest :
 
     @Test
     fun disposes_executor_WHEN_timeout_reached() {
-        upstream.delaySubscription(delayMillis = 10L, scheduler = scheduler).test()
+        upstream.delaySubscription(delay = 10.milliseconds, scheduler = scheduler).test()
 
         scheduler.timer.advanceBy(10L)
 
@@ -56,7 +57,7 @@ class DelaySubscriptionTest :
 
     @Test
     fun disposes_executor_WHEN_disposed() {
-        val observer = upstream.delaySubscription(delayMillis = 10L, scheduler = scheduler).test()
+        val observer = upstream.delaySubscription(delay = 10.milliseconds, scheduler = scheduler).test()
 
         observer.dispose()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DelayTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/DelayTest.kt
@@ -9,9 +9,10 @@ import com.badoo.reaktive.test.observable.assertValue
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.scheduler.TestScheduler
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
 
 class DelayTest :
-    ObservableToObservableTests by ObservableToObservableTestsImpl({ delay(0L, TestScheduler()) }),
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ delay(0.seconds, TestScheduler()) }),
     DelayErrorTests by DelayErrorTests<TestObservable<Int>>(
         TestObservable(),
         { delayMillis, scheduler, delayError -> delay(delayMillis, scheduler, delayError).test() }
@@ -20,7 +21,7 @@ class DelayTest :
     private val upstream = TestObservable<Int?>()
     private val scheduler = TestScheduler()
     private val timer = scheduler.timer
-    private val observer = upstream.delay(1000L, scheduler).test()
+    private val observer = upstream.delay(1.seconds, scheduler).test()
 
     @Test
     fun does_not_emit_values_IF_timeout_not_reached() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/IntervalTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/IntervalTest.kt
@@ -13,15 +13,15 @@ import com.badoo.reaktive.test.scheduler.TestScheduler
 import com.badoo.reaktive.test.scheduler.assertAllExecutorsDisposed
 import kotlin.test.Test
 import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 
 class IntervalTest {
 
     private val scheduler = TestScheduler()
     private val timer = scheduler.timer
     private val upstream = observableInterval(
-        periodMillis = 100L,
-        startDelayMillis = 50L,
+        period = 100.milliseconds,
+        startDelay = 50.milliseconds,
         scheduler = scheduler
     )
     private val observer = upstream.test()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SampleTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/SampleTest.kt
@@ -6,9 +6,10 @@ import com.badoo.reaktive.test.observable.assertValues
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.scheduler.TestScheduler
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
 
 class SampleTest :
-    ObservableToObservableTests by ObservableToObservableTestsImpl({ sample(windowMillis = 100L, scheduler = TestScheduler()) }) {
+    ObservableToObservableTests by ObservableToObservableTestsImpl({ sample(window = 100.milliseconds, scheduler = TestScheduler()) }) {
 
     private val upstream = TestObservable<Int?>()
 
@@ -16,7 +17,7 @@ class SampleTest :
     fun emits_last_values_WHEN_every_timeout_reached() {
         val scheduler = TestScheduler()
         val timer = scheduler.timer
-        val observer = upstream.sample(windowMillis = 300L, scheduler = scheduler).test()
+        val observer = upstream.sample(window = 300.milliseconds, scheduler = scheduler).test()
 
         upstream.onNext(0)
         timer.advanceBy(100L)
@@ -44,7 +45,7 @@ class SampleTest :
     @Test
     fun does_not_emit_value_WHEN_upstream_produced_value_right_after_subscription() {
         val scheduler = TestScheduler(isManualProcessing = true)
-        val observer = upstream.sample(windowMillis = 300L, scheduler = scheduler).test()
+        val observer = upstream.sample(window = 300.milliseconds, scheduler = scheduler).test()
 
         upstream.onNext(0)
         scheduler.process()
@@ -55,7 +56,7 @@ class SampleTest :
     @Test
     fun does_not_emit_value_WHEN_upstream_produced_value_and_upstream_completed_and_timeout_reached() {
         val scheduler = TestScheduler()
-        val observer = upstream.sample(windowMillis = 300L, scheduler = scheduler).test()
+        val observer = upstream.sample(window = 300.milliseconds, scheduler = scheduler).test()
 
         upstream.onNext(0)
         upstream.onComplete()
@@ -67,7 +68,7 @@ class SampleTest :
     @Test
     fun does_not_emit_same_value_WHEN_timeout_reached_second_time() {
         val scheduler = TestScheduler()
-        val observer = upstream.sample(windowMillis = 100L, scheduler = scheduler).test()
+        val observer = upstream.sample(window = 100.milliseconds, scheduler = scheduler).test()
         upstream.onNext(0)
         scheduler.timer.advanceBy(100L)
         observer.reset()

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ThrottleTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/ThrottleTest.kt
@@ -8,13 +8,14 @@ import com.badoo.reaktive.test.observable.onNext
 import com.badoo.reaktive.test.observable.test
 import com.badoo.reaktive.test.scheduler.TestScheduler
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
 
-class ThrottleTest : ObservableToObservableTests by ObservableToObservableTestsImpl({ throttle(100L) }) {
+class ThrottleTest : ObservableToObservableTests by ObservableToObservableTestsImpl({ throttle(100.milliseconds) }) {
 
     private val upstream = TestObservable<Int>()
     private val scheduler = TestScheduler()
     private val timer = scheduler.timer
-    private val observer = upstream.throttle(windowMillis = 100L, scheduler = scheduler).test()
+    private val observer = upstream.throttle(window = 100.milliseconds, scheduler = scheduler).test()
 
     @Test
     fun emits_first_value_WHEN_current_time_is_0L() {
@@ -100,7 +101,7 @@ class ThrottleTest : ObservableToObservableTests by ObservableToObservableTestsI
     @Test
     fun emits_all_values_without_closing_window_WHEN_window_is_0() {
         scheduler.isManualProcessing = true
-        val observer = upstream.throttle(windowMillis = 0L, scheduler = scheduler).test()
+        val observer = upstream.throttle(window = 0.milliseconds, scheduler = scheduler).test()
 
         upstream.onNext(0, 1)
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/TimeoutTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/TimeoutTest.kt
@@ -16,8 +16,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
-class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsImpl({ timeout(1000L, TestScheduler()) }) {
+class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsImpl({ timeout(1.seconds, TestScheduler()) }) {
 
     private val upstream = TestObservable<Int?>()
     private val other = TestObservable<Int?>()
@@ -25,7 +26,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun emits_all_values_in_the_same_order() {
-        val observer = upstream.timeout(1000L, scheduler).test()
+        val observer = upstream.timeout(1.seconds, scheduler).test()
 
         upstream.onNext(0, null, 1, null, 2)
 
@@ -37,7 +38,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
         var errorRef: Throwable? = null
 
         upstream
-            .timeout(1000L, scheduler)
+            .timeout(1.seconds, scheduler)
             .subscribe(
                 object : ObservableObserver<Int?> {
                     override fun onSubscribe(disposable: Disposable) {
@@ -64,7 +65,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun does_not_produce_error_WHEN_timeout_not_reached_after_first_value() {
-        val observer = upstream.timeout(1000L, scheduler).test()
+        val observer = upstream.timeout(1.seconds, scheduler).test()
 
         upstream.onNext(0)
         scheduler.timer.advanceBy(999L)
@@ -74,7 +75,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun produces_error_WHEN_timeout_reached_after_first_value() {
-        val observer = upstream.timeout(1000L, scheduler).test()
+        val observer = upstream.timeout(1.seconds, scheduler).test()
 
         upstream.onNext(0)
         scheduler.timer.advanceBy(1000L)
@@ -84,7 +85,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun does_not_produce_error_WHEN_timeout_not_reached_after_second_value() {
-        val observer = upstream.timeout(1000L, scheduler).test()
+        val observer = upstream.timeout(1.seconds, scheduler).test()
 
         upstream.onNext(0)
         scheduler.timer.advanceBy(999L)
@@ -96,7 +97,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun produces_error_WHEN_timeout_reached_after_second_value() {
-        val observer = upstream.timeout(1000L, scheduler).test()
+        val observer = upstream.timeout(1.seconds, scheduler).test()
 
         upstream.onNext(0)
         scheduler.timer.advanceBy(999L)
@@ -108,7 +109,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun does_not_subscribe_to_other_WHEN_timeout_not_reached_after_first_value() {
-        upstream.timeout(1000L, scheduler, other).test()
+        upstream.timeout(1.seconds, scheduler, other).test()
 
         upstream.onNext(0)
         scheduler.timer.advanceBy(999L)
@@ -118,7 +119,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun subscribes_to_other_WHEN_timeout_reached_after_first_value() {
-        upstream.timeout(1000L, scheduler, other).test()
+        upstream.timeout(1.seconds, scheduler, other).test()
 
         upstream.onNext(0)
         scheduler.timer.advanceBy(1000L)
@@ -128,7 +129,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun does_not_produce_error_WHEN_timeout_reached_after_first_value_and_has_other() {
-        val observer = upstream.timeout(1000L, scheduler, other).test()
+        val observer = upstream.timeout(1.seconds, scheduler, other).test()
 
         upstream.onNext(0)
         scheduler.timer.advanceBy(1000L)
@@ -138,7 +139,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun does_not_subscribe_to_other_WHEN_timeout_not_reached_after_second_value() {
-        upstream.timeout(1000L, scheduler, other).test()
+        upstream.timeout(1.seconds, scheduler, other).test()
 
         upstream.onNext(0)
         scheduler.timer.advanceBy(999L)
@@ -150,7 +151,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun subscribes_to_other_WHEN_timeout_reached_after_second_value() {
-        upstream.timeout(1000L, scheduler, other).test()
+        upstream.timeout(1.seconds, scheduler, other).test()
 
         upstream.onNext(0)
         scheduler.timer.advanceBy(999L)
@@ -162,7 +163,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun does_not_produce_error_WHEN_timeout_reached_after_second_value_and_has_other() {
-        val observer = upstream.timeout(1000L, scheduler, other).test()
+        val observer = upstream.timeout(1.seconds, scheduler, other).test()
 
         upstream.onNext(0)
         scheduler.timer.advanceBy(999L)
@@ -174,7 +175,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun emits_all_values_in_correct_order_from_other() {
-        val observer = upstream.timeout(1000L, scheduler, other).test()
+        val observer = upstream.timeout(1.seconds, scheduler, other).test()
 
         upstream.onNext(0)
         scheduler.timer.advanceBy(1000L)
@@ -186,7 +187,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun completes_WHEN_other_completed() {
-        val observer = upstream.timeout(1000L, scheduler, other).test()
+        val observer = upstream.timeout(1.seconds, scheduler, other).test()
 
         upstream.onNext(0)
         scheduler.timer.advanceBy(1000L)
@@ -197,7 +198,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun produces_error_WHEN_other_produced_error() {
-        val observer = upstream.timeout(1000L, scheduler, other).test()
+        val observer = upstream.timeout(1.seconds, scheduler, other).test()
         val error = Exception()
 
         upstream.onNext(0)
@@ -219,7 +220,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
         var otherSubscribeCount = 0
         val other = observable<Int> { otherSubscribeCount++ }
 
-        upstream.timeout(1000L, scheduler, other).test()
+        upstream.timeout(1.seconds, scheduler, other).test()
 
         requireNotNull(upstreamObserver).onNext(0)
         scheduler.timer.advanceBy(1000L)
@@ -231,7 +232,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun does_not_produce_error_WHEN_timeout_not_reached_after_subscribe() {
-        val observer = upstream.timeout(1000L, scheduler).test()
+        val observer = upstream.timeout(1.seconds, scheduler).test()
 
         scheduler.timer.advanceBy(999L)
 
@@ -240,7 +241,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun produces_error_WHEN_timeout_reached_after_subscribe() {
-        val observer = upstream.timeout(1000L, scheduler).test()
+        val observer = upstream.timeout(1.seconds, scheduler).test()
 
         scheduler.timer.advanceBy(1000L)
 
@@ -249,7 +250,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun does_not_subscribe_to_other_WHEN_timeout_not_reached_after_subscribe() {
-        upstream.timeout(1000L, scheduler, other).test()
+        upstream.timeout(1.seconds, scheduler, other).test()
 
         scheduler.timer.advanceBy(999L)
 
@@ -258,7 +259,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun subscribes_to_other_WHEN_timeout_reached_after_subscribe() {
-        upstream.timeout(1000L, scheduler, other).test()
+        upstream.timeout(1.seconds, scheduler, other).test()
 
         scheduler.timer.advanceBy(1000L)
 
@@ -267,7 +268,7 @@ class TimeoutTest : ObservableToObservableTests by ObservableToObservableTestsIm
 
     @Test
     fun does_not_produce_error_WHEN_timeout_reached_after_subscribe_and_has_other() {
-        val observer = upstream.timeout(1000L, scheduler, other).test()
+        val observer = upstream.timeout(1.seconds, scheduler, other).test()
 
         scheduler.timer.advanceBy(1000L)
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/TimerTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/TimerTest.kt
@@ -13,13 +13,13 @@ import com.badoo.reaktive.test.scheduler.TestScheduler
 import com.badoo.reaktive.test.scheduler.assertAllExecutorsDisposed
 import kotlin.test.Test
 import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 class TimerTest {
 
     private val scheduler = TestScheduler()
     private val timer = scheduler.timer
-    private val upstream = observableTimer(1000L, scheduler)
+    private val upstream = observableTimer(1.seconds, scheduler)
     private val observer = upstream.test()
 
     @Test
@@ -58,7 +58,7 @@ class TimerTest {
     @Test
     fun emit_single_value_WHEN_timeout_reached() {
         timer.advanceBy(1000L)
-        observer.assertValue(1000L)
+        observer.assertValue(1.seconds)
     }
 
     @Test

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DelaySubscriptionTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DelaySubscriptionTest.kt
@@ -9,16 +9,17 @@ import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.time.Duration.Companion.milliseconds
 
 class DelaySubscriptionTest :
-    SingleToSingleTests by SingleToSingleTestsImpl({ delaySubscription(0L, TestScheduler()) }) {
+    SingleToSingleTests by SingleToSingleTestsImpl({ delaySubscription(0.milliseconds, TestScheduler()) }) {
 
     private val upstream = TestSingle<Int?>()
     private val scheduler = TestScheduler()
 
     @Test
     fun does_not_subscribe_to_upstream_WHEN_timeout_not_reached() {
-        upstream.delaySubscription(delayMillis = 10L, scheduler = scheduler).test()
+        upstream.delaySubscription(delay = 10.milliseconds, scheduler = scheduler).test()
 
         scheduler.timer.advanceBy(9L)
 
@@ -27,7 +28,7 @@ class DelaySubscriptionTest :
 
     @Test
     fun subscribes_to_upstream_only_once_WHEN_timeout_reached() {
-        upstream.delaySubscription(delayMillis = 10L, scheduler = scheduler).test()
+        upstream.delaySubscription(delay = 10.milliseconds, scheduler = scheduler).test()
 
         scheduler.timer.advanceBy(10L)
 
@@ -36,7 +37,7 @@ class DelaySubscriptionTest :
 
     @Test
     fun succeeds_WHEN_upstream_succeeded() {
-        val observer = upstream.delaySubscription(delayMillis = 0L, scheduler = scheduler).test()
+        val observer = upstream.delaySubscription(delay = 0.milliseconds, scheduler = scheduler).test()
 
         upstream.onSuccess(null)
 
@@ -45,7 +46,7 @@ class DelaySubscriptionTest :
 
     @Test
     fun disposes_executor_WHEN_timeout_reached() {
-        upstream.delaySubscription(delayMillis = 10L, scheduler = scheduler).test()
+        upstream.delaySubscription(delay = 10.milliseconds, scheduler = scheduler).test()
 
         scheduler.timer.advanceBy(10L)
 
@@ -54,7 +55,7 @@ class DelaySubscriptionTest :
 
     @Test
     fun disposes_executor_WHEN_disposed() {
-        val observer = upstream.delaySubscription(delayMillis = 10L, scheduler = scheduler).test()
+        val observer = upstream.delaySubscription(delay = 10.milliseconds, scheduler = scheduler).test()
 
         observer.dispose()
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DelayTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/DelayTest.kt
@@ -8,9 +8,10 @@ import com.badoo.reaktive.test.single.assertNotSuccess
 import com.badoo.reaktive.test.single.assertSuccess
 import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
 
 class DelayTest :
-    SingleToSingleTests by SingleToSingleTestsImpl({ delay(0L, TestScheduler()) }),
+    SingleToSingleTests by SingleToSingleTestsImpl({ delay(0.seconds, TestScheduler()) }),
     DelayErrorTests by DelayErrorTests<TestSingle<Int>>(
         TestSingle(),
         { delayMillis, scheduler, delayError -> delay(delayMillis, scheduler, delayError).test() }
@@ -19,7 +20,7 @@ class DelayTest :
     private val upstream = TestSingle<Int?>()
     private val scheduler = TestScheduler()
     private val timer = scheduler.timer
-    private val observer = upstream.delay(1000L, scheduler).test()
+    private val observer = upstream.delay(1.seconds, scheduler).test()
 
     @Test
     fun does_not_succeed_IF_timeout_not_reached() {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/TimeoutTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/TimeoutTest.kt
@@ -13,8 +13,9 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
-class TimeoutTest : SingleToSingleTests by SingleToSingleTestsImpl({ timeout(1000L, TestScheduler()) }) {
+class TimeoutTest : SingleToSingleTests by SingleToSingleTestsImpl({ timeout(1.seconds, TestScheduler()) }) {
 
     private val upstream = TestSingle<Int?>()
     private val other = TestSingle<Int?>()
@@ -25,7 +26,7 @@ class TimeoutTest : SingleToSingleTests by SingleToSingleTestsImpl({ timeout(100
         var errorRef: Throwable? = null
 
         upstream
-            .timeout(1000L, scheduler)
+            .timeout(1.seconds, scheduler)
             .subscribe(
                 object : SingleObserver<Int?> {
                     override fun onSubscribe(disposable: Disposable) {
@@ -48,7 +49,7 @@ class TimeoutTest : SingleToSingleTests by SingleToSingleTestsImpl({ timeout(100
 
     @Test
     fun succeeds_WHEN_other_succeeds() {
-        val observer = upstream.timeout(1000L, scheduler, other).test()
+        val observer = upstream.timeout(1.seconds, scheduler, other).test()
 
         scheduler.timer.advanceBy(1000L)
         observer.reset()
@@ -59,7 +60,7 @@ class TimeoutTest : SingleToSingleTests by SingleToSingleTestsImpl({ timeout(100
 
     @Test
     fun produces_error_WHEN_other_produced_error() {
-        val observer = upstream.timeout(1000L, scheduler, other).test()
+        val observer = upstream.timeout(1.seconds, scheduler, other).test()
         val error = Exception()
 
         scheduler.timer.advanceBy(1000L)
@@ -70,7 +71,7 @@ class TimeoutTest : SingleToSingleTests by SingleToSingleTestsImpl({ timeout(100
 
     @Test
     fun does_not_produce_error_WHEN_timeout_not_reached_after_subscribe() {
-        val observer = upstream.timeout(1000L, scheduler).test()
+        val observer = upstream.timeout(1.seconds, scheduler).test()
 
         scheduler.timer.advanceBy(999L)
 
@@ -79,7 +80,7 @@ class TimeoutTest : SingleToSingleTests by SingleToSingleTestsImpl({ timeout(100
 
     @Test
     fun produces_error_WHEN_timeout_reached_after_subscribe() {
-        val observer = upstream.timeout(1000L, scheduler).test()
+        val observer = upstream.timeout(1.seconds, scheduler).test()
 
         scheduler.timer.advanceBy(1000L)
 
@@ -88,7 +89,7 @@ class TimeoutTest : SingleToSingleTests by SingleToSingleTestsImpl({ timeout(100
 
     @Test
     fun does_not_subscribe_to_other_WHEN_timeout_not_reached_after_subscribe() {
-        upstream.timeout(1000L, scheduler, other).test()
+        upstream.timeout(1.seconds, scheduler, other).test()
 
         scheduler.timer.advanceBy(999L)
 
@@ -97,7 +98,7 @@ class TimeoutTest : SingleToSingleTests by SingleToSingleTestsImpl({ timeout(100
 
     @Test
     fun subscribes_to_other_WHEN_timeout_reached_after_subscribe() {
-        upstream.timeout(1000L, scheduler, other).test()
+        upstream.timeout(1.seconds, scheduler, other).test()
 
         scheduler.timer.advanceBy(1000L)
 
@@ -106,7 +107,7 @@ class TimeoutTest : SingleToSingleTests by SingleToSingleTestsImpl({ timeout(100
 
     @Test
     fun does_not_produce_error_WHEN_timeout_reached_after_subscribe_and_has_other() {
-        val observer = upstream.timeout(1000L, scheduler, other).test()
+        val observer = upstream.timeout(1.seconds, scheduler, other).test()
 
         scheduler.timer.advanceBy(1000L)
 

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/TimerTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/single/TimerTest.kt
@@ -11,13 +11,13 @@ import com.badoo.reaktive.test.single.assertSuccess
 import com.badoo.reaktive.test.single.test
 import kotlin.test.Test
 import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 class TimerTest {
 
     private val scheduler = TestScheduler()
     private val timer = scheduler.timer
-    private val upstream = singleTimer(1000L, scheduler)
+    private val upstream = singleTimer(1.seconds, scheduler)
     private val observer = upstream.test()
 
     @Test
@@ -50,7 +50,7 @@ class TimerTest {
     @Test
     fun succeed_WHEN_timeout_reached() {
         timer.advanceBy(1000L)
-        observer.assertSuccess(1000L)
+        observer.assertSuccess(1.seconds)
     }
 
     @Test


### PR DESCRIPTION
Converted all operators to use Duration instead of millis.

Also I have checked how RxJava verifies argument preconditions in those operators. It appears that since RxJava schedulers treat negative durations as 0 (we did the same recently), it's allowed to have negative durations in operators. Except the `window` operator which don't allow zeros, and so requires durations to be positive. I have updated precondition checks in all time-based operators to match RxJava.