### PR TITLE
Make buffer limit arguments of type int instead of long

### DIFF
--- a/reaktive/api/android/reaktive.api
+++ b/reaktive/api/android/reaktive.api
@@ -587,12 +587,12 @@ public final class com/badoo/reaktive/observable/BufferCountSkipKt {
 }
 
 public final class com/badoo/reaktive/observable/BufferKt {
-	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;JZ)Lcom/badoo/reaktive/observable/Observable;
-	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;JZ)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
-	public static final fun buffer-FbhrOv8 (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZ)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun buffer-FbhrOv8$default (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;IZ)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;IZ)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;IZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;IZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun buffer-FbhrOv8 (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;IZ)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun buffer-FbhrOv8$default (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;IZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 	public static final fun buffer-WPwdCS8 (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;IZ)Lcom/badoo/reaktive/observable/Observable;
 	public static synthetic fun buffer-WPwdCS8$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;IZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }

--- a/reaktive/api/jvm/reaktive.api
+++ b/reaktive/api/jvm/reaktive.api
@@ -580,12 +580,12 @@ public final class com/badoo/reaktive/observable/BufferCountSkipKt {
 }
 
 public final class com/badoo/reaktive/observable/BufferKt {
-	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;JZ)Lcom/badoo/reaktive/observable/Observable;
-	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;JZ)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
-	public static final fun buffer-FbhrOv8 (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZ)Lcom/badoo/reaktive/observable/Observable;
-	public static synthetic fun buffer-FbhrOv8$default (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;JZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;IZ)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun buffer (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;IZ)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;IZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun buffer$default (Lcom/badoo/reaktive/observable/Observable;Lcom/badoo/reaktive/observable/Observable;Lkotlin/jvm/functions/Function1;IZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
+	public static final fun buffer-FbhrOv8 (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;IZ)Lcom/badoo/reaktive/observable/Observable;
+	public static synthetic fun buffer-FbhrOv8$default (Lcom/badoo/reaktive/observable/Observable;JJLcom/badoo/reaktive/scheduler/Scheduler;IZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 	public static final fun buffer-WPwdCS8 (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;IZ)Lcom/badoo/reaktive/observable/Observable;
 	public static synthetic fun buffer-WPwdCS8$default (Lcom/badoo/reaktive/observable/Observable;JLcom/badoo/reaktive/scheduler/Scheduler;IZILjava/lang/Object;)Lcom/badoo/reaktive/observable/Observable;
 }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Buffer.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Buffer.kt
@@ -26,10 +26,10 @@ fun <T> Observable<T>.buffer(
  */
 fun <T> Observable<T>.buffer(
     boundaries: Observable<*>,
-    limit: Long = Long.MAX_VALUE,
+    limit: Int = Int.MAX_VALUE,
     restartOnLimit: Boolean = false
 ): Observable<List<T>> =
-    window(boundaries = boundaries, limit = limit, restartOnLimit = restartOnLimit)
+    window(boundaries = boundaries, limit = limit.toLong(), restartOnLimit = restartOnLimit)
         .flatMapSingle { it.toList() }
 
 /**
@@ -41,10 +41,10 @@ fun <T> Observable<T>.buffer(
     span: Duration,
     skip: Duration,
     scheduler: Scheduler,
-    limit: Long = Long.MAX_VALUE,
+    limit: Int = Int.MAX_VALUE,
     restartOnLimit: Boolean = false
 ): Observable<List<T>> =
-    window(span = span, skip = skip, scheduler = scheduler, limit = limit, restartOnLimit = restartOnLimit)
+    window(span = span, skip = skip, scheduler = scheduler, limit = limit.toLong(), restartOnLimit = restartOnLimit)
         .flatMapSingle { it.toList() }
 
 /**
@@ -57,8 +57,8 @@ fun <T> Observable<T>.buffer(
 fun <T, S> Observable<T>.buffer(
     opening: Observable<S>,
     closing: (S) -> Completable,
-    limit: Long = Long.MAX_VALUE,
+    limit: Int = Int.MAX_VALUE,
     restartOnLimit: Boolean = false
 ): Observable<List<T>> =
-    window(opening = opening, closing = closing, limit = limit, restartOnLimit = restartOnLimit)
+    window(opening = opening, closing = closing, limit = limit.toLong(), restartOnLimit = restartOnLimit)
         .flatMapSingle { it.toList() }


### PR DESCRIPTION
Aligned with RxJava.

As part of #620.