### PR TITLE
Fixed incorrect condition in RefCountThreadingTest

### DIFF
--- a/reaktive/src/jvmNativeCommonTest/kotlin/com/badoo/reaktive/observable/RefCountThreadingTest.kt
+++ b/reaktive/src/jvmNativeCommonTest/kotlin/com/badoo/reaktive/observable/RefCountThreadingTest.kt
@@ -49,7 +49,7 @@ class RefCountThreadingTest {
         doInBackground { observer.dispose() }
 
         lock.synchronized {
-            lock.waitForOrFail { !isSecondTime }
+            lock.waitForOrFail { isSecondTime }
         }
 
         refCount.test()


### PR DESCRIPTION
This affected code is supposed to wait for the disconnection to begin (the `Disposable { ... }` above should begin its execution concurrently). However, due to the incorrect condition the test sometimes fails with timeout.