### PR TITLE
Stabilized plugins

### DIFF
--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Various.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/completable/Various.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.completable
 
-import com.badoo.reaktive.annotations.ExperimentalReaktiveApi
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.plugin.onAssembleCompletable
 import kotlin.native.concurrent.SharedImmutable
@@ -10,7 +9,6 @@ import kotlin.native.concurrent.SharedImmutable
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Completable.html#unsafeCreate-io.reactivex.CompletableSource-).
  */
-@OptIn(ExperimentalReaktiveApi::class)
 inline fun completableUnsafe(crossinline onSubscribe: (observer: CompletableObserver) -> Unit): Completable =
     onAssembleCompletable(
         object : Completable {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Various.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/maybe/Various.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.maybe
 
-import com.badoo.reaktive.annotations.ExperimentalReaktiveApi
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.plugin.onAssembleMaybe
 import kotlin.native.concurrent.SharedImmutable
@@ -10,7 +9,6 @@ import kotlin.native.concurrent.SharedImmutable
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Maybe.html#unsafeCreate-io.reactivex.MaybeSource-).
  */
-@OptIn(ExperimentalReaktiveApi::class)
 inline fun <T> maybeUnsafe(crossinline onSubscribe: (observer: MaybeObserver<T>) -> Unit): Maybe<T> =
     onAssembleMaybe(
         object : Maybe<T> {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Various.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/observable/Various.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.observable
 
-import com.badoo.reaktive.annotations.ExperimentalReaktiveApi
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.plugin.onAssembleObservable
 import kotlin.native.concurrent.SharedImmutable
@@ -10,7 +9,6 @@ import kotlin.native.concurrent.SharedImmutable
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Observable.html#unsafeCreate-io.reactivex.ObservableSource-).
  */
-@OptIn(ExperimentalReaktiveApi::class)
 inline fun <T> observableUnsafe(crossinline onSubscribe: (observer: ObservableObserver<T>) -> Unit): Observable<T> =
     onAssembleObservable(
         object : Observable<T> {

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/plugin/ReaktivePlugin.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/plugin/ReaktivePlugin.kt
@@ -1,12 +1,10 @@
 package com.badoo.reaktive.plugin
 
-import com.badoo.reaktive.annotations.ExperimentalReaktiveApi
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.maybe.Maybe
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.single.Single
 
-@ExperimentalReaktiveApi
 interface ReaktivePlugin {
 
     fun <T> onAssembleObservable(observable: Observable<T>): Observable<T> = observable

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/plugin/ReaktivePlugins.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/plugin/ReaktivePlugins.kt
@@ -2,17 +2,14 @@
 
 package com.badoo.reaktive.plugin
 
-import com.badoo.reaktive.annotations.ExperimentalReaktiveApi
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.maybe.Maybe
 import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.single.Single
 import kotlin.jvm.JvmName
 
-@ExperimentalReaktiveApi
 internal var plugins: ArrayList<ReaktivePlugin>? = null
 
-@ExperimentalReaktiveApi
 fun registerReaktivePlugin(plugin: ReaktivePlugin) {
     var list = plugins
     if (list == null) {
@@ -22,7 +19,6 @@ fun registerReaktivePlugin(plugin: ReaktivePlugin) {
     list.add(plugin)
 }
 
-@ExperimentalReaktiveApi
 fun unregisterReaktivePlugin(plugin: ReaktivePlugin) {
     plugins?.also {
         it.remove(plugin)
@@ -32,25 +28,21 @@ fun unregisterReaktivePlugin(plugin: ReaktivePlugin) {
     }
 }
 
-@ExperimentalReaktiveApi
 fun <T> onAssembleObservable(observable: Observable<T>): Observable<T> =
     plugins
         ?.fold(observable) { source, plugin -> plugin.onAssembleObservable(source) }
         ?: observable
 
-@ExperimentalReaktiveApi
 fun <T> onAssembleSingle(single: Single<T>): Single<T> =
     plugins
         ?.fold(single) { src, plugin -> plugin.onAssembleSingle(src) }
         ?: single
 
-@ExperimentalReaktiveApi
 fun <T> onAssembleMaybe(maybe: Maybe<T>): Maybe<T> =
     plugins
         ?.fold(maybe) { src, plugin -> plugin.onAssembleMaybe(src) }
         ?: maybe
 
-@ExperimentalReaktiveApi
 fun onAssembleCompletable(completable: Completable): Completable =
     plugins
         ?.fold(completable) { src, plugin -> plugin.onAssembleCompletable(src) }

--- a/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Various.kt
+++ b/reaktive/src/commonMain/kotlin/com/badoo/reaktive/single/Various.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.single
 
-import com.badoo.reaktive.annotations.ExperimentalReaktiveApi
 import com.badoo.reaktive.disposable.Disposable
 import com.badoo.reaktive.plugin.onAssembleSingle
 import kotlin.native.concurrent.SharedImmutable
@@ -10,7 +9,6 @@ import kotlin.native.concurrent.SharedImmutable
  *
  * Please refer to the corresponding RxJava [document](http://reactivex.io/RxJava/javadoc/io/reactivex/Single.html#unsafeCreate-io.reactivex.SingleSource-).
  */
-@OptIn(ExperimentalReaktiveApi::class)
 inline fun <T> singleUnsafe(crossinline onSubscribe: (observer: SingleObserver<T>) -> Unit): Single<T> =
     onAssembleSingle(
         object : Single<T> {

--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/plugin/ReaktivePluginsTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/plugin/ReaktivePluginsTest.kt
@@ -1,6 +1,5 @@
 package com.badoo.reaktive.plugin
 
-import com.badoo.reaktive.annotations.ExperimentalReaktiveApi
 import com.badoo.reaktive.completable.Completable
 import com.badoo.reaktive.completable.completableUnsafe
 import com.badoo.reaktive.maybe.Maybe
@@ -16,7 +15,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalReaktiveApi::class)
 class ReaktivePluginsTest {
 
     @AfterTest


### PR DESCRIPTION
New methods with default implementations can be added to the `ReaktivePlugin` interface without breaking the API.

As part of #620.