### PR TITLE
Fixed a race condition in refCount

### DIFF
--- a/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RefCountTest.kt
+++ b/reaktive/src/commonTest/kotlin/com/badoo/reaktive/observable/RefCountTest.kt
@@ -83,6 +83,40 @@ class RefCountTest {
     }
 
     @Test
+    fun connects_to_upstream_WHEN_subscriberCount_is_1_and_subscribed_and_disposed_in_onSubscribe() {
+        var isConnected = false
+        val upstream = testUpstream(connect = { isConnected = true })
+        val refCount = upstream.refCount(subscriberCount = 1)
+
+        refCount.subscribe(
+            object : DefaultObservableObserver<Int?> {
+                override fun onSubscribe(disposable: Disposable) {
+                    disposable.dispose()
+                }
+            }
+        )
+
+        assertTrue(isConnected)
+    }
+
+    @Test
+    fun disconnects_from_upstream_WHEN_subscriberCount_is_1_and_subscribed_and_disposed_in_onSubscribe() {
+        val disposable = Disposable()
+        val upstream = testUpstream(connect = { onConnect -> onConnect?.invoke(disposable) })
+        val refCount = upstream.refCount(subscriberCount = 1)
+
+        refCount.subscribe(
+            object : DefaultObservableObserver<Int?> {
+                override fun onSubscribe(disposable: Disposable) {
+                    disposable.dispose()
+                }
+            }
+        )
+
+        assertTrue(disposable.isDisposed)
+    }
+
+    @Test
     fun disconnects_from_upstream_WHEN_subscriberCount_is_2_and_all_subscribers_unsubscribed() {
         val disposable = Disposable()
         val upstream = testUpstream(connect = { it?.invoke(disposable) })

--- a/reaktive/src/jvmNativeCommonTest/kotlin/com/badoo/reaktive/observable/RefCountThreadingTest.kt
+++ b/reaktive/src/jvmNativeCommonTest/kotlin/com/badoo/reaktive/observable/RefCountThreadingTest.kt
@@ -1,0 +1,72 @@
+package com.badoo.reaktive.observable
+
+import com.badoo.reaktive.disposable.Disposable
+import com.badoo.reaktive.test.doInBackground
+import com.badoo.reaktive.test.observable.test
+import com.badoo.reaktive.utils.lock.ConditionLock
+import com.badoo.reaktive.utils.lock.synchronized
+import com.badoo.reaktive.utils.lock.waitFor
+import com.badoo.reaktive.utils.lock.waitForOrFail
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.time.Duration.Companion.seconds
+
+class RefCountThreadingTest {
+
+    @Test
+    fun does_not_connect_second_time_concurrently_while_disconnecting() {
+        val lock = ConditionLock()
+        var isDisconnecting = false
+        var isSecondTime = false
+        var isConnectedSecondTimeConcurrently = false
+
+        val disposable =
+            Disposable {
+                lock.synchronized {
+                    isDisconnecting = true
+                    isSecondTime = true
+                    lock.signal()
+                    lock.waitFor(timeout = 1.seconds) { false }
+                    isDisconnecting = false
+                }
+            }
+
+        val upstream =
+            testUpstream(
+                connect = { onConnect ->
+                    lock.synchronized {
+                        if (!isSecondTime) {
+                            onConnect?.invoke(disposable)
+                        } else {
+                            isConnectedSecondTimeConcurrently = isDisconnecting
+                        }
+                    }
+                }
+            )
+
+        val refCount = upstream.refCount(subscriberCount = 1)
+        val observer = refCount.test()
+        doInBackground { observer.dispose() }
+
+        lock.synchronized {
+            lock.waitForOrFail { !isSecondTime }
+        }
+
+        refCount.test()
+
+        assertFalse(isConnectedSecondTimeConcurrently)
+    }
+
+    private fun testUpstream(
+        connect: (onConnect: ((Disposable) -> Unit)?) -> Unit = {},
+    ): ConnectableObservable<Int?> =
+        object : ConnectableObservable<Int?> {
+            override fun connect(onConnect: ((Disposable) -> Unit)?) {
+                connect.invoke(onConnect)
+            }
+
+            override fun subscribe(observer: ObservableObserver<Int?>) {
+                observer.onSubscribe(Disposable())
+            }
+        }
+}


### PR DESCRIPTION
Fixed a race condition in `refCount` when the second connection is performed concurrently while the first connection is still being disconnected.
Also fixed a bug when the upstream is not connected when disposed synchronously.